### PR TITLE
Adds missing userDefinedOptions intersection from String type

### DIFF
--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -185,7 +185,7 @@ export declare type StringOptions = {
   format?: IsUnion<UserDefinedOptions['format']> extends true 
     ? UserDefinedOptions['format'] | FormatOption 
     : FormatOption;
-}
+} & UserDefinedOptions
 
 export type TLiteral = TStringLiteral<string> | TNumberLiteral<number> | TBooleanLiteral<boolean>
 export type TStringLiteral<T> = { type: 'string', enum: [T] } & UserDefinedOptions

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -185,7 +185,7 @@ export declare type StringOptions = {
   format?: IsUnion<UserDefinedOptions['format']> extends true 
     ? UserDefinedOptions['format'] | FormatOption 
     : FormatOption;
-} & UserDefinedOptions
+} & Omit<UserDefinedOptions, 'format'>
 
 export type TLiteral = TStringLiteral<string> | TNumberLiteral<number> | TBooleanLiteral<boolean>
 export type TStringLiteral<T> = { type: 'string', enum: [T] } & UserDefinedOptions


### PR DESCRIPTION
Adding a description to `Type.String` factory produces this error:
```
Argument of type '{ description: string; }' is not assignable to parameter of type 'StringOptions'.
  Object literal may only specify known properties, and 'description' does not exist in type 'StringOptions'.
```
This PR adds missing intersection.