### PR TITLE
remove modifier flattening | move contract types into schema as extended

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,9 +14,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.10.tgz",
-      "integrity": "sha512-TlWWgb21+0LdkuFqEqfmy7NEgfB/7Jjux15fWQAh3P93gbmXuwTM/vxEdzW89APIcI2BgKR48yjeAkdeH+4qvQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
+      "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
       "dev": true
     },
     "@types/mocha": {
@@ -26,15 +26,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.7.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
-      "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==",
+      "version": "13.13.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.6.tgz",
+      "integrity": "sha512-zqRj8ugfROCjXCNbmPBe2mmQ0fJWP9lQaN519hwunOgpHgVykme4G6FW95++dyNFDvJUk4rtExkVkL0eciu5NA==",
       "dev": true
     },
     "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -296,9 +296,9 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -383,9 +383,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
     },
@@ -614,18 +614,18 @@
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
     },
     "mocha": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
-      "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
+      "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -641,7 +641,7 @@
         "js-yaml": "3.13.1",
         "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.3",
+        "mkdirp": "0.5.5",
         "ms": "2.1.1",
         "node-environment-flags": "1.0.6",
         "object.assign": "4.1.0",
@@ -720,9 +720,9 @@
       }
     },
     "p-limit": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -828,24 +828,46 @@
         "strip-ansi": "^4.0.0"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
       }
     },
     "string.prototype.trimright": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "strip-ansi": {
@@ -888,9 +910,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+      "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
       "dev": true
     },
     "typescript-bundle": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "json-schema",
@@ -30,7 +30,7 @@
     "chai": "^4.1.2",
     "mocha": "^7.1.1",
     "smoke-task": "^1.1.2",
-    "typescript": "^3.8.3",
+    "typescript": "^3.9.2",
     "typescript-bundle": "^1.0.16"
   }
 }

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -79,10 +79,8 @@ export type TConstructor = TConstructor8<TSchema, TSchema, TSchema, TSchema, TSc
   TConstructor1<TSchema, TSchema> |
   TConstructor0<TSchema>
 
-export type TContract = TFunction | TConstructor | TPromise<any> | TVoid | TUndefined
-export type TPromise<T extends TSchema | TVoid | TUndefined> = { type: 'promise', item: T } & UserDefinedOptions
-export type TUndefined = { type: 'undefined' } & UserDefinedOptions
-export type TVoid = { type: 'void' } & UserDefinedOptions
+type TContract = TConstructor | TFunction
+
 
 // #endregion
 
@@ -203,9 +201,12 @@ export type TString = { type: 'string' } & StringOptions
 export type TBoolean = { type: 'boolean' } & UserDefinedOptions
 export type TNull = { type: 'null' } & UserDefinedOptions
 export type TAny = {} & UserDefinedOptions
+// Extended
+export type TPromise<T extends TSchema | TVoid | TUndefined> = { type: 'promise', item: T } & UserDefinedOptions
+export type TUndefined = { type: 'undefined' } & UserDefinedOptions
+export type TVoid = { type: 'void' } & UserDefinedOptions
 
-
-export type TSchema = TLiteral | TNumber | TInteger | TBoolean | TString | TObject<any> | TArray<any> | TEnum<any> | TMap<any> | TNull | TAny
+export type TSchema = TLiteral | TNumber | TInteger | TBoolean | TString | TObject<any> | TArray<any> | TEnum<any> | TMap<any> | TNull | TAny | TPromise<any> | TUndefined | TVoid
 
 // #endregion
 
@@ -236,12 +237,9 @@ type StaticConstructor<T> =
   T extends TConstructor0<infer R> ? new () => Static<R> :
   never;
 
-type StaticContract<T extends TContract> =
+type StaticContract<T extends TSchema> =
   T extends TFunction ? StaticFunction<T> :
   T extends TConstructor ? StaticConstructor<T> :
-  T extends TPromise<infer U> ? Promise<Static<U>> :
-  T extends TVoid ? void :
-  T extends TUndefined ? undefined :
   never;
 
 // #endregion
