### PR TITLE
Schema Referencing

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,18 +1,31 @@
 import { Type, Static, TObject, TProperties } from '@sinclair/typebox'
-
+import { ok } from '../spec/schema/validate'
 // -----------------------------------------------
 // npm start to run example
 // -----------------------------------------------
 
-type VectorA = Static<typeof VectorA>
-const VectorA = Type.Object({
-    x: Type.Number(),
-    y: Type.Number(),
-})
-const VectorB = Type.Object({
-    x: Type.Number(),
-    y: Type.Number(),
-})
-const A = Type.Intersect([VectorA, VectorB])
-console.log(A)
+const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
+const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
+const Vector2 = Type.Object({ x: Type.Number(), y: Type.Number() })
 
+const Box = Type.Box({ vector2: Vector2, Vector3, Vector4 })
+
+const Vertex = Type.Object({
+    position: Type.Ref(Box, 'Vector4'),
+    normal:   Type.Ref(Box, 'Vector3'),
+    uv:       Type.Ref(Box, 'vector2'),
+    time:     Type.Number()
+})
+
+console.log(Vertex)
+
+const S = Type.Omit(Vertex, ['position'])
+
+console.log(S)
+
+ok(Vertex, {
+    position: { x: 1, y: 1, z: 1, w: 1},
+    normal: { x: 1, y: 1, z: 1},
+    uv: { x: 1, y: 1, z: 1},
+    time: 1
+})

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,31 +1,52 @@
 import { Type, Static, TObject, TProperties } from '@sinclair/typebox'
-import { ok } from '../spec/schema/validate'
+import addFormats from 'ajv-formats'
+import Ajv        from 'ajv'
+
+const ajv = addFormats(new Ajv(), [
+  'date-time', 
+  'time', 
+  'date', 
+  'email',  
+  'hostname', 
+  'ipv4', 
+  'ipv6', 
+  'uri', 
+  'uri-reference', 
+  'uuid',
+  'uri-template', 
+  'json-pointer', 
+  'relative-json-pointer', 
+  'regex'
+])
+.addKeyword('kind')
+.addKeyword('modifier')
+
 // -----------------------------------------------
 // npm start to run example
 // -----------------------------------------------
 
-const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
-const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
+// Related Types
 const Vector2 = Type.Object({ x: Type.Number(), y: Type.Number() })
+const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
+const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
+const Math3D  = Type.Box('math3d', { Vector2, Vector3, Vector4 })
 
-const Box = Type.Box({ vector2: Vector2, Vector3, Vector4 })
-
+// Dependent Type
 const Vertex = Type.Object({
-    position: Type.Ref(Box, 'Vector4'),
-    normal:   Type.Ref(Box, 'Vector3'),
-    uv:       Type.Ref(Box, 'vector2'),
-    time:     Type.Number()
+    position:  Type.Ref(Math3D, 'Vector4'),
+    normal:    Type.Ref(Math3D, 'Vector3'),
+    uv:        Type.Ref(Math3D, 'Vector2'),
 })
 
-console.log(Vertex)
 
-const S = Type.Omit(Vertex, ['position'])
+console.log(JSON.stringify(Math3D, null, 2))
+console.log(JSON.stringify(Vertex, null, 2))
 
-console.log(S)
+ajv.addSchema(Math3D)
+console.log(ajv.validate(Vertex, {
+    position: {x: 1, y: 1, z: 1, w: 1},
+    normal: {x: 1, y: 1, z: 1},
+    uv: {x: 1, y: 1},
+}))
 
-ok(Vertex, {
-    position: { x: 1, y: 1, z: 1, w: 1},
-    normal: { x: 1, y: 1, z: 1},
-    uv: { x: 1, y: 1, z: 1},
-    time: 1
-})
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.16.7",
+  "version": "0.17.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.16.7",
+      "version": "0.17.1",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "json-schema",

--- a/readme.md
+++ b/readme.md
@@ -409,10 +409,9 @@ const U = Type.Strict(T)                // const U = {
 
 ### Reference Types
 
-It's common to want to group related schemas together under a common shared namespace. This is usually handled via `$id` and `$ref` in JSON schema. TypeBox provides rudimentary support for this using the `Type.Box(...)` and `Type.Ref(...)` methods. The `Type.Box(...)` method allows one to register a collection of related schemas under a common `$id` or namespace, and `Type.Ref(...)` allows for referencing into the box.
+It's common to want to group related schemas together under a common shared namespace. This is typically handled via `$id` and `$ref` properties in JSON schema. TypeBox provides rudimentary support for this using the `Type.Box(...)` and `Type.Ref(...)` methods. The `Type.Box(...)` method allows one to register a collection of related schemas under a common `$id` or namespace, and `Type.Ref(...)` allows for referencing into the box. The following demonstrates the usage for a set of `Math3D` types.
 
 ```typescript
-
 const Vector2 = Type.Object({ x: Type.Number(), y: Type.Number() })
 const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
 const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
@@ -460,7 +459,7 @@ const Math3D = {
   }
 }
 ```
