### PR TITLE
Use anyOf instead of oneOf for Union (sinclairzx81#37)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -244,7 +244,7 @@ TypeBox provides a number of functions to generate JSON Schema data types. The f
         <tr>
             <td>Union</td>
             <td><code>const T = Type.Union([Type.Number(), Type.String()])</code></td>
-            <td><code>{ oneOf: [{ type: 'number'}, {type: 'string'}] }</code></td>
+            <td><code>{ anyOf: [{ type: 'number'}, {type: 'string'}] }</code></td>
         </tr>
         <tr>
             <td>Tuple</td>

--- a/spec/union.ts
+++ b/spec/union.ts
@@ -13,14 +13,14 @@ describe('Union', () => {
     ok(T, 42)
   })
 
-  it('A | B', () => {
+  it('A | (A & B)', () => {
     const A = Type.Object({ a: Type.String() })
-    const B = Type.Object({ b: Type.Number() })
+    const B = Type.Object({ a: Type.String(), b: Type.Optional(Type.Number()) })
     const T = Type.Union([A, B])
-    
-    fail(T, {a: 'hello', b: 42 })
+
+    fail(T, { })
+    ok(T, {a: 'hello', b: 42 })
     ok(T, { a: 'hello' })
-    ok(T, { b: 42 })
   })
 
   it('A | B | C', () => {
@@ -29,7 +29,7 @@ describe('Union', () => {
     const C = Type.Object({ c: Type.Boolean() })
     const T = Type.Union([A, B, C])
     
-    fail(T, {a: 'hello', b: 42, c: true })
+    fail(T, { })
     ok(T, {a: 'hello' })
     ok(T, {b: 42 })
     ok(T, {c: true })

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -53,7 +53,7 @@ type TContract = TConstructor | TFunction
 // #region TComposite
 
 export type TIntersect<T extends TSchema[] = any> = { allOf: [...T] } & UserDefinedOptions
-export type TUnion<T extends TSchema[] = any> = { oneOf: [...T] } & UserDefinedOptions
+export type TUnion<T extends TSchema[] = any> = { anyOf: [...T] } & UserDefinedOptions
 
 export type TTuple<T extends TSchema[] = any> = { type: 'array', items: [...T], additionalItems: false, minItems: number, maxItems: number } & UserDefinedOptions
 
@@ -238,7 +238,7 @@ export class Type {
 
   /** Creates a Union type for the given arguments. */
   public static Union<T extends TSchema[]>(items: [...T], options: UserDefinedOptions = {}): TUnion<T> {
-    return { ...options, oneOf: items };
+    return { ...options, anyOf: items };
   }
 
   /** Creates an Intersect type for the given arguments. */


### PR DESCRIPTION
This PR has the proposed fix for #37 
Also changed the test cases for Union to reflect the new (correct) behavior. Made sure that new tests would not pass with the old logic.