### PR TITLE
feature/symbol modifier key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.9.9",
+  "version": "0.9.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "json-schema",

--- a/spec/index.ts
+++ b/spec/index.ts
@@ -1,6 +1,9 @@
 // TS Asserts
 import './asserts'
 
+// TModifer
+import './modifier'
+
 // TSchema
 import './literal'
 import './string'

--- a/spec/index.ts
+++ b/spec/index.ts
@@ -1,7 +1,7 @@
 // TS Asserts
 import './asserts'
 
-// TModifer
+// TModifier
 import './modifier'
 
 // TSchema

--- a/spec/modifier.ts
+++ b/spec/modifier.ts
@@ -1,26 +1,26 @@
-import { Type, Readonly, ReadonlyOptional, Optional } from '../src/typebox'
+import { Type, modifier } from '../src/typebox'
 import * as assert from 'assert'
 
 describe('Modifier', () => {
   it('Should omit modifier properties',  () => {
-    
+
     const T = Type.Object({
       a: Type.ReadonlyOptional(Type.String()),
       b: Type.Readonly(Type.String()),
       c: Type.Optional(Type.String()),
     })
-
+    
     const S = JSON.stringify(T)
     const P = JSON.parse(S) as any
 
     // check assignment on Type
-    assert.equal(T.properties.a.modifier, ReadonlyOptional)
-    assert.equal(T.properties.b.modifier, Readonly)
-    assert.equal(T.properties.c.modifier, Optional)
+    assert.equal(T.properties.a[modifier], 'readonly-optional')
+    assert.equal(T.properties.b[modifier], 'readonly')
+    assert.equal(T.properties.c[modifier], 'optional')
     
     // check deserialized
-    assert.equal(P.properties.a.modifier, undefined)
-    assert.equal(P.properties.b.modifier, undefined)
-    assert.equal(P.properties.c.modifier, undefined)
+    assert.equal(P.properties.a[modifier], undefined)
+    assert.equal(P.properties.b[modifier], undefined)
+    assert.equal(P.properties.c[modifier], undefined)
   })
 })