-And the `Vertex` type is expressed as.
+And the `Vertex` is expressed as.
 ```typescript
 const Vertex = {
   type: "object",

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ License MIT
 - [Modifiers](#Modifiers)
 - [Options](#Options)
 - [Strict](#Strict)
-- [Referencing](#Referencing)
+- [Reference Types](#Reference-Types)
 - [Extended Types](#Extended-Types)
 - [Interfaces](#Interfaces)
 - [Validation](#Validation)
@@ -405,27 +405,27 @@ const U = Type.Strict(T)                // const U = {
                                         //     } 
                                         // }
 ```
-<a name="Referencing"></a>
+<a name="Reference-Types"></a>
 
-### Referencing
+### Reference Types
 
-When working with JSON schema, its common to want to group related schemas together under a common namespace. This is usually handled via JSON schema `$id` and `$ref`. TypeBox provides rudimentary support for this with `Type.Box(...)` and `Type.Ref(...)` methods. The `Type.Box(...)` method allows one to register a collection of related schemas under a common `$id` or namespace, and `Type.Ref(...)` allows for referencing into the box.
+It's common to want to group related schemas together under a common shared namespace. This is usually handled via `$id` and `$ref` in JSON schema. TypeBox provides rudimentary support for this using the `Type.Box(...)` and `Type.Ref(...)` methods. The `Type.Box(...)` method allows one to register a collection of related schemas under a common `$id` or namespace, and `Type.Ref(...)` allows for referencing into the box.
 
 ```typescript
-// Related Math Types
+
 const Vector2 = Type.Object({ x: Type.Number(), y: Type.Number() })
 const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
 const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
+
 const Math3D  = Type.Box('math3d', { Vector2, Vector3, Vector4 })
 
-// Dependent Type
 const Vertex = Type.Object({
     position: Type.Ref(Math3D, 'Vector4'),
     normal:   Type.Ref(Math3D, 'Vector3'),
     uv:       Type.Ref(Math3D, 'Vector2'),
 })
 ```
-Where the box `Math3D` is expressed with the following schema.
+Where `Math3D` is expressed as
 ```typescript
 const Math3D = {
   $id: "math3d",
@@ -472,7 +472,7 @@ const Vertex = {
   required: ["position", "normal", "uv"]
 }
 ```
-> Note the methods `Type.Partial(...)`, `Type.Required(...)`, `Type.Pick(...)` and `Type.Omit(...)` are currently not supported for referenced types. This may change in future releases where the boxed schema is copied into the dependent schema with the appropriate schema modifications applied.
+> Note, the methods `Type.Partial(...)`, `Type.Required(...)`, `Type.Pick(...)` and `Type.Omit(...)` are currently not supported for referenced types. This may change in future releases where the referenced schema is copied into the dependent schema with the appropriate schema modifications applied. This project is open to community feedback on advancing this feature in future releases.
 
 <a name="Extended-Types"></a>
 

