### PR TITLE
Prevent empty array for object required

### DIFF
--- a/spec/object.ts
+++ b/spec/object.ts
@@ -1,3 +1,4 @@
+import * as assert from 'assert';
 import { Type } from '../src/typebox'
 import { ok, fail } from './validate'
 
@@ -94,4 +95,27 @@ describe('Object', () => {
     fail(T, 123)
     fail(T, null)
   })
+
+  describe('Required', () => {
+    it('Contains all non-optional properties', () => {
+      const T = Type.Object({
+        a: Type.String(),
+        b: Type.Optional(Type.String()),
+        c: Type.String(),
+      });
+
+      assert.deepEqual(T.required, ['a', 'c']);
+    });
+
+    it('Is omitted when no properties are required', () => {
+      const T = Type.Object({
+        a: Type.Optional(Type.String()),
+        b: Type.Optional(Type.String()),
+        c: Type.Optional(Type.String()),
+      });
+
+      assert.equal(T.required, undefined);
+    });
+  });
+
 })

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -193,7 +193,7 @@ export type TStringLiteral<T> = { type: 'string', enum: [T] } & UserDefinedOptio
 export type TNumberLiteral<T> = { type: 'number', enum: [T] } & UserDefinedOptions
 export type TBooleanLiteral<T> = { type: 'boolean', enum: [T] } & UserDefinedOptions
 export type TProperties = { [key: string]: TSchema | TComposite | TOptional<TSchema | TComposite> | TReadonly<TSchema | TComposite> }
-export type TObject<T extends TProperties> = { type: 'object', properties: T, required: string[] } & UserDefinedOptions
+export type TObject<T extends TProperties> = { type: 'object', properties: T, required?: string[] } & UserDefinedOptions
 export type TMap<T extends TSchema | TComposite> = { type: 'object', additionalProperties: T } & UserDefinedOptions
 export type TArray<T extends TSchema | TComposite> = { type: 'array', items: T } & ArrayOptions
 export type TEnum<T extends string | number> = { enum: Array<T> } & UserDefinedOptions
@@ -520,7 +520,7 @@ export class Type {
          candidate[modifierSymbol] === 'optional'))
     })
     const required = property_names.filter(name => !optional.includes(name))
-    return { ...options, type: 'object', properties, required }
+    return { ...options, type: 'object', properties, required: required.length? required : undefined }
   }
 
   /** Creates a `{[key: string]: T}` type for the given item. */


### PR DESCRIPTION
Swagger UI complains when the `required` array is empty, which occurs when all properties in an object schema are optional.

This PR changes it so that `required` is omitted in this case

<img width="666" alt="Screenshot 2020-05-08 at 14 54 46" src="https://user-images.githubusercontent.com/4622378/81412523-e5a33d80-913b-11ea-85c3-7a20f362ff98.png">
<img width="672" alt="Screenshot 2020-05-08 at 14 54 54" src="https://user-images.githubusercontent.com/4622378/81412527-e76d0100-913b-11ea-84ca-4c011eb3ea9e.png">

(P.S. I really love this project!)
