### PR TITLE
Add type keyword for Enum

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -228,9 +228,9 @@ The following table outlines the TypeBox mappings between TypeScript and JSON sc
 │   	                         │                             │                                │
 ├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
 │ enum Foo {                     │ enum Foo {                  │ const T = {                    │
-│   A,                           │   A,                        │    enum: [0, 1]                │
-│   B                            │   B                         │ }                              │
-│ }                              │ }                           │                                │
+│   A,                           │   A,                        │    enum: [0, 1],               │
+│   B                            │   B                         │    type: 'number'              │
+│ }                              │ }                           │ }                              │
 │                                │                             │                                │
 │ type T = Type.Enum(Foo)        │ type T = Foo                │                                │
 │                                │                             │                                │

--- a/spec/schema/enum.ts
+++ b/spec/schema/enum.ts
@@ -1,5 +1,6 @@
 import { Type } from '@sinclair/typebox'
 import { ok, fail } from './validate'
+import * as assert from 'assert'
 
 describe('Enum<T>', () => {
   it('number enum', () => {
@@ -12,6 +13,8 @@ describe('Enum<T>', () => {
     fail(T, 'Foo')
     ok(T, 0)
     ok(T, 1)
+      
+    assert.strictEqual(T.type, 'number')
   })
 
   it('string enum', () => {
@@ -24,6 +27,8 @@ describe('Enum<T>', () => {
     fail(T, 'Foo')
     ok(T, 'foo')
     ok(T, 'bar')
+      
+    assert.strictEqual(T.type, 'string')
   })
 
   it('mixed string|number enum', () => {
@@ -37,5 +42,13 @@ describe('Enum<T>', () => {
     fail(T, 1)
     ok(T, 0)
     ok(T, 'bar')
+      
+    assert.deepStrictEqual(T.type, ['string', 'number'])
+  })
+
+  it('empty enum', () => {
+    enum EmptyEnum {}
+    const T = Type.Enum(EmptyEnum)
+    assert.strictEqual(T.type, undefined)
   })
 })

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -113,7 +113,7 @@ export type TKeyOf     <T extends TKey[]>      = { kind: typeof KeyOfKind, enum:
 export type TDict      <T extends TSchema>     = { kind: typeof DictKind, type: 'object', additionalProperties: T } & DictOptions
 export type TArray     <T extends TSchema>     = { kind: typeof ArrayKind, type: 'array', items: T } & ArrayOptions
 export type TLiteral   <T extends TValue>      = { kind: typeof LiteralKind, const: T } & CustomOptions
-export type TEnum      <T extends TKey>        = { kind: typeof EnumKind, enum: T[] } & CustomOptions
+export type TEnum      <T extends TKey>        = { kind: typeof EnumKind, type?: 'string' | 'number' | ['string', 'number'], enum: T[] } & CustomOptions
 export type TString                            = { kind: typeof StringKind, type: 'string' } & StringOptions<string>
 export type TNumber                            = { kind: typeof NumberKind, type: 'number' } & NumberOptions
 export type TInteger                           = { kind: typeof IntegerKind, type: 'integer' } & NumberOptions
@@ -313,7 +313,14 @@ export class TypeBuilder {
     /** `STANDARD` Creates an `Enum<T>` schema from a TypeScript `enum` definition. */
     public Enum<T extends TEnumType>(item: T, options: CustomOptions = {}): TEnum<T[keyof T]> {
         const values = Object.keys(item).filter(key => isNaN(key as any)).map(key => item[key]) as T[keyof T][]
-        return { ...options, kind: EnumKind, enum: values }
+        if (values.length === 0) {
+            return { ...options, kind: EnumKind, enum: values }
+        }
+        const type = typeof values[0] as 'string' | 'number'
+        if (values.some(value => typeof value !== type)) {
+            return { ...options, kind: EnumKind, type: ['string', 'number'], enum: values }
+        }
+        return { ...options, kind: EnumKind, type, enum: values }
     }
 
     /** `STANDARD` Creates a literal schema. Supports `string | number | boolean` values. */


### PR DESCRIPTION
Derive the `"type"` keyword based on the enum values (either strings, numbers or mixed).

Empty enums are not particularly advisable but it is allowed by the [spec](https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.1.2) and included for completeness.