### PR TITLE
add uuid-format

### DIFF
--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -157,7 +157,7 @@ export type TModifier = TOptional<any> | TReadonly<any> | TReadonlyOptional<any>
 
 export type FormatOption =
   | 'date-time' | 'time' | 'date' | 'email' | 'idn-email' | 'hostname'
-  | 'idn-hostname' | 'ipv4' | 'ipv6' | 'uri' | 'uri-reference' | 'iri'
+  | 'idn-hostname' | 'ipv4' | 'ipv6' | 'uri' | 'uri-reference' | 'iri' | 'uuid'
   | 'iri-reference' | 'uri-template' | 'json-pointer' | 'relative-json-pointer'
   | 'regex'
 


### PR DESCRIPTION
this adds the `uuid` format as per https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.7.3.5 .