### PR TITLE
override existing options from a specialized schema

### DIFF
--- a/spec/schema/omit.ts
+++ b/spec/schema/omit.ts
@@ -1,5 +1,6 @@
 import { Type } from '@sinclair/typebox'
 import { ok, fail } from './validate'
+import { strictEqual } from 'assert'
 
 describe('Omit', () => {
     it('Vector3 to Vector2', () => {
@@ -20,5 +21,16 @@ describe('Omit', () => {
       });
       const PartialUser = Type.Omit(User, ['id'])
       ok(PartialUser, { name: 'user', email: 'user@example.com' })
+    })
+
+    it('Options', () => {
+        const Vector3 = Type.Object({
+            x: Type.Number(),
+            y: Type.Number(),
+            z: Type.Number()
+        }, { title: 'Vector3' })
+        const Vector2 = Type.Omit(Vector3, ['z'], { title: 'Vector2' })
+        strictEqual(Vector3.title, 'Vector3')
+        strictEqual(Vector2.title, 'Vector2')
     })
 })

--- a/spec/schema/partial.ts
+++ b/spec/schema/partial.ts
@@ -31,4 +31,15 @@ describe('Partial', () => {
         strictEqual(U.properties.z.modifier, OptionalModifier)
         strictEqual(U.properties.w.modifier, OptionalModifier)
     })
+
+    it('Options', () => {
+        const Required = Type.Object({
+            x: Type.Number(),
+            y: Type.Number(),
+            z: Type.Number()
+        }, { title: 'Required' })
+        const Partial = Type.Partial(Required, { title: 'Partial' })
+        strictEqual(Required.title, 'Required')
+        strictEqual(Partial.title, 'Partial')
+    })
 })

--- a/spec/schema/pick.ts
+++ b/spec/schema/pick.ts
@@ -1,5 +1,6 @@
 import { Type } from '@sinclair/typebox'
 import { ok, fail } from './validate'
+import { strictEqual } from 'assert'
 
 describe('Pick', () => {
     it('Vector3 to Vector2', () => {
@@ -10,5 +11,16 @@ describe('Pick', () => {
       })
       const Vector2 = Type.Pick(Vector3, ['x', 'y'])
       ok(Vector2, { x: 1, y: 1 })
+    })
+
+    it('Options', () => {
+        const Vector3 = Type.Object({
+            x: Type.Number(),
+            y: Type.Number(),
+            z: Type.Number()
+        }, { title: 'Vector3' })
+        const Vector2 = Type.Pick(Vector3, ['x', 'y'], { title: 'Vector2' })
+        strictEqual(Vector3.title, 'Vector3')
+        strictEqual(Vector2.title, 'Vector2')
     })
 })

--- a/spec/schema/required.ts
+++ b/spec/schema/required.ts
@@ -29,4 +29,15 @@ describe('Required', () => {
         strictEqual(U.properties.z.modifier, undefined)
         strictEqual(U.properties.w.modifier, undefined)
     })
+
+    it('Options', () => {
+        const Partial = Type.Object({
+            x: Type.Optional(Type.Number()),
+            y: Type.Optional(Type.Number()),
+            z: Type.Optional(Type.Number())
+        }, { title: 'Partial' })
+        const Required = Type.Required(Partial, { title: 'Required' })
+        strictEqual(Partial.title, 'Partial')
+        strictEqual(Required.title, 'Required')
+    })
 })

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -399,7 +399,7 @@ export class TypeBuilder {
 
     /** `STANDARD` Make all properties in schema object required. */
     public Required<T extends TObject<TProperties>>(schema: T, options: CustomOptions = {}): TObject<TRequired<T['properties']>> {
-        const next = { ...options, ...clone(schema) }
+        const next = { ...clone(schema), ...options }
         next.required = Object.keys(next.properties)
         for(const key of Object.keys(next.properties)) {
             const property = next.properties[key]
@@ -415,7 +415,7 @@ export class TypeBuilder {
 
     /** `STANDARD`  Make all properties in schema object optional. */
     public Partial<T extends TObject<TProperties>>(schema: T, options: CustomOptions = {}): TObject<TPartial<T['properties']>> {
-        const next = { ...options, ...clone(schema) }
+        const next = { ...clone(schema), ...options }
         delete next.required
         for(const key of Object.keys(next.properties)) {
             const property = next.properties[key]
@@ -431,7 +431,7 @@ export class TypeBuilder {
 
     /** `STANDARD` Picks property keys from the given object schema. */
     public Pick<T extends TObject<TProperties>, K extends PropertyKeys<T['properties']>[]>(schema: T, keys: [...K], options: CustomOptions = {}): TObject<Pick<T['properties'], K[number]>> {
-        const next = { ...options, ...clone(schema) }
+        const next = { ...clone(schema), ...options }
         next.required = next.required ? next.required.filter((key: string) => keys.includes(key)) : undefined
         for(const key of Object.keys(next.properties)) {
             if(!keys.includes(key)) delete next.properties[key]
@@ -441,7 +441,7 @@ export class TypeBuilder {
     
     /** `STANDARD` Omits property keys from the given object schema. */
     public Omit<T extends TObject<TProperties>, K extends PropertyKeys<T['properties']>[]>(schema: T, keys: [...K], options: CustomOptions = {}): TObject<Omit<T['properties'], K[number]>> {
-        const next = { ...options, ...clone(schema) }
+        const next = { ...clone(schema), ...options }
         next.required = next.required ? next.required.filter((key: string) => !keys.includes(key)) : undefined
         for(const key of Object.keys(next.properties)) {
             if(keys.includes(key)) delete next.properties[key]


### PR DESCRIPTION
Take the options passed to Omit/Partial/Pick/Required over the options to the original schema.

Fixes this situation:
```ts
const Vector3 = Type.Object({
    x: Type.Number(),
    y: Type.Number(),
    z: Type.Number()
}, {
  title: 'Vector3'
})

const Vector2 = Type.Pick(Vector3, ['x', 'y'], {
  title: 'Vector2'
})

Vector2.title // "Vector3"
```