### PR TITLE
doc: Fix incorrect typescript example for Dict type

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -191,8 +191,8 @@ The following table outlines the TypeBox mappings between TypeScript and JSON sc
 │   	                         │                             │                                │
 ├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
 │ const T = Type.Dict(           │ type T = {                  │ const T = {                    │
-│    Type.Number()               │      [key: string]          │    type: 'object'              │
-│ )                              │ } : number                  │    additionalProperties: {     │
+│    Type.Number()               │    [key: string] : number   │    type: 'object'              │
+│ )                              │ }                           │    additionalProperties: {     │
 │   	                         │                             │      type: 'number'            │
 │   	                         │                             │    }                           │
 │   	                         │                             │ }                              │


### PR DESCRIPTION
I was looking at the docs on the `README.md` file and found that the typescript type for `Type.Dict` was incorrect. I have amended this.

Also, an alternative way of representing this Dict type would be to do the following:

```ts
type T = Record<string, number>
```

Should we also add this example into the same cell?