--- a/spec/schema/box.ts
+++ b/spec/schema/box.ts
@@ -1,0 +1,88 @@
+import { Type } from '@sinclair/typebox'
+import { createValidator } from './validate'
+
+
+describe("Box", () => {
+    it('Should validate with correct data', () => {
+        const Vector2 = Type.Object({ x: Type.Number(), y: Type.Number() })
+        const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
+        const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
+        const Math3D = Type.Box('math3d', { Vector2, Vector3, Vector4 })
+        const Vertex = Type.Object({
+            position: Type.Ref(Math3D, 'Vector4'),
+            normal: Type.Ref(Math3D, 'Vector3'),
+            uv: Type.Ref(Math3D, 'Vector2'),
+        })
+
+        const validator = createValidator().addSchema(Math3D)
+        const ok = validator.validate(Vertex, {
+            position: { x: 1, y: 1, z: 1, w: 1 },
+            normal: { x: 1, y: 1, z: 1 },
+            uv: { x: 1, y: 1 },
+        })
+
+
+
+        if (ok === false) throw Error('Expected success')
+
+    })
+    it('Should fail with missing property', () => {
+        const Vector2 = Type.Object({ x: Type.Number(), y: Type.Number() })
+        const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
+        const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
+        const Math3D = Type.Box('math3d', { Vector2, Vector3, Vector4 })
+        const Vertex = Type.Object({
+            position: Type.Ref(Math3D, 'Vector4'),
+            normal: Type.Ref(Math3D, 'Vector3'),
+            uv: Type.Ref(Math3D, 'Vector2'),
+        })
+        const validator = createValidator().addSchema(Math3D)
+        const ok = validator.validate(Vertex, {
+            position: { x: 1, y: 1, z: 1, w: 1 },
+            normal: { x: 1, y: 1, z: 1 },
+        })
+        if (ok === true) throw Error('Expected fail')
+    })
+    it('Should fail with invalid data', () => {
+        const Vector2 = Type.Object({ x: Type.Number(), y: Type.Number() })
+        const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
+        const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
+        const Math3D = Type.Box('math3d', { Vector2, Vector3, Vector4 })
+        const Vertex = Type.Object({
+            position: Type.Ref(Math3D, 'Vector4'),
+            normal: Type.Ref(Math3D, 'Vector3'),
+            uv: Type.Ref(Math3D, 'Vector2'),
+        })
+        const validator = createValidator().addSchema(Math3D)
+        const ok = validator.validate(Vertex, {
+            position: { x: 1, y: 1, z: 1, w: 1 },
+            normal: { x: 1, y: 1, z: 1 },
+            uv: { x: 1, y: 'not a number'},
+        })
+        if (ok === true) throw Error('Expected fail')
+    })
+    it('Should throw for non-registered box', () => {
+        const Vector2 = Type.Object({ x: Type.Number(), y: Type.Number() })
+        const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
+        const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
+        const Math3D = Type.Box('math3d', { Vector2, Vector3, Vector4 })
+        const Vertex = Type.Object({
+            position: Type.Ref(Math3D, 'Vector4'),
+            normal: Type.Ref(Math3D, 'Vector3'),
+            uv: Type.Ref(Math3D, 'Vector2'),
+        })
+        const validator = createValidator()
+        let did_throw = false
+        try {
+            validator.validate(Vertex, {
+                position: { x: 1, y: 1, z: 1, w: 1 },
+                normal: { x: 1, y: 1, z: 1 },
+                uv: { x: 1, y: 1},
+            })
+        } catch {
+            did_throw = true
+        }
+
+        if (did_throw === false) throw Error('Expected throw')
+    })
+})

--- a/spec/schema/index.ts
+++ b/spec/schema/index.ts
@@ -1,6 +1,7 @@
 import './any'
 import './array'
 import './boolean'
+import './box'
 import './dict'
 import './enum'
 import './intersect'

--- a/spec/schema/validate.ts
+++ b/spec/schema/validate.ts
@@ -57,3 +57,24 @@ export function fail<T extends TSchema>(type: T, data: unknown) {
     throw Error('expected fail')
   }
 }
+
+export function createValidator() {
+  return addFormats(new Ajv(), [
+    'date-time', 
+    'time', 
+    'date', 
+    'email',  
+    'hostname', 
+    'ipv4', 
+    'ipv6', 
+    'uri', 
+    'uri-reference', 
+    'uuid',
+    'uri-template', 
+    'json-pointer', 
+    'relative-json-pointer', 
+    'regex'
+  ])
+  .addKeyword('kind')
+  .addKeyword('modifier')
+}

--- a/spec/static/box.ts
+++ b/spec/static/box.ts
@@ -1,0 +1,14 @@
+import { Type, Static } from '@sinclair/typebox'
+
+// --------------------------------------------
+
+const T0 = Type.Tuple([Type.Number(), Type.Number()])
+
+const B0 = Type.Box('ns', { T0 })
+
+const R0 = Type.Ref(B0, 'T0')
+
+const F0 = (arg: Static<typeof R0>) => {}
+
+F0([1, 2])
+

--- a/spec/static/index.ts
+++ b/spec/static/index.ts
@@ -1,6 +1,7 @@
 import './any'
 import './array'
 import './boolean'
+import './box'
 import './dict'
 import './enum'
 import './intersect'


### PR DESCRIPTION
This PR adds two new functions to the TypeBox API. These are `Type.Box(...)` and `Type.Ref(...)`. These functions are used in tandem to normalize shared schemas and allow cross schema referencing using `$id` and `$ref`.

These methods are currently flagged as `EXPERIEMENTAL`, with the functionality submitted for community review.