### PR TITLE
Add "Hidden" modifier

### DIFF
--- a/spec/schema/modifier.ts
+++ b/spec/schema/modifier.ts
@@ -1,5 +1,8 @@
 import { Type, ReadonlyModifier, OptionalModifier } from '@sinclair/typebox'
+
 import * as assert from 'assert'
+
+import { expect } from 'chai';
 
 describe('Modifier', () => {
   it('Omit modifier',  () => {
@@ -7,17 +10,33 @@ describe('Modifier', () => {
     const T = Type.Object({
       a: Type.Readonly(Type.String()),
       b: Type.Optional(Type.String()),
+      c: Type.Hidden(Type.String()),
     })
     
     const S = JSON.stringify(T)
     const P = JSON.parse(S) as any
 
     // check assignment on Type
-    assert.equal(T.properties.a['modifier'], ReadonlyModifier)
-    assert.equal(T.properties.b['modifier'], OptionalModifier)
+    assert.strictEqual(T.properties.a['modifier'], ReadonlyModifier)
+    assert.strictEqual(T.properties.b['modifier'], OptionalModifier)
+
+    expect(T.required).to.be.deep.eq(['a']);
+
+    // Hidden-Modifier
+    expect('c' in T.properties).to.be.false;
     
     // check deserialized
-    assert.equal(P.properties.a['modifier'], undefined)
-    assert.equal(P.properties.b['modifier'], undefined)
-  })
+    assert.strictEqual(P.properties.a['modifier'], undefined)
+    assert.strictEqual(P.properties.b['modifier'], undefined)
+  });
+
+  it('Type.Hidden can only be used on Objects', () => 
+  {
+    const hidden = Type.Hidden(Type.Object({}));
+
+    expect(() => Type.Array(hidden)).to.throw();
+    expect(() => Type.Tuple([Type.String(), hidden])).to.throw();
+    expect(() => Type.Intersect([Type.Object({}), hidden])).to.throw();
+    expect(() => Type.Dict(hidden)).to.throw();
+  });
 })

--- a/spec/static/modifier.ts
+++ b/spec/static/modifier.ts
@@ -3,18 +3,21 @@ import { Type, Static } from '@sinclair/typebox'
 const T0 = Type.Object({
     a: Type.Optional(Type.Number()),
     b: Type.Readonly(Type.String()),
-    c: Type.ReadonlyOptional(Type.Boolean())
+    c: Type.ReadonlyOptional(Type.Boolean()),
+    d: Type.Hidden(Type.String()),
 })
 const F0 = (arg: Static<typeof T0>) => {}
 
 F0({
     b: 'hello',
-    c: false // note: can't trigger the readonly optional case.
+    c: false, // note: can't trigger the readonly optional case.
+    d: 'hidden',
 })
 
 F0({
     a: 1,
     b: 'hello',
-    c: false // note: can't trigger the readonly optional case.
+    c: false, // note: can't trigger the readonly optional case.
+    d: 'hidden'
 })
 


### PR DESCRIPTION
# TL;DR
I added a Hidden-modifier that removes object properties from the resulting schema but not from the generated types. 
# Usage
```typescript
const T = Type.Object(
{
    a: Type.Hidden(Type.String()),
});
```
Generates: 
```typescript
interface T{
    a?: string;
}
```
```typescript
const T = { 
    type: 'object',
    properties: {},
};
```
# Motivation
The primary motivation for this pr came from REST-APIs. Let's say you have a resource like this: 
```typescript
// could be a tweet or a Facebook post
const post = Type.Object(
{
    content: Type.String(),
    likes: Type.Integer(),
});
```
The resulting schema would contain the property ``likes``. If you used this schema (and nothing else) to validate ``POST`` or ``PUT`` requests, API users would be able to set the number of ``likes`` by updating/creating a post. This can be either solved by manually creating a separate schema or by using the ``Type.Hidden`` modifier on the property ``likes``. 
# Downsides
- hidden types must be object properties
- causes the property to be optional in TypeScript 
- does not use the ``modifier`` property internally 