### PR TITLE
fix clone when options have a null value

### DIFF
--- a/spec/schema/omit.ts
+++ b/spec/schema/omit.ts
@@ -11,4 +11,14 @@ describe('Omit', () => {
       const Vector2 = Type.Omit(Vector3, ['z'])
       ok(Vector2, { x: 1, y: 1 })
     })
+  
+    it('User', () => {
+      const User = Type.Object({
+        id: Type.Readonly(Type.Integer()),
+        name: Type.String({ default: null }),
+        email: Type.String({ default: undefined }),
+      });
+      const PartialUser = Type.Omit(User, ['id'])
+      ok(PartialUser, { name: 'user', email: 'user@example.com' })
+    })
 })

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -241,12 +241,12 @@ export type Static<T> =
 // ------------------------------------------------------------------------
 
 function clone(object: any): any {
-    if(typeof object === 'object' && !Array.isArray(object)) {
+    if(typeof object === 'object' && object !== null && !Array.isArray(object)) {
         return Object.keys(object).reduce((acc, key) => {
             acc[key] = clone(object[key])
             return acc
         }, {} as any)
-    } else if(typeof object === 'object' && Array.isArray(object)) {
+    } else if(typeof object === 'object' && object !== null && Array.isArray(object)) {
         return object.map((item: any) => clone(item))
     } else {
         return object


### PR DESCRIPTION
If you use `null` in the options, and any method which calls `clone` (Required, Partial, Pick, Omit), you might get an error like this:
```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at clone (target/spec/index.js:41:31)
    at /Users/dwickern/code/typebox/target/spec/index.js:42:32
    at Array.reduce (<anonymous>)
    at clone (target/spec/index.js:41:44)
    at /Users/dwickern/code/typebox/target/spec/index.js:42:32
    at Array.reduce (<anonymous>)
    at clone (target/spec/index.js:41:44)
    at /Users/dwickern/code/typebox/target/spec/index.js:42:32
    at Array.reduce (<anonymous>)
    at clone (target/spec/index.js:41:44)
    at TypeBuilder.Omit (target/spec/index.js:190:47)
    at Context.<anonymous> (target/spec/index.js:743:53)
    at processImmediate (internal/timers.js:461:21)
```

This happens because `typeof null === 'object'`.