@@ -303,15 +301,11 @@ type ReadonlyPropertyKeys<T> = { [K in keyof T]: T[K] extends TReadonly<infer U>
 type OptionalPropertyKeys<T> = { [K in keyof T]: T[K] extends TOptional<infer U> ? K : never }[keyof T]
 type PropertyKeys<T> = keyof Omit<T, OptionalPropertyKeys<T> | ReadonlyPropertyKeys<T> | ReadonlyOptionalPropertyKeys<T>>
 
-type StaticObjectPropertiesExpansion<T> =
+type StaticObjectProperties<T> =
   { readonly [K in ReadonlyOptionalPropertyKeys<T>]?: Static<T[K]> } &
   { readonly [K in ReadonlyPropertyKeys<T>]: Static<T[K]> } &
   { [K in OptionalPropertyKeys<T>]?: Static<T[K]> } &
   { [K in PropertyKeys<T>]: Static<T[K]> }
-
-type StaticObjectProperties<T> = {
-  [K in keyof StaticObjectPropertiesExpansion<T>]: StaticObjectPropertiesExpansion<T>[K]
-}
 
 type StaticSchema<T extends TSchema> =
   T extends TObject<infer U> ? StaticObjectProperties<U> :
@@ -325,11 +319,15 @@ type StaticSchema<T extends TSchema> =
   T extends TBoolean ? boolean :
   T extends TNull ? null :
   T extends TAny ? any :
+  // Extended
+  T extends TPromise<infer U> ? Promise<Static<U>> :
+  T extends TVoid ? void :
+  T extends TUndefined ? undefined :
   never;
 
 // #endregion
 
-export type TStatic = TComposite | TSchema | TContract | TModifier
+export type TStatic = TComposite | TSchema | TModifier | TContract
 
 // Static
 export type Static<T extends TStatic> =
@@ -433,48 +431,48 @@ export class Type {
   // #region TContract
 
   /** Creates a `function` type for the given arguments. */
-  public static Function<T0 extends TStatic, T1 extends TStatic, T2 extends TStatic, T3 extends TStatic, T4 extends TStatic, T5 extends TStatic, T6 extends TStatic, T7 extends TStatic, U extends TStatic>(args: [T0, T1, T2, T3, T4, T5, T6, T7], returns: U, options?: UserDefinedOptions): TFunction8<T0, T1, T2, T3, T4, T5, T6, T7, U>
+  public static Function<T0 extends TSchema, T1 extends TSchema, T2 extends TSchema, T3 extends TSchema, T4 extends TSchema, T5 extends TSchema, T6 extends TSchema, T7 extends TSchema, U extends TSchema>(args: [T0, T1, T2, T3, T4, T5, T6, T7], returns: U, options?: UserDefinedOptions): TFunction8<T0, T1, T2, T3, T4, T5, T6, T7, U>
   /** Creates a `function` type for the given arguments. */
-  public static Function<T0 extends TStatic, T1 extends TStatic, T2 extends TStatic, T3 extends TStatic, T4 extends TStatic, T5 extends TStatic, T6 extends TStatic, U extends TStatic>(args: [T0, T1, T2, T3, T4, T5, T6], returns: U, options?: UserDefinedOptions): TFunction7<T0, T1, T2, T3, T4, T5, T6, U>
+  public static Function<T0 extends TSchema, T1 extends TSchema, T2 extends TSchema, T3 extends TSchema, T4 extends TSchema, T5 extends TSchema, T6 extends TSchema, U extends TSchema>(args: [T0, T1, T2, T3, T4, T5, T6], returns: U, options?: UserDefinedOptions): TFunction7<T0, T1, T2, T3, T4, T5, T6, U>
   /** Creates a `function` type for the given arguments. */
-  public static Function<T0 extends TStatic, T1 extends TStatic, T2 extends TStatic, T3 extends TStatic, T4 extends TStatic, T5 extends TStatic, U extends TStatic>(args: [T0, T1, T2, T3, T4, T5], returns: U, options?: UserDefinedOptions): TFunction6<T0, T1, T2, T3, T4, T5, U>
+  public static Function<T0 extends TSchema, T1 extends TSchema, T2 extends TSchema, T3 extends TSchema, T4 extends TSchema, T5 extends TSchema, U extends TSchema>(args: [T0, T1, T2, T3, T4, T5], returns: U, options?: UserDefinedOptions): TFunction6<T0, T1, T2, T3, T4, T5, U>
   /** Creates a `function` type for the given arguments. */
-  public static Function<T0 extends TStatic, T1 extends TStatic, T2 extends TStatic, T3 extends TStatic, T4 extends TStatic, U extends TStatic>(args: [T0, T1, T2, T3, T4], returns: U, options?: UserDefinedOptions): TFunction5<T0, T1, T2, T3, T4, U>
+  public static Function<T0 extends TSchema, T1 extends TSchema, T2 extends TSchema, T3 extends TSchema, T4 extends TSchema, U extends TSchema>(args: [T0, T1, T2, T3, T4], returns: U, options?: UserDefinedOptions): TFunction5<T0, T1, T2, T3, T4, U>
   /** Creates a `function` type for the given arguments. */
-  public static Function<T0 extends TStatic, T1 extends TStatic, T2 extends TStatic, T3 extends TStatic, U extends TStatic>(args: [T0, T1, T2, T3], returns: U, options?: UserDefinedOptions): TFunction4<T0, T1, T2, T3, U>
+  public static Function<T0 extends TSchema, T1 extends TSchema, T2 extends TSchema, T3 extends TSchema, U extends TSchema>(args: [T0, T1, T2, T3], returns: U, options?: UserDefinedOptions): TFunction4<T0, T1, T2, T3, U>
   /** Creates a `function` type for the given arguments. */
-  public static Function<T0 extends TStatic, T1 extends TStatic, T2 extends TStatic, U extends TStatic>(args: [T0, T1, T2], returns: U, options?: UserDefinedOptions): TFunction3<T0, T1, T2, U>
+  public static Function<T0 extends TSchema, T1 extends TSchema, T2 extends TSchema, U extends TSchema>(args: [T0, T1, T2], returns: U, options?: UserDefinedOptions): TFunction3<T0, T1, T2, U>
   /** Creates a `function` type for the given arguments. */
-  public static Function<T0 extends TStatic, T1 extends TStatic, U extends TStatic>(args: [T0, T1], returns: U, options?: UserDefinedOptions): TFunction2<T0, T1, U>
+  public static Function<T0 extends TSchema, T1 extends TSchema, U extends TSchema>(args: [T0, T1], returns: U, options?: UserDefinedOptions): TFunction2<T0, T1, U>
   /** Creates a `function` type for the given arguments. */
-  public static Function<T0 extends TStatic, U extends TStatic>(args: [T0], returns: U, options?: UserDefinedOptions): TFunction1<T0, U>
+  public static Function<T0 extends TSchema, U extends TSchema>(args: [T0], returns: U, options?: UserDefinedOptions): TFunction1<T0, U>
   /** Creates a `function` type for the given arguments. */
-  public static Function<U extends TStatic>(args: [], returns: U, options?: UserDefinedOptions): TFunction0<U>
+  public static Function<U extends TSchema>(args: [], returns: U, options?: UserDefinedOptions): TFunction0<U>
   /** Creates a `function` type for the given arguments. */
-  public static Function(args: TStatic[], returns: TStatic, options: UserDefinedOptions = {}): TFunction {
+  public static Function(args: TSchema[], returns: TSchema, options: UserDefinedOptions = {}): TFunction {
     return { ...options, type: 'function', arguments: args, returns } as TFunction
   }
 
   /** Creates a `constructor` type for the given arguments. */
-  public static Constructor<T0 extends TStatic, T1 extends TStatic, T2 extends TStatic, T3 extends TStatic, T4 extends TStatic, T5 extends TStatic, T6 extends TStatic, T7 extends TStatic, U extends TStatic>(args: [T0, T1, T2, T3, T4, T5, T6, T7], returns: U, options?: UserDefinedOptions): TConstructor8<T0, T1, T2, T3, T4, T5, T6, T7, U>
+  public static Constructor<T0 extends TSchema, T1 extends TSchema, T2 extends TSchema, T3 extends TSchema, T4 extends TSchema, T5 extends TSchema, T6 extends TSchema, T7 extends TSchema, U extends TSchema>(args: [T0, T1, T2, T3, T4, T5, T6, T7], returns: U, options?: UserDefinedOptions): TConstructor8<T0, T1, T2, T3, T4, T5, T6, T7, U>
   /** Creates a `constructor` type for the given arguments. */
-  public static Constructor<T0 extends TStatic, T1 extends TStatic, T2 extends TStatic, T3 extends TStatic, T4 extends TStatic, T5 extends TStatic, T6 extends TStatic, U extends TStatic>(args: [T0, T1, T2, T3, T4, T5, T6], returns: U, options?: UserDefinedOptions): TConstructor7<T0, T1, T2, T3, T4, T5, T6, U>
+  public static Constructor<T0 extends TSchema, T1 extends TSchema, T2 extends TSchema, T3 extends TSchema, T4 extends TSchema, T5 extends TSchema, T6 extends TSchema, U extends TSchema>(args: [T0, T1, T2, T3, T4, T5, T6], returns: U, options?: UserDefinedOptions): TConstructor7<T0, T1, T2, T3, T4, T5, T6, U>
   /** Creates a `constructor` type for the given arguments. */
-  public static Constructor<T0 extends TStatic, T1 extends TStatic, T2 extends TStatic, T3 extends TStatic, T4 extends TStatic, T5 extends TStatic, U extends TStatic>(args: [T0, T1, T2, T3, T4, T5], returns: U, options?: UserDefinedOptions): TConstructor6<T0, T1, T2, T3, T4, T5, U>
+  public static Constructor<T0 extends TSchema, T1 extends TSchema, T2 extends TSchema, T3 extends TSchema, T4 extends TSchema, T5 extends TSchema, U extends TSchema>(args: [T0, T1, T2, T3, T4, T5], returns: U, options?: UserDefinedOptions): TConstructor6<T0, T1, T2, T3, T4, T5, U>
   /** Creates a `constructor` type for the given arguments. */
-  public static Constructor<T0 extends TStatic, T1 extends TStatic, T2 extends TStatic, T3 extends TStatic, T4 extends TStatic, U extends TStatic>(args: [T0, T1, T2, T3, T4], returns: U, options?: UserDefinedOptions): TConstructor5<T0, T1, T2, T3, T4, U>
+  public static Constructor<T0 extends TSchema, T1 extends TSchema, T2 extends TSchema, T3 extends TSchema, T4 extends TSchema, U extends TSchema>(args: [T0, T1, T2, T3, T4], returns: U, options?: UserDefinedOptions): TConstructor5<T0, T1, T2, T3, T4, U>
   /** Creates a `constructor` type for the given arguments. */
-  public static Constructor<T0 extends TStatic, T1 extends TStatic, T2 extends TStatic, T3 extends TStatic, U extends TStatic>(args: [T0, T1, T2, T3], returns: U, options?: UserDefinedOptions): TConstructor4<T0, T1, T2, T3, U>
+  public static Constructor<T0 extends TSchema, T1 extends TSchema, T2 extends TSchema, T3 extends TSchema, U extends TSchema>(args: [T0, T1, T2, T3], returns: U, options?: UserDefinedOptions): TConstructor4<T0, T1, T2, T3, U>
   /** Creates a `constructor` type for the given arguments. */
-  public static Constructor<T0 extends TStatic, T1 extends TStatic, T2 extends TStatic, U extends TStatic>(args: [T0, T1, T2], returns: U, options?: UserDefinedOptions): TConstructor3<T0, T1, T2, U>
+  public static Constructor<T0 extends TSchema, T1 extends TSchema, T2 extends TSchema, U extends TSchema>(args: [T0, T1, T2], returns: U, options?: UserDefinedOptions): TConstructor3<T0, T1, T2, U>
   /** Creates a `constructor` type for the given arguments. */
-  public static Constructor<T0 extends TStatic, T1 extends TStatic, U extends TStatic>(args: [T0, T1], returns: U, options?: UserDefinedOptions): TConstructor2<T0, T1, U>
+  public static Constructor<T0 extends TSchema, T1 extends TSchema, U extends TSchema>(args: [T0, T1], returns: U, options?: UserDefinedOptions): TConstructor2<T0, T1, U>
   /** Creates a `constructor` type for the given arguments. */
-  public static Constructor<T0 extends TStatic, U extends TStatic>(args: [T0], returns: U, options?: UserDefinedOptions): TConstructor1<T0, U>
+  public static Constructor<T0 extends TSchema, U extends TSchema>(args: [T0], returns: U, options?: UserDefinedOptions): TConstructor1<T0, U>
   /** Creates a `constructor` type for the given arguments. */
-  public static Constructor<U extends TStatic>(args: [], returns: U, options?: UserDefinedOptions): TConstructor0<U>
+  public static Constructor<U extends TSchema>(args: [], returns: U, options?: UserDefinedOptions): TConstructor0<U>
   /** Creates a `constructor` type for the given arguments. */
-  public static Constructor(args: TStatic[], returns: TStatic, options: UserDefinedOptions = {}): TConstructor {
+  public static Constructor(args: TSchema[], returns: TSchema, options: UserDefinedOptions = {}): TConstructor {
     return { ...options, type: 'constructor', arguments: args, returns } as TConstructor
   }
 


### PR DESCRIPTION
This fix aligns TypeBox to inference changes made in TypeScript 3.9.2.

- Removes Object Property Flattening for Readonly, Optional modifiers
- Updates on Function | Constructor constraints.