### PR TITLE
additionalProperties false by default on objects

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,10 +1,14 @@
 import { Type, Static } from '@sinclair/typebox'
 
-const T = Type.Partial(
-    Type.Object({
-        x: Type.Number(),
-        y: Type.Number()
-    })
-)
+const A = Type.Object({
+    x: Type.Number()
+})
+const B = Type.Object({
+    y: Type.Optional(Type.String())
+})
+
+const T = Type.Required(Type.Intersect([A, B]))
+
+type T = Static<typeof T>
 
 console.log(T)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.12.9",
+  "version": "0.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.12.9",
+      "version": "0.14.1",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.1.3",

--- a/readme.md
+++ b/readme.md
@@ -44,10 +44,9 @@ License MIT
 - [Example](#Example)
 - [Types](#Types)
 - [Modifiers](#Modifiers)
-- [Utility Types](#Utility-Types)
 - [Options](#Options)
 - [Strict](#Strict)
-- [Functions](#Functions)
+- [Extended Types](#Extended-Types)
 - [Interfaces](#Interfaces)
 - [Validation](#Validation)
 
@@ -136,123 +135,182 @@ function receive(record: Record) { // ... as a type
 The following table outlines the TypeBox mappings between TypeScript and JSON schema.
 
 ```typescript
-┌────────────────────────────────┬─────────────────────────────┬─────────────────────────────┐
-│ TypeBox                        │ TypeScript                  │ JSON Schema                 │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Any()           │ type T = any                │ const T = { }               │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Unknown()       │ type T = unknown            │ const T = { }               │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.String()        │ type T = string             │ const T = {                 │
-│                                │                             │    type: 'string'           │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Number()        │ type T = number             │ const T = {                 │
-│                                │                             │    type: 'number'           │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Integer()       │ type T = number             │ const T = {                 │
-│                                │                             │    type: 'integer'          │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Boolean()       │ type T = boolean            │ const T = {                 │
-│                                │                             │    type: 'boolean'          │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Null()          │ type T = null               │ const T = {                 │
-│                                │                             │    type: 'null'             │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.RegEx(/foo/)	 │ type T = string             │ const T = {                 │
-│                                │                             │    type: 'string',          │
-│                                │                             │    pattern: 'foo'           │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Literal('foo')  │ type T = 'foo'              │ const T = {                 │
-│                                │                             │    type: 'string',          │
-│                                │                             │    enum: ['foo']            │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Array(          │ type T = number[]           │ const T = {                 │
-│    Type.Number()               │                             │    type: 'array',           │
-│ )                              │                             │    items: {                 │
-│                                │                             │      type: 'number'         │
-│                                │                             │    }                        │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Dict(           │ type T = {                  │ const T = {                 │
-│    Type.Number()               │      [key: string]          │    type: 'object'           │
-│ )                              │ } : number                  │    additionalProperties: {  │
-│   	                         │                             │      type: 'number'         │
-│   	                         │                             │    }                        │
-│   	                         │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Object({        │ type T = {                  │ const T = {                 │
-│   name:  Type.String(),        │    name: string,            │   type: 'object',           │
-│   email: Type.String(),        │    email: string            │   properties: {             │
-│ })	                         │ }                           │      name: {                │
-│   	                         │                             │        type: 'string'       │
-│   	                         │                             │      },                     │
-│   	                         │                             │      email: {               │
-│                                │                             │        type: 'string'       │
-│   	                         │                             │      }                      │
-│   	                         │                             │   },                        │
-│                                │                             │   required: [               │
-│                                │                             │      'name',                │
-│                                │                             │      'email'                │
-│                                │                             │   ]                         |
-│   	                         │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Tuple([         │ type T = [string, number]   │ const T = {                 │
-│   Type.String(),               │                             │    type: 'array',           │
-│   Type.Number()                │                             │    items: [                 │
-│ ])                             │                             │       {                     │
-│   	                         │                             │         type: 'string'      │
-│   	                         │                             │       }, {                  │
-│   	                         │                             │         type: 'number'      │
-│   	                         │                             │       }                     │
-│   	                         │                             │    ],                       │
-│   	                         │                             │    additionalItems: false,  │
-│   	                         │                             │    minItems: 2,             │
-│   	                         │                             │    maxItems: 2,             │
-│   	                         │                             │ }                           |
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ enum Foo {                     │ enum Foo {                  │ const T = {                 │
-│   A,                           │   A,                        │    enum: [0, 1]             │
-│   B                            │   B                         │ }                           │
-│ }                              │ }                           │                             │
-│                                │                             │                             │
-│ type T = Type.Enum(Foo)        │ type T = Foo                │                             │
-│                                │                             │                             │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Union([         │ type T = string | number    │ const T = {                 │
-│   Type.String(),               │                             │    anyOf: [{                │
-│   Type.Number()                │                             │       type: 'string'        │
-│ ])                             │                             │    }, {                     │
-│                                │                             │       type: 'number'        │
-│                                │                             │    }]                       │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Intersect([     │ type T = {                  │ const T = {                 │
-│    Type.Object({               │    a: string                │   allOf: [{                 │
-│         a: Type.String()       │ } & {                       │     type: 'object',         │
-│    }),                         │    b: number                │     properties: {           │
-│    Type.Object({               │ }                           │        a: {                 │
-│       b: Type.Number()         │                             │          type: 'string'     │
-│   })                           │                             │        }                    │
-│ })                             │                             │     },                      │
-│                                │                             │     required: ['a']         │
-│                                │                             │   }, {                      │
-│                                │                             │     type: 'object',         │
-│                                │                             │     properties: {           │
-│                                │                             │       b: {                  │
-│                                │                             │         type: 'number'      │
-│                                │                             │       }                     │
-│                                │                             │     },                      │
-│                                │                             │     required:['b']          │
-│                                │                             │   }]                        │
-│                                │                             │ }                           │
-└────────────────────────────────┴─────────────────────────────┴─────────────────────────────┘
+┌────────────────────────────────┬─────────────────────────────┬────────────────────────────────┐
+│ TypeBox                        │ TypeScript                  │ JSON Schema                    │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Any()           │ type T = any                │ const T = { }                  │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Unknown()       │ type T = unknown            │ const T = { }                  │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.String()        │ type T = string             │ const T = {                    │
+│                                │                             │    type: 'string'              │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Number()        │ type T = number             │ const T = {                    │
+│                                │                             │    type: 'number'              │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Integer()       │ type T = number             │ const T = {                    │
+│                                │                             │    type: 'integer'             │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Boolean()       │ type T = boolean            │ const T = {                    │
+│                                │                             │    type: 'boolean'             │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Null()          │ type T = null               │ const T = {                    │
+│                                │                             │    type: 'null'                │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.RegEx(/foo/)	 │ type T = string             │ const T = {                    │
+│                                │                             │    type: 'string',             │
+│                                │                             │    pattern: 'foo'              │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Literal('foo')  │ type T = 'foo'              │ const T = {                    │
+│                                │                             │    type: 'string',             │
+│                                │                             │    enum: ['foo']               │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Array(          │ type T = number[]           │ const T = {                    │
+│    Type.Number()               │                             │    type: 'array',              │
+│ )                              │                             │    items: {                    │
+│                                │                             │      type: 'number'            │
+│                                │                             │    }                           │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Dict(           │ type T = {                  │ const T = {                    │
+│    Type.Number()               │      [key: string]          │    type: 'object'              │
+│ )                              │ } : number                  │    additionalProperties: {     │
+│   	                         │                             │      type: 'number'            │
+│   	                         │                             │    }                           │
+│   	                         │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Object({        │ type T = {                  │ const T = {                    │
+│   a: Type.Number(),            │    a: number,               │   type: 'object',              │
+│   b: Type.String()             │    b: string,               │   additionalProperties: false, │
+│ })                             │ }                           │   properties: {                │
+│                                │                             │      a: {                      │
+│   	                         │                             │        type: 'number'          │
+│   	                         │                             │      },                        │
+│   	                         │                             │      b: {                      │
+│                                │                             │        type: 'string'          │
+│   	                         │                             │      }                         │
+│   	                         │                             │   },                           │
+│                                │                             │   required: ['a', 'b']         │
+│   	                         │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Tuple([         │ type T = [string, number]   │ const T = {                    │
+│   Type.String(),               │                             │    type: 'array',              │
+│   Type.Number()                │                             │    items: [                    │
+│ ])                             │                             │       {                        │
+│   	                         │                             │         type: 'string'         │
+│   	                         │                             │       }, {                     │
+│   	                         │                             │         type: 'number'         │
+│   	                         │                             │       }                        │
+│   	                         │                             │    ],                          │
+│   	                         │                             │    additionalItems: false,     │
+│   	                         │                             │    minItems: 2,                │
+│   	                         │                             │    maxItems: 2,                │
+│   	                         │                             │ }                              |
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ enum Foo {                     │ enum Foo {                  │ const T = {                    │
+│   A,                           │   A,                        │    enum: [0, 1]                │
+│   B                            │   B                         │ }                              │
+│ }                              │ }                           │                                │
+│                                │                             │                                │
+│ type T = Type.Enum(Foo)        │ type T = Foo                │                                │
+│                                │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Union([         │ type T = string | number    │ const T = {                    │
+│   Type.String(),               │                             │    anyOf: [{                   │
+│   Type.Number()                │                             │       type: 'string'           │
+│ ])                             │                             │    }, {                        │
+│                                │                             │       type: 'number'           │
+│                                │                             │    }]                          │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Intersect([     │ type T = {                  │ const T = {                    │
+│    Type.Object({               │    a: string                │   type: 'object',              │
+│       a: Type.String()         │ } & {                       │   additionalProperties: false, │
+│    }),                         │    b: number                │   properties: {                │
+│    Type.Object({               │ }                           │     a: {                       │
+│       b: Type.Number()         │                             │        type: 'string'          │
+│   })                           │                             │     },                         │
+│ })                             │                             │     b: {                       │
+│                                │                             │        type: 'number'          │
+│                                │                             │     }                          │
+│                                │                             │   },                           │
+│                                │                             │   required: ['a', 'b']         │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Partial(        │ type T = Partial<{          │ const T = {                    │
+│    Type.Object({               │    x: number,               │   type: 'object',              │
+│         x: Type.Number(),      │    y: number                │   properties: {                │
+│         y: Type.Number()       | }>                          │     x: {                       │
+│    })                          │                             │        type: 'number'          │
+│ )                              │                             │     },                         │
+│                                │                             │     y: {                       │
+│                                │                             │        type: 'number'          │
+│                                │                             │     }                          │
+│                                │                             │   }                            │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Required(       │ type T = Required<{         │ const T = {                    │
+│    Type.Object({               │    x?: number,              │   type: 'object',              │
+│       x: Type.Optional(        │    y?: number               │   properties: {                │
+│          Type.Number()         | }>                          │     x: {                       │
+│       ),                       │                             │        type: 'number'          │
+│       y: Type.Optional(        │                             │     },                         │
+│          Type.Number()         │                             │     y: {                       │
+│       )                        │                             │        type: 'number'          │
+│    })                          │                             │     }                          │
+│ )                              │                             │   }                            │
+│                                │                             │   required: ['x', 'y']         │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Pick(           │ type T = Pick<{             │ const T = {                    │
+│    Type.Object({               │    x: number,               │   type: 'object',              │
+│       x: Type.Optional(        │    y: number                │   properties: {                │
+│          Type.Number()         | }, 'x'>                     │     x: {                       │
+│       ),                       │                             │        type: 'number'          │
+│       y: Type.Optional(        │                             │     }                          │
+│          Type.Number()         │                             │   },                           │
+│       )                        │                             │   required: ['x']              │
+│    })                          │                             │ }                              │
+│ , ['x'])                       │                             │                                │
+│                                │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Omit(           │ type T = Omit<{             │ const T = {                    │
+│    Type.Object({               │    x: number,               │   type: 'object',              │
+│       x: Type.Optional(        │    y: number,               │   properties: {                │
+│          Type.Number()         | }, 'y'>                     │     x: {                       │
+│       ),                       │                             │        type: 'number'          │
+│       y: Type.Optional(        │                             │     }                          │
+│          Type.Number()         │                             │   },                           │
+│       )                        │                             │   required: ['x']              │
+│    })                          │                             │ }                              │
+│ , ['y'])                       │                             │                                │
+│                                │                             │                                │
+└────────────────────────────────┴─────────────────────────────┴────────────────────────────────┘
 ```
 <a name="Modifiers"></a>
 
@@ -261,98 +319,40 @@ The following table outlines the TypeBox mappings between TypeScript and JSON sc
 TypeBox provides modifiers that can be applied to an objects properties. This allows for `optional` and `readonly` to be applied to that property. The following table illustates how they map between TypeScript and JSON Schema.
 
 ```typescript
-┌────────────────────────────────┬─────────────────────────────┬─────────────────────────────┐
-│ TypeBox                        │ TypeScript                  │ JSON Schema                 │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Object({        │ type T = {                  │ const T = {                 │
-│   name: Type.Optional(         │    name?: string,           │   type: 'object',           │
-│      Type.String(),            │ }                           │   properties: {             │
-│   )	                         │                             │      name: {                │
-│ })  	                         │                             │        type: 'string'       │
-│   	                         │                             │      }                      │
-│   	                         │                             │   }                         │
-│   	                         │                             │ }                           │
-│   	                         │                             │                             │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Object({        │ type T = {                  │ const T = {                 │
-│   name: Type.Readonly(         │    readonly name: string,   │   type: 'object',           │
-│      Type.String(),            │ }                           │   properties: {             │
-│   )	                         │                             │      name: {                │
-│ })  	                         │                             │        type: 'string'       │
-│   	                         │                             │      }                      │
-│   	                         │                             │   },                        │
-│                                │                             │   required: ['name']        │
-│   	                         │                             │ }                           │
-│   	                         │                             │                             │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Object({        │ type T = {                  │ const T = {                 │
-│   name: Type.ReadonlyOptional( │    readonly name?: string,  │   type: 'object',           │
-│      Type.String(),            │ }                           │   properties: {             │
-│   )	                         │                             │      name: {                │
-│ })  	                         │                             │        type: 'string'       │
-│   	                         │                             │      }                      │
-│   	                         │                             │   }                         │
-│                                │                             │ }                           │
-│   	                         │                             │                             │
-└────────────────────────────────┴─────────────────────────────┴─────────────────────────────┘
-```
-<a name="Utility-Types"></a>
-
-### Utility Types
-
-TypeBox supports a subset of TypeScript's built-in [Utility Types](https://www.typescriptlang.org/docs/handbook/utility-types.html). These types operate on schemas of `Type.Object({...})` only. The following table outlines the TypeBox mappings between TypeScript and JSON schema.
-
-```typescript
-┌────────────────────────────────┬─────────────────────────────┬─────────────────────────────┐
-│ const T = Type.Partial(        │ type T = Partial<{          │ const T = {                 │
-│    Type.Object({               │    x: number,               │   type: 'object',           │
-│         x: Type.Number(),      │    y: number                │   properties: {             │
-│         y: Type.Number()       | }>                          │     x: {                    │
-│    })                          │                             │        type: 'number'       │
-│ )                              │                             │     },                      │
-│                                │                             │     y: {                    │
-│                                │                             │        type: 'number'       │
-│                                │                             │     }                       │
-│                                │                             │   }                         │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Required(       │ type T = Required<{         │ const T = {                 │
-│    Type.Object({               │    x?: number,              │   type: 'object',           │
-│       x: Type.Optional(        │    y?: number               │   properties: {             │
-│          Type.Number()         | }>                          │     x: {                    │
-│       ),                       │                             │        type: 'number'       │
-│       y: Type.Optional(        │                             │     },                      │
-│          Type.Number()         │                             │     y: {                    │
-│       )                        │                             │        type: 'number'       │
-│    })                          │                             │     }                       │
-│ )                              │                             │   }                         │
-│                                │                             │   required: ['x', 'y']      │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Pick(           │ type T = Pick<{             │ const T = {                 │
-│    Type.Object({               │    x: number,               │   type: 'object',           │
-│       x: Type.Optional(        │    y: number                │   properties: {             │
-│          Type.Number()         | }, 'x'>                     │     x: {                    │
-│       ),                       │                             │        type: 'number'       │
-│       y: Type.Optional(        │                             │     }                       │
-│          Type.Number()         │                             │   },                        │
-│       )                        │                             │   required: ['x']           │
-│    })                          │                             │ }                           │
-│ , ['x'])                       │                             │                             │
-│                                │                             │                             │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Omit(           │ type T = Omit<{             │ const T = {                 │
-│    Type.Object({               │    x: number,               │   type: 'object',           │
-│       x: Type.Optional(        │    y: number,               │   properties: {             │
-│          Type.Number()         | }, 'y'>                     │     x: {                    │
-│       ),                       │                             │        type: 'number'       │
-│       y: Type.Optional(        │                             │     }                       │
-│          Type.Number()         │                             │   },                        │
-│       )                        │                             │   required: ['x']           │
-│    })                          │                             │ }                           │
-│ , ['y'])                       │                             │                             │
-│                                │                             │                             │
-└────────────────────────────────┴─────────────────────────────┴─────────────────────────────┘
+┌────────────────────────────────┬─────────────────────────────┬────────────────────────────────┐
+│ TypeBox                        │ TypeScript                  │ JSON Schema                    │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Object({        │ type T = {                  │ const T = {                    │
+│   name: Type.Optional(         │    name?: string,           │   type: 'object',              │
+│      Type.String(),            │ }                           │   properties: {                │
+│   )	                         │                             │      name: {                   │
+│ })  	                         │                             │        type: 'string'          │
+│   	                         │                             │      }                         │
+│   	                         │                             │   }                            │
+│   	                         │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Object({        │ type T = {                  │ const T = {                    │
+│   name: Type.Readonly(         │    readonly name: string,   │   type: 'object',              │
+│      Type.String(),            │ }                           │   properties: {                │
+│   )	                         │                             │      name: {                   │
+│ })  	                         │                             │        type: 'string'          │
+│   	                         │                             │      }                         │
+│   	                         │                             │   },                           │
+│                                │                             │   required: ['name']           │
+│   	                         │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Object({        │ type T = {                  │ const T = {                    │
+│   name: Type.ReadonlyOptional( │    readonly name?: string,  │   type: 'object',              │
+│      Type.String(),            │ }                           │   properties: {                │
+│   )	                         │                             │      name: {                   │
+│ })  	                         │                             │        type: 'string'          │
+│   	                         │                             │      }                         │
+│   	                         │                             │   }                            │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+└────────────────────────────────┴─────────────────────────────┴────────────────────────────────┘
 ```
 
 <a name="Options"></a>
@@ -401,55 +401,60 @@ const U = Type.Strict(T)                // const U = {
                                         // }
 ```
 
-<a name="Functions"></a>
+<a name="Extended-Types"></a>
 
-### Functions
+### Extended Types
 
 In addition to JSON schema types, TypeBox provides several extended types that allow for `function` and `constructor` types to be composed. These additional types are not valid JSON Schema and will not validate using typical JSON Schema validation. However, these types can be used to frame JSON schema and describe callable interfaces that may receive JSON validated data. These types are as follows.
 
 ```typescript
-┌────────────────────────────────┬─────────────────────────────┬─────────────────────────────┐
-│ TypeBox                        │ TypeScript                  │ Extended Schema             │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Constructor([   │ type T = new (              │ const T = {                 │
-|    Type.String(),              │  arg0: string,              │   type: 'constructor'       │
-│    Type.Number(),              │  arg1: number               │   arguments: [{             │
-│ ], Type.Boolean())             │ ) => boolean                │      type: 'string'         │
-│                                │                             │   }, {                      │
-│                                │                             │      type: 'number'         │
-│                                │                             │   }],                       │
-│                                │                             │   returns: {                │
-│                                │                             │      type: 'boolean'        │
-│                                │                             │   }                         │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Function([      │ type T = (                  │ const T = {                 │
-|    Type.String(),              │  arg0: string,              │   type : 'function',        │
-│    Type.Number(),              │  arg1: number               │   arguments: [{             │
-│ ], Type.Boolean())             │ ) => boolean                │      type: 'string'         │
-│                                │                             │   }, {                      │
-│                                │                             │      type: 'number'         │
-│                                │                             │   }],                       │
-│                                │                             │   returns: {                │
-│                                │                             │      type: 'boolean'        │
-│                                │                             │   }                         │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Promise(        │ type T = Promise<string>    │ const T = {                 │
-|    Type.String()               │                             │   type: 'promise',          │
-| )                              │                             │   item: {                   │
-│                                │                             │      type: 'string'         │
-│                                │                             │   }                         │
-│                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Undefined()     │ type T = undefined          │ const T = {                 │
-|                                │                             │   type: 'undefined'         │
-|                                │                             │ }                           │
-├────────────────────────────────┼─────────────────────────────┼─────────────────────────────┤
-│ const T = Type.Void()          │ type T = void               │ const T = {                 │
-|                                │                             │   type: 'void'              │
-|                                │                             │ }                           │
-└────────────────────────────────┴─────────────────────────────┴─────────────────────────────┘
+┌────────────────────────────────┬─────────────────────────────┬────────────────────────────────┐
+│ TypeBox                        │ TypeScript                  │ Extended Schema                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Constructor([   │ type T = new (              │ const T = {                    │
+|    Type.String(),              │  arg0: string,              │   type: 'constructor'          │
+│    Type.Number(),              │  arg1: number               │   arguments: [{                │
+│ ], Type.Boolean())             │ ) => boolean                │      type: 'string'            │
+│                                │                             │   }, {                         │
+│                                │                             │      type: 'number'            │
+│                                │                             │   }],                          │
+│                                │                             │   returns: {                   │
+│                                │                             │      type: 'boolean'           │
+│                                │                             │   }                            │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Function([      │ type T = (                  │ const T = {                    │
+|    Type.String(),              │  arg0: string,              │   type : 'function',           │
+│    Type.Number(),              │  arg1: number               │   arguments: [{                │
+│ ], Type.Boolean())             │ ) => boolean                │      type: 'string'            │
+│                                │                             │   }, {                         │
+│                                │                             │      type: 'number'            │
+│                                │                             │   }],                          │
+│                                │                             │   returns: {                   │
+│                                │                             │      type: 'boolean'           │
+│                                │                             │   }                            │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Promise(        │ type T = Promise<string>    │ const T = {                    │
+|    Type.String()               │                             │   type: 'promise',             │
+| )                              │                             │   item: {                      │
+│                                │                             │      type: 'string'            │
+│                                │                             │   }                            │
+│                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Undefined()     │ type T = undefined          │ const T = {                    │
+|                                │                             │   type: 'undefined'            │
+|                                │                             │ }                              │
+│   	                         │                             │                                │
+├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
+│ const T = Type.Void()          │ type T = void               │ const T = {                    │
+|                                │                             │   type: 'void'                 │
+|                                │                             │ }                              │
+│   	                         │                             │                                │
+└────────────────────────────────┴─────────────────────────────┴────────────────────────────────┘
 ```
 
 <a name="Interfaces"></a>

--- a/spec/schema/intersect.ts
+++ b/spec/schema/intersect.ts
@@ -22,4 +22,19 @@ describe('Intersect', () => {
     fail(T, {b: 42 })
     fail(T, {c: true })
   })
+
+  describe('Additional Properties', () => {
+    const A = Type.Object({
+      a: Type.String(),
+      b: Type.String(),
+    })
+    const B = Type.Object({
+      c: Type.String(),
+    });
+    const T = Type.Intersect([A, B])
+    
+    ok(T, { a: '1', b: '2', c: '3' })
+    fail(T, { a: '1', b: '2' })
+    fail(T, { a: '1', b: '2', c: '3', d: '4' })
+  })
 })

--- a/spec/schema/object.ts
+++ b/spec/schema/object.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert'
+import { deepStrictEqual, strictEqual } from 'assert'
 import { Type } from '@sinclair/typebox'
 import { ok, fail } from './validate'
 
@@ -33,6 +33,7 @@ describe('Object', () => {
     fail(T, 123)
     fail(T, null)
   })
+
   it('Optional',  () => {
     const T = Type.Object({
       a: Type.Optional(Type.Number()),
@@ -65,6 +66,7 @@ describe('Object', () => {
     fail(T, 123)
     fail(T, null)
   })
+
   it('Readonly',  () => {
     const T = Type.Object({
       a: Type.Readonly(Type.Number()),
@@ -104,7 +106,7 @@ describe('Object', () => {
         c: Type.String(),
       });
 
-      assert.deepEqual(T.required, ['a', 'c']);
+      deepStrictEqual(T.required, ['a', 'c']);
     });
 
     it('Is omitted when no properties are required', () => {
@@ -114,8 +116,18 @@ describe('Object', () => {
         c: Type.Optional(Type.String()),
       });
 
-      assert.equal(T.required, undefined);
+      strictEqual(T.required, undefined);
     });
   });
-
+  
+  describe('Additional Properties', () => {
+    const T = Type.Object({
+      a: Type.String(),
+      b: Type.String(),
+      c: Type.String(),
+    });
+    ok(T, { a: '1', b: '2', c: '3' })
+    fail(T, { a: '1', b: '2' })
+    fail(T, { a: '1', b: '2', c: '3', d: '4' })
+  })
 })

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -34,17 +34,16 @@ export const ReadonlyOptionalModifier = Symbol('ReadonlyOptionalModifier')
 export const OptionalModifier         = Symbol('OptionalModifier')
 export const ReadonlyModifier         = Symbol('ReadonlyModifier')
 
+export type TModifier                            = TReadonlyOptional<TSchema> | TOptional<TSchema> | TReadonly<TSchema>
 export type TReadonlyOptional<T extends TSchema> = T & { modifier: typeof ReadonlyOptionalModifier }
 export type TOptional<T extends TSchema>         = T & { modifier: typeof OptionalModifier }
 export type TReadonly<T extends TSchema>         = T & { modifier: typeof ReadonlyModifier }
-export type TModifier = TReadonlyOptional<TSchema> | TOptional<TSchema> | TReadonly<TSchema>
 
 // ------------------------------------------------------------------------
 // Schema: Core
 // ------------------------------------------------------------------------
 
 export const UnionKind     = Symbol('UnionKind')
-export const IntersectKind = Symbol('IntersectKind')
 export const TupleKind     = Symbol('TupleKind')
 export const ObjectKind    = Symbol('ObjectKind')
 export const DictKind      = Symbol('DictKind')
@@ -104,22 +103,22 @@ export type DictOptions = {
 export type TEnumType = Record<string, string | number>
 export type TKey      = string | number
 export type TValue    = string | number | boolean
-export type TIntersect<T extends TSchema[]> = { kind: typeof IntersectKind, allOf: [...T] } & CustomOptions
-export type TUnion<T extends TSchema[]>     = { kind: typeof UnionKind, anyOf: [...T] } & CustomOptions
-export type TTuple<T extends TSchema[]>     = { kind: typeof TupleKind, type: 'array', items: [...T], additionalItems: false, minItems: number, maxItems: number } & CustomOptions
-export type TProperties                     = { [key: string]: TSchema }
-export type TObject<T extends TProperties>  = { kind: typeof ObjectKind, type: 'object', properties: T, required?: string[] } & CustomOptions
-export type TDict<T extends TSchema>        = { kind: typeof DictKind, type: 'object', additionalProperties: T } & DictOptions
-export type TArray<T extends TSchema>       = { kind: typeof ArrayKind, type: 'array', items: T } & ArrayOptions
-export type TLiteral<T extends TValue>      = { kind: typeof LiteralKind, type: 'string' | 'number' | 'boolean', enum: [T] } & CustomOptions
-export type TEnum<T extends TKey>           = { kind: typeof EnumKind, enum: T[] } & CustomOptions
-export type TString                         = { kind: typeof StringKind, type: 'string' } & StringOptions<string>
-export type TNumber                         = { kind: typeof NumberKind, type: 'number' } & NumberOptions
-export type TInteger                        = { kind: typeof IntegerKind, type: 'integer' } & NumberOptions
-export type TBoolean                        = { kind: typeof BooleanKind, type: 'boolean' } & CustomOptions
-export type TNull                           = { kind: typeof NullKind, type: 'null' } & CustomOptions
-export type TUnknown                        = { kind: typeof UnknownKind } & CustomOptions
-export type TAny                            = { kind: typeof AnyKind } & CustomOptions
+
+export type TTuple     <T extends TSchema[]>   = { kind: typeof TupleKind,   type: 'array', items: [...T], additionalItems: false, minItems: number, maxItems: number } & CustomOptions
+export type TProperties                        = { [key: string]: TSchema }
+export type TObject    <T extends TProperties> = { kind: typeof ObjectKind, type: 'object', additionalProperties: false, properties: T, required?: string[] } & CustomOptions
+export type TUnion     <T extends TSchema[]>   = { kind: typeof UnionKind, anyOf: [...T] } & CustomOptions
+export type TDict      <T extends TSchema>     = { kind: typeof DictKind, type: 'object', additionalProperties: T } & DictOptions
+export type TArray     <T extends TSchema>     = { kind: typeof ArrayKind, type: 'array', items: T } & ArrayOptions
+export type TLiteral   <T extends TValue>      = { kind: typeof LiteralKind, type: 'string' | 'number' | 'boolean', enum: [T] } & CustomOptions
+export type TEnum      <T extends TKey>        = { kind: typeof EnumKind, enum: T[] } & CustomOptions
+export type TString                            = { kind: typeof StringKind, type: 'string' } & StringOptions<string>
+export type TNumber                            = { kind: typeof NumberKind, type: 'number' } & NumberOptions
+export type TInteger                           = { kind: typeof IntegerKind, type: 'integer' } & NumberOptions
+export type TBoolean                           = { kind: typeof BooleanKind, type: 'boolean' } & CustomOptions
+export type TNull                              = { kind: typeof NullKind, type: 'null' } & CustomOptions
+export type TUnknown                           = { kind: typeof UnknownKind } & CustomOptions
+export type TAny                               = { kind: typeof AnyKind } & CustomOptions
 
 // ------------------------------------------------------------------------
 // Schema: Extended
@@ -131,8 +130,8 @@ export const PromiseKind     = Symbol('PromiseKind')
 export const UndefinedKind   = Symbol('UndefinedKind')
 export const VoidKind        = Symbol('VoidKind')
 export type TConstructor <T extends TSchema[], U extends TSchema> = { kind: typeof ConstructorKind, type: 'constructor', arguments: readonly [...T], returns: U } & CustomOptions
-export type TFunction    <T extends TSchema[], U extends TSchema> = { kind: typeof FunctionKind, type: 'function', arguments: readonly [...T], returns: U } & CustomOptions
-export type TPromise     <T extends TSchema>                      = { kind: typeof PromiseKind, type: 'promise', item: T } & CustomOptions
+export type TFunction    <T extends TSchema[], U extends TSchema> = { kind: typeof FunctionKind,    type: 'function', arguments: readonly [...T], returns: U } & CustomOptions
+export type TPromise     <T extends TSchema>                      = { kind: typeof PromiseKind,     type: 'promise', item: T } & CustomOptions
 export type TUndefined      = { kind: typeof UndefinedKind, type: 'undefined' } & CustomOptions
 export type TVoid           = { kind: typeof VoidKind, type: 'void' } & CustomOptions
 
@@ -141,7 +140,6 @@ export type TVoid           = { kind: typeof VoidKind, type: 'void' } & CustomOp
 // ------------------------------------------------------------------------
 
 export type TSchema =
-    | TIntersect<any>
     | TUnion<any>
     | TTuple<any>
     | TObject<any>
@@ -185,7 +183,9 @@ export type TPartial<T extends TProperties> = {
 // Static Inference
 // ------------------------------------------------------------------------
 
-export type UnionToIntersect<U>                                  = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+export type UnionToIntersect<U>     = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+export type IntersectObjectArray<T> = T extends Array<TObject<infer U>> ? UnionToIntersect<U> : TProperties
+
 export type PropertyKeys                 <T extends TProperties> = keyof T
 export type ReadonlyOptionalPropertyKeys <T extends TProperties> = { [K in keyof T]: T[K] extends TReadonlyOptional<infer U> ? K : never }[keyof T]
 export type ReadonlyPropertyKeys         <T extends TProperties> = { [K in keyof T]: T[K] extends TReadonly<infer U> ? K : never }[keyof T]
@@ -195,9 +195,9 @@ export type StaticProperties<T extends TProperties> =
     { readonly [K in ReadonlyOptionalPropertyKeys<T>]?: Static<T[K]> } &
     { readonly [K in ReadonlyPropertyKeys<T>]: Static<T[K]>          } &
     {          [K in OptionalPropertyKeys<T>]?: Static<T[K]>         } &
-    {          [K in RequiredPropertyKeys<T>]: Static<T[K]>                  }
+    {          [K in RequiredPropertyKeys<T>]: Static<T[K]>          }
 
-export type StaticIntersect   <T extends readonly TSchema[]> = UnionToIntersect<StaticUnion<T>>
+export type StaticIntersect   <T extends TProperties>        = StaticProperties<T>
 export type StaticUnion       <T extends readonly TSchema[]> = { [K in keyof T]: Static<T[K]> }[number]
 export type StaticTuple       <T extends readonly TSchema[]> = { [K in keyof T]: Static<T[K]> }
 export type StaticObject      <T extends TProperties>        = StaticProperties<T>
@@ -210,7 +210,6 @@ export type StaticFunction    <T extends readonly TSchema[], U extends TSchema> 
 export type StaticPromise     <T extends TSchema>            = Promise<Static<T>>
 
 export type Static<T> =
-    T extends TIntersect<infer U>            ? StaticIntersect<U>      :
     T extends TUnion<infer U>                ? StaticUnion<U>          :
     T extends TTuple<infer U>                ? StaticTuple<U>          :
     T extends TObject<infer U>               ? StaticObject<U>         :
@@ -305,8 +304,8 @@ export class TypeBuilder {
         const required = (required_names.length > 0) ? required_names : undefined
         const additionalProperties = false
         return (required) ? 
-            { ...options, kind: ObjectKind, type: 'object', properties, required, additionalProperties } : 
-            { ...options, kind: ObjectKind, type: 'object', properties, additionalProperties }
+            { ...options, kind: ObjectKind, type: 'object', additionalProperties, properties, required } : 
+            { ...options, kind: ObjectKind, type: 'object', additionalProperties, properties }
     }
 
     /** `STANDARD` Creates a `{ [key: string]: T }` schema. */
@@ -398,61 +397,55 @@ export class TypeBuilder {
         return { ...options, type: 'void', kind: VoidKind }
     }
 
-    /** `EXPERIMENTAL` Omits the `kind` and `modifier` properties from the given schema. */
-    public Strict<T extends TSchema>(schema: T): T {
-        return JSON.parse(JSON.stringify(schema)) as T
-    }
-
-    /** `STANDARD` Creates an Intersect schema. */
-    public Intersect<T extends TObject<TProperties>[]>(items: [...T], options: CustomOptions = {}): TIntersect<T> {
-        const properties           = items.reduce((acc, object) => ({ ...acc, ...object['properties'] }), {} as TProperties)
-        const required             = items.reduce((acc, object) => object['required'] ? [ ...acc, ...object['required'] ] : acc, [] as string[])
-        const type                 = 'object'
-        const additionalProperties = false
-        return { ...options, type, properties, required, additionalProperties } as any as TIntersect<T>
-        // return { ...options, kind: IntersectKind, allOf: items }
-    }
-
     /** `STANDARD` Creates a Union schema. */
     public Union<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TUnion<T> {
         return { ...options, kind: UnionKind, anyOf: items }
     }
 
-    /** `UTILITY` Make all properties in schema object required. */
-    public Required<T extends TObject<TProperties>>(schema: T): TObject<TRequired<T['properties']>> {
-        const next = clone(schema)
+    /** `STANDARD` Creates an intersection schema of the given object schemas. */
+    public Intersect<T extends TObject<TProperties>[]>(items: [...T], options: CustomOptions = {}): TObject<IntersectObjectArray<T>> {
+        const type                 = 'object'
+        const additionalProperties = false
+        const properties           = items.reduce((acc, object) => ({ ...acc, ...object['properties'] }), {} as IntersectObjectArray<T>)
+        const required             = items.reduce((acc, object) => object['required'] ? [ ...acc, ...object['required'] ] : acc, [] as string[])
+        return { ...options, type, kind: ObjectKind, additionalProperties, properties, required }
+    }
+
+    /** `STANDARD` Make all properties in schema object required. */
+    public Required<T extends TObject<TProperties>>(schema: T, options: CustomOptions = {}): TObject<TRequired<T['properties']>> {
+        const next = { ...options, ...clone(schema) }
         next.required = Object.keys(next.properties)
         for(const key of Object.keys(next.properties)) {
             const property = next.properties[key]
             switch(property.modifier) {
                 case ReadonlyOptionalModifier: property.modifier = ReadonlyModifier; break;
-                case ReadonlyModifier:         property.modifier = ReadonlyModifier; break;
-                case OptionalModifier:         delete property.modifier;             break;
-                default:                       delete property.modifier;             break;
+                case ReadonlyModifier: property.modifier = ReadonlyModifier; break;
+                case OptionalModifier: delete property.modifier; break;
+                default: delete property.modifier; break;
             }
         }
         return next
     }
 
-    /** `UTILITY`  Make all properties in schema object optional. */
-    public Partial<T extends TObject<TProperties>>(schema: T): TObject<TPartial<T['properties']>> {
-        const next = clone(schema)
+    /** `STANDARD`  Make all properties in schema object optional. */
+    public Partial<T extends TObject<TProperties>>(schema: T, options: CustomOptions = {}): TObject<TPartial<T['properties']>> {
+        const next = { ...options, ...clone(schema) }
         delete next.required
         for(const key of Object.keys(next.properties)) {
             const property = next.properties[key]
             switch(property.modifier) {
                 case ReadonlyOptionalModifier: property.modifier = ReadonlyOptionalModifier; break;
-                case ReadonlyModifier:         property.modifier = ReadonlyOptionalModifier; break;
-                case OptionalModifier:         property.modifier = OptionalModifier;         break;
-                default:                       property.modifier = OptionalModifier;         break;
+                case ReadonlyModifier: property.modifier = ReadonlyOptionalModifier; break;
+                case OptionalModifier: property.modifier = OptionalModifier; break;
+                default: property.modifier = OptionalModifier; break;
             }
         }
         return next
     }
 
-    /** `UTILITY` Picks property keys from the given object schema. */
-    public Pick<T extends TObject<TProperties>, K extends PropertyKeys<T['properties']>[]>(schema: T, keys: [...K]): TObject<Pick<T['properties'], K[number]>> {
-        const next = clone(schema)
+    /** `STANDARD` Picks property keys from the given object schema. */
+    public Pick<T extends TObject<TProperties>, K extends PropertyKeys<T['properties']>[]>(schema: T, keys: [...K], options: CustomOptions = {}): TObject<Pick<T['properties'], K[number]>> {
+        const next = { ...options, ...clone(schema) }
         next.required = next.required ? next.required.filter((key: string) => keys.includes(key)) : undefined
         for(const key of Object.keys(next.properties)) {
             if(!keys.includes(key)) delete next.properties[key]
@@ -460,14 +453,19 @@ export class TypeBuilder {
         return next
     }
     
-    /** `UTILITY` Omits property keys from the given object schema. */
-    public Omit<T extends TObject<TProperties>, K extends PropertyKeys<T['properties']>[]>(schema: T, keys: [...K]): TObject<Omit<T['properties'], K[number]>> {
-        const next = clone(schema)
+    /** `STANDARD` Omits property keys from the given object schema. */
+    public Omit<T extends TObject<TProperties>, K extends PropertyKeys<T['properties']>[]>(schema: T, keys: [...K], options: CustomOptions = {}): TObject<Omit<T['properties'], K[number]>> {
+        const next = { ...options, ...clone(schema) }
         next.required = next.required ? next.required.filter((key: string) => !keys.includes(key)) : undefined
         for(const key of Object.keys(next.properties)) {
             if(keys.includes(key)) delete next.properties[key]
         }
         return next
+    }
+
+    /** `EXPERIMENTAL` Omits the `kind` and `modifier` properties from the given schema. */
+    public Strict<T extends TSchema>(schema: T): T {
+        return JSON.parse(JSON.stringify(schema)) as T
     }
 }
 

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -284,16 +284,6 @@ export class TypeBuilder {
         return { ...item, modifier: OptionalModifier }
     }
 
-    /** `STANDARD` Creates an Intersect schema. */
-    public Intersect<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TIntersect<T> {
-        return { ...options, kind: IntersectKind, allOf: items }
-    }
-
-    /** `STANDARD` Creates a Union schema. */
-    public Union<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TUnion<T> {
-        return { ...options, kind: UnionKind, anyOf: items }
-    }
-
     /** `STANDARD` Creates a Tuple schema. */
     public Tuple<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TTuple<T> {
         const additionalItems = false
@@ -315,8 +305,8 @@ export class TypeBuilder {
         const required = (required_names.length > 0) ? required_names : undefined
         const additionalProperties = false
         return (required) ? 
-            { ...options, kind: ObjectKind, type: 'object', properties, required } : 
-            { ...options, kind: ObjectKind, type: 'object', properties }
+            { ...options, kind: ObjectKind, type: 'object', properties, required, additionalProperties } : 
+            { ...options, kind: ObjectKind, type: 'object', properties, additionalProperties }
     }
 
     /** `STANDARD` Creates a `{ [key: string]: T }` schema. */
@@ -411,6 +401,21 @@ export class TypeBuilder {
     /** `EXPERIMENTAL` Omits the `kind` and `modifier` properties from the given schema. */
     public Strict<T extends TSchema>(schema: T): T {
         return JSON.parse(JSON.stringify(schema)) as T
+    }
+
+    /** `STANDARD` Creates an Intersect schema. */
+    public Intersect<T extends TObject<TProperties>[]>(items: [...T], options: CustomOptions = {}): TIntersect<T> {
+        const properties           = items.reduce((acc, object) => ({ ...acc, ...object['properties'] }), {} as TProperties)
+        const required             = items.reduce((acc, object) => object['required'] ? [ ...acc, ...object['required'] ] : acc, [] as string[])
+        const type                 = 'object'
+        const additionalProperties = false
+        return { ...options, type, properties, required, additionalProperties } as any as TIntersect<T>
+        // return { ...options, kind: IntersectKind, allOf: items }
+    }
+
+    /** `STANDARD` Creates a Union schema. */
+    public Union<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TUnion<T> {
+        return { ...options, kind: UnionKind, anyOf: items }
     }
 
     /** `UTILITY` Make all properties in schema object required. */

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -372,31 +372,6 @@ export class TypeBuilder {
         return { ...options, kind: AnyKind }
     }
 
-    /** `EXTENDED` Creates a `constructor` schema. */
-    public Constructor<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TConstructor<T, U> {
-        return { ...options, kind: ConstructorKind, type: 'constructor', arguments: args, returns };
-    }
-
-    /** `EXTENDED` Creates a `function` schema. */
-    public Function<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TFunction<T, U> {
-        return { ...options, kind: FunctionKind, type: 'function', arguments: args, returns };
-    }
-
-    /** `EXTENDED` Creates a `Promise<T>` schema. */
-    public Promise<T extends TSchema>(item: T, options: CustomOptions = {}): TPromise<T> {
-        return { ...options, type: 'promise', kind: PromiseKind, item }
-    }
-
-    /** `EXTENDED` Creates a `undefined` schema. */
-    public Undefined(options: CustomOptions = {}): TUndefined {
-        return { ...options, type: 'undefined', kind: UndefinedKind }
-    }
-
-    /** `EXTENDED` Creates a `void` schema. */
-    public Void(options: CustomOptions = {}): TVoid {
-        return { ...options, type: 'void', kind: VoidKind }
-    }
-
     /** `STANDARD` Creates a Union schema. */
     public Union<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TUnion<T> {
         return { ...options, kind: UnionKind, anyOf: items }
@@ -463,9 +438,34 @@ export class TypeBuilder {
         return next
     }
 
-    /** `EXPERIMENTAL` Omits the `kind` and `modifier` properties from the given schema. */
+    /** `STANDARD` Omits the `kind` and `modifier` properties from the given schema. */
     public Strict<T extends TSchema>(schema: T): T {
         return JSON.parse(JSON.stringify(schema)) as T
+    }
+
+    /** `EXTENDED` Creates a `constructor` schema. */
+    public Constructor<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TConstructor<T, U> {
+        return { ...options, kind: ConstructorKind, type: 'constructor', arguments: args, returns };
+    }
+
+    /** `EXTENDED` Creates a `function` schema. */
+    public Function<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TFunction<T, U> {
+        return { ...options, kind: FunctionKind, type: 'function', arguments: args, returns };
+    }
+
+    /** `EXTENDED` Creates a `Promise<T>` schema. */
+    public Promise<T extends TSchema>(item: T, options: CustomOptions = {}): TPromise<T> {
+        return { ...options, type: 'promise', kind: PromiseKind, item }
+    }
+
+    /** `EXTENDED` Creates a `undefined` schema. */
+    public Undefined(options: CustomOptions = {}): TUndefined {
+        return { ...options, type: 'undefined', kind: UndefinedKind }
+    }
+
+    /** `EXTENDED` Creates a `void` schema. */
+    public Void(options: CustomOptions = {}): TVoid {
+        return { ...options, type: 'void', kind: VoidKind }
     }
 }
 


### PR DESCRIPTION
This PR makes `TObject<TProperties>` use `additionalProperties: false` by default. Additionally, this PR updates the implementation for `Type.Intersect(..)`, removing the `TIntersect` type and returning a `TObject<IntersectObjectArray<T>>` (inline with `TRequired` and `TPartial` that have no specific type representations) and merges the intersecting objects manually (instead of `allOf`).

Had considered pursuing the `allOf` + `unevaluatedProperties` which would have been inline with the previous implementation, however this is a opt in plugin for AJV and probably not well supported.