### PR TITLE
fix: Type.Optional() set `nullable: true`

### DIFF
--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -36,7 +36,7 @@ export const ReadonlyModifier                    = Symbol('ReadonlyModifier')
 
 export type TModifier                            = TReadonlyOptional<TSchema> | TOptional<TSchema> | TReadonly<TSchema>
 export type TReadonlyOptional<T extends TSchema> = T & { modifier: typeof ReadonlyOptionalModifier }
-export type TOptional<T extends TSchema>         = T & { modifier: typeof OptionalModifier }
+export type TOptional<T extends TSchema>         = T & { modifier: typeof OptionalModifier, nullable?: boolean }
 export type TReadonly<T extends TSchema>         = T & { modifier: typeof ReadonlyModifier }
 
 // ------------------------------------------------------------------------
@@ -285,7 +285,10 @@ export class TypeBuilder {
 
     /** `STANDARD` Modifies a schema object property to be `optional`. */
     public Optional<T extends TSchema>(item: T): TOptional<T> {
-        return { ...item, nullable: true, modifier: OptionalModifier }
+        if (item.type === 'string') {
+            return { ...item, nullable: true, modifier: OptionalModifier }
+        }
+        return { ...item, modifier: OptionalModifier }
     }
 
     /** `STANDARD` Creates a Tuple schema. */

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -285,7 +285,7 @@ export class TypeBuilder {
 
     /** `STANDARD` Modifies a schema object property to be `optional`. */
     public Optional<T extends TSchema>(item: T): TOptional<T> {
-        return { ...item, modifier: OptionalModifier }
+        return { ...item, nullable: true, modifier: OptionalModifier }
     }
 
     /** `STANDARD` Creates a Tuple schema. */


### PR DESCRIPTION
Hello! :wave: @sinclairzx81 

## Current Behavior

Currently, a `null` value of `type: "string"` in the `ajv` schema is serialized as a double-quoted empty string (`""`)

## Expected Behavior

A  `null` string should be serialized as `null`, and not `""`.

## Solution

This PR adds `nullable: true` to the schema object that returns `Type.Optional`.
Might be a **BREAKING CHANGE**, I don't really know to be honest but, maybe we could add an option to `Type.Optional` to not add this behavior by default.

## References

- https://ajv.js.org/json-schema.html#nullable
- https://github.com/fastify/fast-json-stringify/issues/152