### PR TITLE
Allow format keyword to be augmented with custom formats

### DIFF
--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -179,8 +179,8 @@ export type StringOptions = {
   minLength?: number
   maxLength?: number
   pattern?: string
-  format?: FormatOption
-} & UserDefinedOptions
+  format?: FormatOption | UserDefinedOptions['format']
+} & Omit<UserDefinedOptions, 'format'>
 
 export type TLiteral = TStringLiteral<string> | TNumberLiteral<number> | TBooleanLiteral<boolean>
 export type TStringLiteral<T> = { type: 'string', enum: [T] } & UserDefinedOptions

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -175,12 +175,17 @@ export type NumberOptions = {
   multipleOf?: number
 } & UserDefinedOptions
 
-export type StringOptions = {
-  minLength?: number
-  maxLength?: number
-  pattern?: string
-  format?: FormatOption | UserDefinedOptions['format']
-} & Omit<UserDefinedOptions, 'format'>
+type UnionToIntersection<U> =
+  (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never;
+type IsUnion<T> = [T] extends [UnionToIntersection<T>] ? false : true;
+export declare type StringOptions = {
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  format?: IsUnion<UserDefinedOptions['format']> extends true 
+    ? UserDefinedOptions['format'] | FormatOption 
+    : FormatOption;
+} & Omit<UserDefinedOptions, 'format'>;
 
 export type TLiteral = TStringLiteral<string> | TNumberLiteral<number> | TBooleanLiteral<boolean>
 export type TStringLiteral<T> = { type: 'string', enum: [T] } & UserDefinedOptions


### PR DESCRIPTION
Allows consumers to augment the `format` keyword, for example:

```ts
declare module '@sinclair/typebox' {
  interface UserDefinedOptions {
    format: 'custom-format-1' | 'custom-format-2';
  }
}
```