--- a/spec/modifier.ts
+++ b/spec/modifier.ts
@@ -1,8 +1,8 @@
-import { Type, modifier } from '../src/typebox'
+import { Type, modifierSymbol } from '../src/typebox'
 import * as assert from 'assert'
 
 describe('Modifier', () => {
-  it('Should omit modifier properties',  () => {
+  it('Omit modifierSymbol',  () => {
 
     const T = Type.Object({
       a: Type.ReadonlyOptional(Type.String()),
@@ -14,13 +14,13 @@ describe('Modifier', () => {
     const P = JSON.parse(S) as any
 
     // check assignment on Type
-    assert.equal(T.properties.a[modifier], 'readonly-optional')
-    assert.equal(T.properties.b[modifier], 'readonly')
-    assert.equal(T.properties.c[modifier], 'optional')
+    assert.equal(T.properties.a[modifierSymbol], 'readonly-optional')
+    assert.equal(T.properties.b[modifierSymbol], 'readonly')
+    assert.equal(T.properties.c[modifierSymbol], 'optional')
     
     // check deserialized
-    assert.equal(P.properties.a[modifier], undefined)
-    assert.equal(P.properties.b[modifier], undefined)
-    assert.equal(P.properties.c[modifier], undefined)
+    assert.equal(P.properties.a[modifierSymbol], undefined)
+    assert.equal(P.properties.b[modifierSymbol], undefined)
+    assert.equal(P.properties.c[modifierSymbol], undefined)
   })
 })

--- a/spec/modifier.ts
+++ b/spec/modifier.ts
@@ -1,0 +1,26 @@
+import { Type, Readonly, ReadonlyOptional, Optional } from '../src/typebox'
+import * as assert from 'assert'
+
+describe('Modifier', () => {
+  it('Should omit modifier properties',  () => {
+    
+    const T = Type.Object({
+      a: Type.ReadonlyOptional(Type.String()),
+      b: Type.Readonly(Type.String()),
+      c: Type.Optional(Type.String()),
+    })
+
+    const S = JSON.stringify(T)
+    const P = JSON.parse(S) as any
+
+    // check assignment on Type
+    assert.equal(T.properties.a.modifier, ReadonlyOptional)
+    assert.equal(T.properties.b.modifier, Readonly)
+    assert.equal(T.properties.c.modifier, Optional)
+    
+    // check deserialized
+    assert.equal(P.properties.a.modifier, undefined)
+    assert.equal(P.properties.b.modifier, undefined)
+    assert.equal(P.properties.c.modifier, undefined)
+  })
+})

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -146,10 +146,10 @@ export type TComposite = TIntersect | TUnion | TTuple
 
 // #region TModifier
 
-export const modifier = Symbol('Modifier')
-export type TOptional<T extends TSchema | TComposite> = T & { [modifier]: 'optional' }
-export type TReadonly<T extends TSchema | TComposite> = T & { [modifier]: 'readonly' }
-export type TReadonlyOptional<T extends TSchema | TComposite> = T & { [modifier]: 'readonly-optional' }
+export const modifierSymbol = Symbol('Modifier')
+export type TOptional<T extends TSchema | TComposite> = T & { [modifierSymbol]: 'optional' }
+export type TReadonly<T extends TSchema | TComposite> = T & { [modifierSymbol]: 'readonly' }
+export type TReadonlyOptional<T extends TSchema | TComposite> = T & { [modifierSymbol]: 'readonly-optional' }
 export type TModifier = TOptional<any> | TReadonly<any> | TReadonlyOptional<any>
 
 // #endregion
@@ -344,17 +344,17 @@ export class Type {
 
   /** Modifies the inner type T into a readonly optional T. */
   public static ReadonlyOptional<T extends TSchema | TUnion | TIntersect>(item: T): TReadonlyOptional<T> {
-    return { ...item, [modifier]: 'readonly-optional' }
+    return { ...item, [modifierSymbol]: 'readonly-optional' }
   }
 
   /** Modifies the inner type T into an optional T. */
   public static Optional<T extends TSchema | TUnion | TIntersect>(item: T): TOptional<T> {
-    return { ...item, [modifier]: 'optional' }
+    return { ...item, [modifierSymbol]: 'optional' }
   }
 
   /** Modifies the inner type T into an readonly T. */
   public static Readonly<T extends TSchema | TUnion | TIntersect>(item: T): TReadonly<T> {
-    return { ...item, [modifier]: 'readonly' }
+    return { ...item, [modifierSymbol]: 'readonly' }
   }
 
   // #endregion
@@ -515,9 +515,9 @@ export class Type {
     const property_names = Object.keys(properties)
     const optional = property_names.filter(name => {
       const candidate = properties[name] as TModifier
-      return (candidate[modifier] &&
-        (candidate[modifier] === 'readonly-optional' ||
-         candidate[modifier] === 'optional'))
+      return (candidate[modifierSymbol] &&
+        (candidate[modifierSymbol] === 'readonly-optional' ||
+         candidate[modifierSymbol] === 'optional'))
     })
     const required = property_names.filter(name => !optional.includes(name))
     return { ...options, type: 'object', properties, required }

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -146,9 +146,13 @@ export type TComposite = TIntersect | TUnion | TTuple
 
 // #region TModifier
 
-export type TOptional<T extends TSchema | TComposite> = T & { modifier: 'optional' }
-export type TReadonly<T extends TSchema | TComposite> = T & { modifier: 'readonly' }
-export type TReadonlyOptional<T extends TSchema | TComposite> = T & { modifier: 'readonly-optional' }
+export const ReadonlyOptional = Symbol('ReadonlyOptional')
+export const Readonly = Symbol('Readonly')
+export const Optional = Symbol('Optional')
+
+export type TOptional<T extends TSchema | TComposite> = T & { modifier: typeof Optional }
+export type TReadonly<T extends TSchema | TComposite> = T & { modifier: typeof Readonly }
+export type TReadonlyOptional<T extends TSchema | TComposite> = T & { modifier: typeof ReadonlyOptional }
 export type TModifier = TOptional<any> | TReadonly<any> | TReadonlyOptional<any>
 
 // #endregion
@@ -343,17 +347,17 @@ export class Type {
 
   /** Modifies the inner type T into a readonly optional T. */
   public static ReadonlyOptional<T extends TSchema | TUnion | TIntersect>(item: T): TReadonlyOptional<T> {
-    return { ...item, modifier: 'readonly-optional' }
+    return { ...item, modifier: ReadonlyOptional }
   }
 
   /** Modifies the inner type T into an optional T. */
   public static Optional<T extends TSchema | TUnion | TIntersect>(item: T): TOptional<T> {
-    return { ...item, modifier: 'optional' }
+    return { ...item, modifier: Optional }
   }
 
   /** Modifies the inner type T into an readonly T. */
   public static Readonly<T extends TSchema | TUnion | TIntersect>(item: T): TReadonly<T> {
-    return { ...item, modifier: 'readonly' }
+    return { ...item, modifier: Readonly }
   }
 
   // #endregion
@@ -515,8 +519,8 @@ export class Type {
     const optional = property_names.filter(name => {
       const candidate = properties[name] as TModifier
       return (candidate.modifier &&
-        (candidate.modifier === 'readonly-optional' ||
-          candidate.modifier === 'optional'))
+        (candidate.modifier === ReadonlyOptional ||
+          candidate.modifier === Optional))
     })
     const required = property_names.filter(name => !optional.includes(name))
     return { ...options, type: 'object', properties, required }

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -146,13 +146,10 @@ export type TComposite = TIntersect | TUnion | TTuple
 
 // #region TModifier
 
-export const ReadonlyOptional = Symbol('ReadonlyOptional')
-export const Readonly = Symbol('Readonly')
-export const Optional = Symbol('Optional')
-
-export type TOptional<T extends TSchema | TComposite> = T & { modifier: typeof Optional }
-export type TReadonly<T extends TSchema | TComposite> = T & { modifier: typeof Readonly }
-export type TReadonlyOptional<T extends TSchema | TComposite> = T & { modifier: typeof ReadonlyOptional }
+export const modifier = Symbol('Modifier')
+export type TOptional<T extends TSchema | TComposite> = T & { [modifier]: 'optional' }
+export type TReadonly<T extends TSchema | TComposite> = T & { [modifier]: 'readonly' }
+export type TReadonlyOptional<T extends TSchema | TComposite> = T & { [modifier]: 'readonly-optional' }
 export type TModifier = TOptional<any> | TReadonly<any> | TReadonlyOptional<any>
 
 // #endregion
@@ -347,17 +344,17 @@ export class Type {
 
   /** Modifies the inner type T into a readonly optional T. */
   public static ReadonlyOptional<T extends TSchema | TUnion | TIntersect>(item: T): TReadonlyOptional<T> {
-    return { ...item, modifier: ReadonlyOptional }
+    return { ...item, [modifier]: 'readonly-optional' }
   }
 
   /** Modifies the inner type T into an optional T. */
   public static Optional<T extends TSchema | TUnion | TIntersect>(item: T): TOptional<T> {
-    return { ...item, modifier: Optional }
+    return { ...item, [modifier]: 'optional' }
   }
 
   /** Modifies the inner type T into an readonly T. */
   public static Readonly<T extends TSchema | TUnion | TIntersect>(item: T): TReadonly<T> {
-    return { ...item, modifier: Readonly }
+    return { ...item, [modifier]: 'readonly' }
   }
 
   // #endregion
@@ -518,9 +515,9 @@ export class Type {
     const property_names = Object.keys(properties)
     const optional = property_names.filter(name => {
       const candidate = properties[name] as TModifier
-      return (candidate.modifier &&
-        (candidate.modifier === ReadonlyOptional ||
-          candidate.modifier === Optional))
+      return (candidate[modifier] &&
+        (candidate[modifier] === 'readonly-optional' ||
+         candidate[modifier] === 'optional'))
     })
     const required = property_names.filter(name => !optional.includes(name))
     return { ...options, type: 'object', properties, required }


### PR DESCRIPTION
This update changes object modifier key to be a non-enumerable `Symbol`. This has the benefit of omitting the modifier property on property enumeration and JSON serialization while continuing to provide enough hooks for the readonly | optional mapping / inference.

Associated GH issue located here https://github.com/sinclairzx81/typebox/issues/21