### PR TITLE
Flesh out options examples in the readme with title, description, etc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -394,6 +394,17 @@ const T = Type.Number({ multipleOf: 2 })
 
 // array must have at least 5 integer values
 const T = Type.Array(Type.Integer(), { minItems: 5 })
+
+// object is documented and annotated for openapi
+const T = Type.Object({
+  email: Type.String({ format: 'email' }),
+  address: Type.String({ description: 'US street address' })
+}, {
+  title: 'Customer', 
+  description: 'A customer record',
+  'x-custom-attribute': true,
+  nullable: true, // not reflected in TS; see https://github.com/sinclairzx81/typebox/issues/38#issuecomment-740310268
+ })
 ```
 <a name="Generic-Types"></a>
 


### PR DESCRIPTION
https://github.com/sinclairzx81/typebox/issues/9#issuecomment-894818860

I had searched for "title", "description", "document", and "nullable" in search of how to add annotations.  
Many JSON Schema users use it for OpenAPI, which has the `nullable` property that isn't in JSON Schema, and may be curious how to use it. They may also wish to know whether extensions like `x-mycompany-myattribute` work.