### PR TITLE
fix: typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -308,7 +308,7 @@ The following table outlines the TypeBox mappings between TypeScript and JSON sc
 │          Type.Number()         │                             │     y: {                       │
 │       )                        │                             │        type: 'number'          │
 │    })                          │                             │     }                          │
-│ )                              │                             │   }                            │
+│ )                              │                             │   },                           │
 │                                │                             │   required: ['x', 'y']         │
 │                                │                             │ }                              │
 │   	                         │                             │                                │


### PR DESCRIPTION
Added a missing comma in the readme examples