### PR TITLE
Forward Inference

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+## [0.21.0](https://www.npmjs.com/package/@sinclair/typebox/v/0.21.0)
+
+Updates:
+
+- TypeBox static inference has been updated inline with additional inference constraints added in TypeScript 4.5. All types now include a phantom `_infer` property which contains the inference TS type for a given schema. The type of this property is inferred at the construction of the schema, and referenced directly via `Static<T>`.
+- `Type.Box(...)` has been renamed to `Type.Namespace(...)` to draw an analogy with XML's `xmlns` XSD types.
+- `Type.Record(...)` updated to accept `Type.KeyOf(...)` instead of `Type.Union([...Type.Literal(...)])`. 
+
 ## [0.20.1](https://www.npmjs.com/package/@sinclair/typebox/v/0.20.1)
 
 Updates:

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,12 +1,3 @@
-
 import { Type, Static, TSchema } from '@sinclair/typebox';
-
-const T = Type.Union([Type.String(), Type.Null()])
-
-const R = Type.Ref(T)
-
-type T = Static<typeof R>
-
-
 
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,12 +1,27 @@
-import { Type, Static } from '@sinclair/typebox'
 
-const Node = Type.Rec(Self => Type.Object({
-    nodeId: Type.String(),
-    nodes: Type.Array(Self)
-}, { additionalProperties: false }), { $id: 'Node' })
+import { Type, Static, TSchema } from '@sinclair/typebox';
 
+import * as X from '@sinclair/typebox'
 
-const T = Type.Constructor([Type.String(), Type.String()], Type.Number())
+// const T = Type.Array(Type.Number())                  // ok
+// const T = Type.Tuple([Type.String(), Type.Number()]) // ok
+
+const T = Type.Object({
+     name: Type.Readonly(Type.Number()),
+     age:  Type.Optional(Type.Number())
+})
+const K = Type.Omit(T, ['name'])
+
+type K = Static<typeof K>
 
 type T = Static<typeof T>
+
+function test(value: T) {
+    
+}
+
+test({ name: 1 })
+
+
+
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,12 +1,11 @@
 
 import { Type, Static, TSchema } from '@sinclair/typebox';
 
-const Foo = Type.Object({
-    a: Type.Number(),
-    b: Type.Number()
-})
+const T = Type.Union([Type.String(), Type.Null()])
 
+const R = Type.Ref(T)
 
+type T = Static<typeof R>
 
 
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,3 +1,5 @@
 import { Type, Static, TSchema } from '@sinclair/typebox';
 
+const T = Type.String()
 
+type T = Static<typeof T>

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,26 +1,12 @@
 
 import { Type, Static, TSchema } from '@sinclair/typebox';
 
-import * as X from '@sinclair/typebox'
-
-// const T = Type.Array(Type.Number())                  // ok
-// const T = Type.Tuple([Type.String(), Type.Number()]) // ok
-
-const T = Type.Object({
-     name: Type.Readonly(Type.Number()),
-     age:  Type.Optional(Type.Number())
+const Foo = Type.Object({
+    a: Type.Number(),
+    b: Type.Number()
 })
-const K = Type.Omit(T, ['name'])
 
-type K = Static<typeof K>
 
-type T = Static<typeof T>
-
-function test(value: T) {
-    
-}
-
-test({ name: 1 })
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.20.6",
+  "version": "0.21.0",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "json-schema",

--- a/readme.md
+++ b/readme.md
@@ -447,10 +447,10 @@ const R = Type.Ref(T)                        // const R = {
                                              // }
 ```
 
-It can be helpful to organize shared referenced types under a common namespace. The `Type.Box(...)` function can be used to create a shared definition container for related types. The following creates a `Math3D` container and a `Vertex` structure that references types in the container.
+It can be helpful to organize shared referenced types under a common namespace. The `Type.Namespace(...)` function can be used to create a shared definition container for related types. The following creates a `Math3D` container and a `Vertex` structure that references types in the container.
 
 ```typescript
-const Math3D = Type.Box({                     //  const Math3D = {
+const Math3D = Type.Namespace({               //  const Math3D = {
   Vector4: Type.Object({                      //    $id: 'Math3D',
     x: Type.Number(),                         //    definitions: {
     y: Type.Number(),                         //      Vector4: {
@@ -691,7 +691,7 @@ const ok = ajv.validate(User, {
 
 #### Reference Types
 
-Referenced types can be added to AJV with the `ajv.addSchema(...)` function. The following moves the `userId` and `email` property types into a `Type.Box(...)` and registers the box with AJV.
+Referenced types can be added to AJV with the `ajv.addSchema(...)` function. The following moves the `userId` and `email` property types into a `Type.Namespace(...)` and registers the box with AJV.
 
 ```typescript
 //--------------------------------------------------------------------------------------------
@@ -700,7 +700,7 @@ Referenced types can be added to AJV with the `ajv.addSchema(...)` function. The
 //
 //--------------------------------------------------------------------------------------------
 
-const Shared = Type.Box({
+const Shared = Type.Namespace({
   UserId: Type.String({ format: 'uuid' }),
   Email:  Type.String({ format: 'email' })
 }, { $id: 'Shared' })

--- a/spec/schema/box.ts
+++ b/spec/schema/box.ts
@@ -7,7 +7,7 @@ describe("Box", () => {
         const Vector2 = Type.Object({ x: Type.Number(), y: Type.Number() })
         const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
         const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
-        const Math3D = Type.Box({ Vector2, Vector3, Vector4 }, { $id: 'Math3D' })
+        const Math3D = Type.Namespace({ Vector2, Vector3, Vector4 }, { $id: 'Math3D' })
         const Vertex = Type.Object({
             position: Type.Ref(Math3D, 'Vector4'),
             normal: Type.Ref(Math3D, 'Vector3'),
@@ -25,7 +25,7 @@ describe("Box", () => {
         const Vector2 = Type.Object({ x: Type.Number(), y: Type.Number() })
         const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
         const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
-        const Math3D = Type.Box({ Vector2, Vector3, Vector4 }, { $id: 'Math3D' })
+        const Math3D = Type.Namespace({ Vector2, Vector3, Vector4 }, { $id: 'Math3D' })
         const Vertex = Type.Object({
             position: Type.Ref(Math3D, 'Vector4'),
             normal: Type.Ref(Math3D, 'Vector3'),
@@ -42,7 +42,7 @@ describe("Box", () => {
         const Vector2 = Type.Object({ x: Type.Number(), y: Type.Number() })
         const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
         const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
-        const Math3D = Type.Box({ Vector2, Vector3, Vector4 }, { $id: 'Math3D' })
+        const Math3D = Type.Namespace({ Vector2, Vector3, Vector4 }, { $id: 'Math3D' })
         const Vertex = Type.Object({
             position: Type.Ref(Math3D, 'Vector4'),
             normal:  Type.Ref(Math3D, 'Vector3'),
@@ -59,7 +59,7 @@ describe("Box", () => {
         const Vector2 = Type.Object({ x: Type.Number(), y: Type.Number() })
         const Vector3 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() })
         const Vector4 = Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number(), w: Type.Number() })
-        const Math3D = Type.Box({ Vector2, Vector3, Vector4 }, { $id: 'Math3D' })
+        const Math3D = Type.Namespace({ Vector2, Vector3, Vector4 }, { $id: 'Math3D' })
         const Vertex = Type.Object({
             position: Type.Ref(Math3D, 'Vector4'),
             normal:   Type.Ref(Math3D, 'Vector3'),

--- a/spec/schema/intersect.ts
+++ b/spec/schema/intersect.ts
@@ -66,25 +66,6 @@ describe('Intersect', () => {
         })
     })
 
-    describe('Should intersect object with union literal record', () => {
-        const A = Type.Object({
-            a: Type.String(),
-            b: Type.String(),
-            c: Type.String()
-        })
-        const K = Type.Union([
-            Type.Literal('x'),
-            Type.Literal('y'),
-            Type.Literal('z')
-        ])
-        const B = Type.Record(K, Type.Number())
-        const T = Type.Intersect([A, B])
-        ok(T, {
-            a: 'a', b: 'b', c: 'c',
-            x: 1, y: 2, z: 3
-        })
-    })
-
     describe('Should intersect with partial', () => {
         const A = Type.Object({ a: Type.Number() })
         const B = Type.Object({ b: Type.Number() })

--- a/spec/schema/keyof.ts
+++ b/spec/schema/keyof.ts
@@ -13,4 +13,27 @@ describe("KeyOf", () => {
         ok(T, 'z')
         fail(T, 'w')
     })
+
+    it('Should validate when using pick', () => {
+        const T = Type.KeyOf(Type.Pick(Type.Object({
+            x: Type.Number(),
+            y: Type.Number(),
+            z: Type.Number()
+        }), ['x', 'y']))
+        ok(T, 'x')
+        ok(T, 'y')
+        fail(T, 'z')
+    })
+
+    it('Should validate when using omit', () => {
+        const T = Type.KeyOf(Type.Omit(Type.Object({
+            x: Type.Number(),
+            y: Type.Number(),
+            z: Type.Number()
+        }), ['x', 'y']))
+
+        fail(T, 'x')
+        fail(T, 'y')
+        ok(T, 'z')
+    })
 })

--- a/spec/schema/record.ts
+++ b/spec/schema/record.ts
@@ -48,24 +48,14 @@ describe('Record', () => {
         fail(T, { '0': 1, '1': 2, '2': 3, '3': 4, 'a': 'hello' })
     })
 
-    it('Should validate when specifying union literals for the known keys', () => {
-        const K = Type.Union([
-            Type.Literal('a'),
-            Type.Literal('b'),
-            Type.Literal('c'),
-        ])
-        const T = Type.Record(K, Type.Number())
-        ok(T, { a: 1, b: 2, c: 3, d: 'hello' })
-    })
-
-    it('Should not validate when specifying union literals for the known keys and with additionalProperties: false', () => {
-        const K = Type.Union([
-            Type.Literal('a'),
-            Type.Literal('b'),
-            Type.Literal('c'),
-        ])
-        const T = Type.Record(K, Type.Number(), { additionalProperties: false })
-        fail(T, { a: 1, b: 2, c: 3, d: 'hello' })
+    it('Should validate for keyof records', () => {
+        const T = Type.Object({
+            a: Type.String(),
+            b: Type.Number(),
+            c: Type.String()
+        })
+        const R = Type.Record(Type.KeyOf(T), Type.Number())
+        ok(R, { a: 1, b: 2, c: 3 })
     })
 
     it('Should should validate when specifying regular expressions', () => {

--- a/spec/schema/ref.ts
+++ b/spec/schema/ref.ts
@@ -65,7 +65,7 @@ describe('Ref', () => {
             z: Type.Number()
         }, { $id: 'Vertex' })
         
-        const Box = Type.Box({ 
+        const Box = Type.Namespace({ 
             Vertex 
         }, { $id: 'Box' })
         

--- a/spec/static/index.ts
+++ b/spec/static/index.ts
@@ -1,7 +1,7 @@
 import './any'
 import './array'
 import './boolean'
-import './box'
+import './namespace'
 import './enum'
 import './intersect'
 import './keyof'

--- a/spec/static/namespace.ts
+++ b/spec/static/namespace.ts
@@ -4,7 +4,7 @@ import { Type, Static } from '@sinclair/typebox'
 
 const T0 = Type.Tuple([Type.Number(), Type.Number()])
 
-const B0 = Type.Box('ns', { T0 })
+const B0 = Type.Namespace({ T0 }, { $id: 'ns' })
 
 const R0 = Type.Ref(B0, 'T0')
 

--- a/spec/static/record.ts
+++ b/spec/static/record.ts
@@ -22,21 +22,22 @@ F1({
 
 // --------------------------------------------
 
-const K = Type.Union([
-    Type.Literal('a'),
-    Type.Literal('b'),
-    Type.Literal('c'),
-    Type.Literal(0),
-    Type.Literal(1),
-    Type.Literal(2),
-])
-const T2 = Type.Record(K, Type.Number())
+const K = Type.Object({
+    a: Type.Literal('a'),
+    b: Type.Literal('b'),
+    c: Type.Literal('c'),
+    d: Type.Literal(0),
+    e: Type.Literal(1),
+    f: Type.Literal(2),
+})
+
+const T2 = Type.Record(Type.KeyOf(K), Type.Number())
 const F2 = (arg: Static<typeof T2>) => { }
 F2({
     'a': 1,
     'b': 2,
     'c': 3,
-    0: 1,
-    1: 2,
-    2: 3
+    'd': 1,
+    'e': 2,
+    'f': 3
 })

--- a/spec/static/ref.ts
+++ b/spec/static/ref.ts
@@ -17,7 +17,7 @@ F1({
 
 // --------------------------------------------
 
-const T2 = Type.Box({
+const T2 = Type.Namespace({
     Vector: Type.Object({
         x: Type.Number(),
         y: Type.Number()

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -379,8 +379,7 @@ export class TypeBuilder {
     
     /** `standard` Creates a record type */
     public Record<K extends TRecordKey, T extends TSchema>(key: K, value: T, options: ObjectOptions = {}): TRecord<StaticRecord<K, T>> {
-        // @ts-ignore
-        const pattern = key.kind === UnionKind  ? `^${key.anyOf.map((literal: TLiteral<StaticLiteral<TValue>>) => literal.const).join('|')}$` :
+        const pattern = key.kind === KeyOfKind  ? `^${key.enum.join('|')}$` :
                         key.kind === NumberKind ? '^(0|[1-9][0-9]*)$' :
                         key.pattern             ? key.pattern :  '^.*$'
         return { ...options, kind: RecordKind, type: 'object', patternProperties: { [pattern]: value } } as any

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -113,25 +113,25 @@ export type TValue             = string | number | boolean
 export type TRecordKey         = TString | TNumber | TUnion<TLiteral<string | number>[]>
 export type TEnumKey<T = TKey> = { type: 'number' | 'string', const: T }
 
-export type TDefinitions                                         = { [key: string]: TSchema }
-export type TProperties                                          = { [key: string]: TSchema }
-export type TBox       <T extends TDefinitions>                  = { kind: typeof BoxKind, definitions: T } & CustomOptions
-export type TTuple     <T extends TSchema[]>                     = { kind: typeof TupleKind, type: 'array', items?: [...T], additionalItems?: false, minItems: number, maxItems: number } & CustomOptions
-export type TObject    <T extends TProperties>                   = { kind: typeof ObjectKind, type: 'object', properties: T, required?: string[] } & ObjectOptions
-export type TUnion     <T extends TSchema[]>                     = { kind: typeof UnionKind, anyOf: [...T] } & CustomOptions
-export type TIntersect <T extends TSchema[]>                     = { kind: typeof IntersectKind, type: 'object', allOf: [...T] } & IntersectOptions
-export type TKeyOf     <T extends TKey[]>                        = { kind: typeof KeyOfKind, type: 'string', enum: [...T] } & CustomOptions
-export type TRecord    <K extends TRecordKey, T extends TSchema> = { kind: typeof RecordKind, type: 'object', patternProperties: { [pattern: string]: T } } & ObjectOptions
-export type TArray     <T extends TSchema>                       = { kind: typeof ArrayKind, type: 'array', items: T } & ArrayOptions
-export type TLiteral   <T extends TValue>                        = { kind: typeof LiteralKind, const: T } & CustomOptions
-export type TEnum      <T extends TEnumKey[]>                    = { kind: typeof EnumKind, anyOf: T } & CustomOptions
-export type TString                                              = { kind: typeof StringKind, type: 'string' } & StringOptions<string>
-export type TNumber                                              = { kind: typeof NumberKind, type: 'number' } & NumberOptions
-export type TInteger                                             = { kind: typeof IntegerKind, type: 'integer' } & NumberOptions
-export type TBoolean                                             = { kind: typeof BooleanKind, type: 'boolean' } & CustomOptions
-export type TNull                                                = { kind: typeof NullKind, type: 'null' } & CustomOptions
-export type TUnknown                                             = { kind: typeof UnknownKind } & CustomOptions
-export type TAny                                                 = { kind: typeof AnyKind } & CustomOptions
+export type TDefinitions            = { [key: string]: TSchema }
+export type TProperties             = { [key: string]: TSchema }
+export type TBox       <I>          = { _infer: I, kind: typeof BoxKind, definitions: any } & CustomOptions
+export type TTuple     <I>          = { _infer: I, kind: typeof TupleKind, type: 'array', items?: TSchema[], additionalItems?: false, minItems: number, maxItems: number } & CustomOptions
+export type TObject    <I>          = { _infer: I, kind: typeof ObjectKind, type: 'object', properties: TProperties, required?: string[] } & ObjectOptions
+export type TUnion     <I>          = { _infer: I, kind: typeof UnionKind, anyOf: TSchema[] } & CustomOptions
+export type TIntersect <I>          = { _infer: I, kind: typeof IntersectKind, type: 'object', allOf: TSchema[] } & IntersectOptions
+export type TKeyOf     <I>          = { _infer: I, kind: typeof KeyOfKind, type: 'string', enum: string[] } & CustomOptions
+export type TRecord    <I>          = { _infer: I, kind: typeof RecordKind, type: 'object', patternProperties: { [pattern: string]: TSchema } } & ObjectOptions
+export type TArray     <I>          = { _infer: I, kind: typeof ArrayKind, type: 'array', items: any } & ArrayOptions
+export type TLiteral   <I>          = { _infer: I, kind: typeof LiteralKind, const: TSchema } & CustomOptions
+export type TEnum      <I>          = { _infer: I, kind: typeof EnumKind, anyOf: TSchema } & CustomOptions
+export type TString                 = { _infer: string, kind: typeof StringKind, type: 'string' } & StringOptions<string>
+export type TNumber                 = { _infer: number, kind: typeof NumberKind, type: 'number' } & NumberOptions
+export type TInteger                = { _infer: number, kind: typeof IntegerKind, type: 'integer' } & NumberOptions
+export type TBoolean                = { _infer: boolean, kind: typeof BooleanKind, type: 'boolean' } & CustomOptions
+export type TNull                   = { _infer: null, kind: typeof NullKind, type: 'null' } & CustomOptions
+export type TUnknown                = { _infer: unknown, kind: typeof UnknownKind } & CustomOptions
+export type TAny                    = { _infer: any, kind: typeof AnyKind } & CustomOptions
 
 // ------------------------------------------------------------------------
 // Schema Extended
@@ -142,11 +142,11 @@ export const FunctionKind    = Symbol('FunctionKind')
 export const PromiseKind     = Symbol('PromiseKind')
 export const UndefinedKind   = Symbol('UndefinedKind')
 export const VoidKind        = Symbol('VoidKind')
-export type TConstructor <T extends TSchema[], U extends TSchema> = { kind: typeof ConstructorKind, type: 'constructor', arguments: readonly [...T], returns: U } & CustomOptions
-export type TFunction    <T extends TSchema[], U extends TSchema> = { kind: typeof FunctionKind,    type: 'function', arguments: readonly [...T], returns: U } & CustomOptions
-export type TPromise     <T extends TSchema>                      = { kind: typeof PromiseKind,     type: 'promise', item: T } & CustomOptions
-export type TUndefined       = { kind: typeof UndefinedKind, type: 'undefined' } & CustomOptions
-export type TVoid            = { kind: typeof VoidKind, type: 'void' } & CustomOptions
+export type TConstructor <I> = { _infer: I, kind: typeof ConstructorKind, type: 'constructor', arguments: TSchema[], returns: TSchema } & CustomOptions
+export type TFunction    <I> = { _infer: I, kind: typeof FunctionKind,    type: 'function', arguments: TSchema[], returns: TSchema } & CustomOptions
+export type TPromise     <I> = { _infer: I, kind: typeof PromiseKind,     type: 'promise', item: TSchema } & CustomOptions
+export type TUndefined       = { _infer: undefined, kind: typeof UndefinedKind, type: 'undefined' } & CustomOptions
+export type TVoid            = { _indef: void, kind: typeof VoidKind, type: 'void' } & CustomOptions
 
 // ------------------------------------------------------------------------
 // Schema
@@ -158,7 +158,7 @@ export type TSchema =
     | TTuple<any>
     | TObject<any>
     | TKeyOf<any>
-    | TRecord<any, any>
+    | TRecord<any>
     | TArray<any>
     | TEnum<any>
     | TLiteral<any>
@@ -169,8 +169,8 @@ export type TSchema =
     | TNull
     | TUnknown
     | TAny
-    | TConstructor<any[], any>
-    | TFunction<any[], any>
+    | TConstructor<any>
+    | TFunction<any>
     | TPromise<any>
     | TUndefined
     | TVoid
@@ -199,17 +199,17 @@ export type TPartial<T extends TProperties> = {
 // ------------------------------------------------------------------------
 
 export type UnionToIntersect<U>                                  = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
-export type ObjectPropertyKeys           <T>                     = T extends TObject<infer U> ? PropertyKeys<U> : never
+export type ObjectPropertyKeys           <T>                     = T extends TObject<any> ? keyof T['_infer'] : never
 export type PropertyKeys                 <T extends TProperties> = keyof T
 export type ReadonlyOptionalPropertyKeys <T extends TProperties> = { [K in keyof T]: T[K] extends TReadonlyOptional<TSchema> ? K : never }[keyof T]
 export type ReadonlyPropertyKeys         <T extends TProperties> = { [K in keyof T]: T[K] extends TReadonly<TSchema> ? K : never }[keyof T]
 export type OptionalPropertyKeys         <T extends TProperties> = { [K in keyof T]: T[K] extends TOptional<TSchema> ? K : never }[keyof T]
 export type RequiredPropertyKeys         <T extends TProperties> = keyof Omit<T, ReadonlyOptionalPropertyKeys<T> | ReadonlyPropertyKeys<T> | OptionalPropertyKeys<T>>
-export type ReduceModifiers              <T extends object> = { [K in keyof T]: T[K] }
-export type StaticModifiers<T extends TProperties> =
-    { readonly [K in ReadonlyOptionalPropertyKeys<T>]?: T[K] extends TReadonlyOptional<infer U> ? Static<U> : never } &
-    { readonly [K in ReadonlyPropertyKeys<T>]:          T[K] extends TReadonly<infer U>         ? Static<U> : never } &
-    {          [K in OptionalPropertyKeys<T>]?:         T[K] extends TOptional<infer U>         ? Static<U> : never } &
+
+export type StaticProperties<T extends TProperties> =
+    { readonly [K in ReadonlyOptionalPropertyKeys<T>]?: Static<T[K]> } &
+    { readonly [K in ReadonlyPropertyKeys<T>]:          Static<T[K]> } &
+    {          [K in OptionalPropertyKeys<T>]?:         Static<T[K]> } &
     {          [K in RequiredPropertyKeys<T>]:          Static<T[K]> }
 
 export type StaticEnum        <T>                                               = T extends TEnumKey<infer U>[] ? U : never
@@ -217,40 +217,38 @@ export type StaticKeyOf       <T extends TKey[]>                                
 export type StaticIntersect   <T extends readonly TSchema[]>                    = UnionToIntersect<StaticUnion<T>>
 export type StaticUnion       <T extends readonly TSchema[]>                    = { [K in keyof T]: Static<T[K]> }[number]
 export type StaticTuple       <T extends readonly TSchema[]>                    = { [K in keyof T]: Static<T[K]> }
-export type StaticObject      <T extends TProperties>                           = ReduceModifiers<StaticModifiers<T>>
+export type StaticObject      <T extends TProperties>                           = StaticProperties<StaticProperties<T>>
 export type StaticRecord      <K extends TRecordKey, T extends TSchema>         = K extends TString ? { [key: string]: Static<T> } : K extends TNumber ? { [key: number]: Static<T> } : K extends TUnion<infer L> ? L extends TLiteral<any>[] ? {[K in StaticUnion<L>]: Static<T> } : never : never
 export type StaticArray       <T extends TSchema>                               = Array<Static<T>>
 export type StaticLiteral     <T extends TValue>                                = T
 
 // Note: Disabled on TS 4.5 due to updated TS heuristics
-// export type StaticConstructor <T extends readonly TSchema[], U extends TSchema> = new (...args: [...{ [K in keyof T]: Static<T[K]> }]) => Static<U>
-// export type StaticFunction    <T extends readonly TSchema[], U extends TSchema> = (...args: [...{ [K in keyof T]: Static<T[K]> }]) => Static<U>
-export type StaticConstructor <T extends readonly TSchema[], U extends TSchema> = new (...args: unknown[]) => Static<U>
-export type StaticFunction    <T extends readonly TSchema[], U extends TSchema> = (...args: unknown[]) => Static<U>
+export type StaticConstructor <T extends readonly TSchema[], U extends TSchema> = new (...args: [...{ [K in keyof T]: Static<T[K]> }]) => Static<U>
+export type StaticFunction    <T extends readonly TSchema[], U extends TSchema> = (...args: [...{ [K in keyof T]: Static<T[K]> }]) => Static<U>
 export type StaticPromise     <T extends TSchema>                               = Promise<Static<T>>
 
 export type Static<T> =
-    T extends TKeyOf<infer U>                ? StaticKeyOf<U>          :
-    T extends TIntersect<infer U>            ? StaticIntersect<U>      : 
-    T extends TUnion<infer U>                ? StaticUnion<U>          :
-    T extends TTuple<infer U>                ? StaticTuple<U>          :
-    T extends TObject<infer U>               ? StaticObject<U>         :
-    T extends TRecord<infer K, infer U>      ? StaticRecord<K, U>      :
-    T extends TArray<infer U>                ? StaticArray<U>          :
-    T extends TEnum<infer U>                 ? StaticEnum<U>           :
-    T extends TLiteral<infer U>              ? StaticLiteral<U>        :
-    T extends TString                        ? string                  :
-    T extends TNumber                        ? number                  :
-    T extends TInteger                       ? number                  :
-    T extends TBoolean                       ? boolean                 : 
-    T extends TNull                          ? null                    :
-    T extends TUnknown                       ? unknown                 :
-    T extends TAny                           ? any                     :
-    T extends TConstructor<infer U, infer R> ? StaticConstructor<U, R> :
-    T extends TFunction<infer U, infer R>    ? StaticFunction<U, R>    :
-    T extends TPromise<infer U>              ? StaticPromise<U>        :
-    T extends TUndefined                     ? undefined               :
-    T extends TVoid                          ? void                    :
+    T extends TKeyOf<infer I>        ? I :
+    T extends TIntersect<infer I>    ? I : 
+    T extends TUnion<infer I>        ? I :
+    T extends TTuple<infer I>        ? I :
+    T extends TObject<infer I>       ? { [K in keyof I]: I[K] } :
+    T extends TRecord<infer I>       ? I :
+    T extends TArray<infer I>        ? I :
+    T extends TEnum<infer I>         ? I :
+    T extends TLiteral<infer I>      ? I :
+    T extends TString                ? T['_infer'] :
+    T extends TNumber                ? T['_infer'] :
+    T extends TInteger               ? T['_infer'] :
+    T extends TBoolean               ? T['_infer'] : 
+    T extends TNull                  ? T['_infer'] :
+    T extends TUnknown               ? T['_infer'] :
+    T extends TAny                   ? T['_infer'] :
+    T extends TConstructor<infer I>  ? I :
+    T extends TFunction<infer I>     ? I :
+    T extends TPromise<infer I>      ? I :
+    T extends TUndefined             ? T['_infer'] :
+    T extends TVoid                  ? T['_infer'] :
     never
 
 // ------------------------------------------------------------------------
@@ -293,17 +291,17 @@ export class TypeBuilder {
     }
 
     /** `STANDARD` Creates a Tuple schema. */
-    public Tuple<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TTuple<T> {
+    public Tuple<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TTuple<StaticTuple<T>> {
         const additionalItems = false
         const minItems = items.length
         const maxItems = items.length
         return (items.length > 0)
             ? { ...options, kind: TupleKind, type: 'array', items, additionalItems, minItems, maxItems }
-            : { ...options, kind: TupleKind, type: 'array', minItems, maxItems }
+            : { ...options, kind: TupleKind, type: 'array', minItems, maxItems } as any
     }
 
     /** `STANDARD` Creates a `object` schema with the given properties. */
-    public Object<T extends TProperties>(properties: T, options: ObjectOptions = {}): TObject<T> {
+    public Object<T extends TProperties>(properties: T, options: ObjectOptions = {}): TObject<StaticProperties<T>> {
         const property_names = Object.keys(properties)
         const optional = property_names.filter(name => {
             const candidate = properties[name] as TModifier
@@ -315,92 +313,93 @@ export class TypeBuilder {
         const required = (required_names.length > 0) ? required_names : undefined
         return (required) ?
             { ...options, kind: ObjectKind, type: 'object', properties, required } : 
-            { ...options, kind: ObjectKind, type: 'object', properties }
+            { ...options, kind: ObjectKind, type: 'object', properties } as any
     }
 
     /** `STANDARD` Creates an intersection schema. Note this function requires draft `2019-09` to constrain with `unevaluatedProperties`. */
-    public Intersect<T extends TSchema[]>(items: [...T], options: IntersectOptions = {}): TIntersect<T> {
-        return { ...options, kind: IntersectKind, type: 'object', allOf: items }
+    public Intersect<T extends TSchema[]>(items: [...T], options: IntersectOptions = {}): TIntersect<StaticIntersect<T>> {
+        return { ...options, kind: IntersectKind, type: 'object', allOf: items } as any
     }
     
     /** `STANDARD` Creates a Union schema. */
-    public Union<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TUnion<T> {
-        return { ...options, kind: UnionKind, anyOf: items }
+    public Union<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TUnion<StaticUnion<T>> {
+        return { ...options, kind: UnionKind, anyOf: items } as any
     }
 
     /** `STANDARD` Creates an `Array<T>` schema. */
-    public Array<T extends TSchema>(items: T, options: ArrayOptions = {}): TArray<T> {
-        return { ...options, kind: ArrayKind, type: 'array', items }
+    public Array<T extends TSchema>(items: T, options: ArrayOptions = {}): TArray<StaticArray<T>> {
+        return { ...options, kind: ArrayKind, type: 'array', items } as any
     }
     
     /** `STANDARD` Creates an `Enum<T>` schema from a TypeScript `enum` definition. */
-    public Enum<T extends TEnumType>(item: T, options: CustomOptions = {}): TEnum<TEnumKey<T[keyof T]>[]> {
+    public Enum<T extends TEnumType>(item: T, options: CustomOptions = {}): TEnum<StaticEnum<TEnumKey<T[keyof T]>[]>> {
         const values = Object.keys(item).filter(key => isNaN(key as any)).map(key => item[key]) as T[keyof T][]
         const anyOf  = values.map(value => typeof value === 'string' ? { type: 'string' as const, const: value } : { type: 'number' as const, const: value })
-        return { ...options, kind: EnumKind, anyOf } 
+        return { ...options, kind: EnumKind, anyOf } as any
     }
 
     /** `STANDARD` Creates a literal schema. Supports `string | number | boolean` values. */
-    public Literal<T extends TValue>(value: T, options: CustomOptions = {}): TLiteral<T> {
-        return { ...options, kind: LiteralKind, const: value, type: typeof value as 'string' | 'number' | 'boolean' }
+    public Literal<T extends TValue>(value: T, options: CustomOptions = {}): TLiteral<StaticLiteral<T>> {
+        return { ...options, kind: LiteralKind, const: value, type: typeof value as 'string' | 'number' | 'boolean' } as any
     }
 
     /** `STANDARD` Creates a `string` schema. */
     public String<TCustomFormatOption extends string>(options: StringOptions<StringFormatOption | TCustomFormatOption> = {}): TString {
-        return { ...options, kind: StringKind, type: 'string' }
+        return { ...options, kind: StringKind, type: 'string' } as any
     }
 
     /** `STANDARD` Creates a `string` schema from a regular expression. */
     public RegEx(regex: RegExp, options: CustomOptions = {}): TString {
-        return this.String({ ...options, pattern: regex.source })
+        return this.String({ ...options, pattern: regex.source }) as any
     }
 
     /** `STANDARD` Creates a `number` schema. */
     public Number(options: NumberOptions = {}): TNumber {
-        return { ...options, kind: NumberKind, type: 'number' }
+        return { ...options, kind: NumberKind, type: 'number' } as any
     }
 
     /** `STANDARD` Creates a `integer` schema. */
     public Integer(options: NumberOptions = {}): TInteger {
-        return { ...options, kind: IntegerKind, type: 'integer' }
+        return { ...options, kind: IntegerKind, type: 'integer' } as any
     }
 
     /** `STANDARD` Creates a `boolean` schema. */
     public Boolean(options: CustomOptions = {}): TBoolean {
-        return { ...options, kind: BooleanKind, type: 'boolean' }
+        return { ...options, kind: BooleanKind, type: 'boolean' } as any
     }
 
     /** `STANDARD` Creates a `null` schema. */
     public Null(options: CustomOptions = {}): TNull {
-        return { ...options, kind: NullKind, type: 'null' }
+        return { ...options, kind: NullKind, type: 'null' } as any
     }
 
     /** `STANDARD` Creates an `unknown` schema. */
     public Unknown(options: CustomOptions = {}): TUnknown {
-        return { ...options, kind: UnknownKind }
+        return { ...options, kind: UnknownKind } as any
     }
 
     /** `STANDARD` Creates an `any` schema. */
     public Any(options: CustomOptions = {}): TAny {
-        return { ...options, kind: AnyKind }
+        return { ...options, kind: AnyKind } as any
     }
     
     /** `STANDARD` Creates a `keyof` schema. */
-    public KeyOf<T extends TObject<TProperties>>(schema: T, options: CustomOptions = {}): TKeyOf<ObjectPropertyKeys<T>[]> {
+    public KeyOf<T extends TObject<any>>(schema: T, options: CustomOptions = {}): TKeyOf<keyof T['_infer']> {
         const keys = Object.keys(schema.properties) as ObjectPropertyKeys<T>[]
-        return {...options, kind: KeyOfKind, type: 'string', enum: keys }
+        return {...options, kind: KeyOfKind, type: 'string', enum: keys } as any
     }
     
     /** `STANDARD` Creates a `Record<Keys, Value>` schema. */
-    public Record<K extends TRecordKey, T extends TSchema>(key: K, value: T, options: ObjectOptions = {}): TRecord<K, T> {
-        const pattern = key.kind === UnionKind  ? `^${key.anyOf.map((literal: TLiteral<TValue>) => literal.const).join('|')}$` :
+    public Record<K extends TRecordKey, T extends TSchema>(key: K, value: T, options: ObjectOptions = {}): TRecord<StaticRecord<K, T>> {
+        // @ts-ignore
+        const pattern = key.kind === UnionKind  ? `^${key.anyOf.map((literal: TLiteral<StaticLiteral<TValue>>) => literal.const).join('|')}$` :
                         key.kind === NumberKind ? '^(0|[1-9][0-9]*)$' :
                         key.pattern             ? key.pattern :  '^.*$'
-        return { ...options, kind: RecordKind, type: 'object', patternProperties: { [pattern]: value } }
+        return { ...options, kind: RecordKind, type: 'object', patternProperties: { [pattern]: value } } as any
     }
 
     /** `STANDARD` Make all properties in schema object required. */
-    public Required<T extends TObject<TProperties>>(schema: T, options: ObjectOptions = {}): TObject<TRequired<T['properties']>> {
+    public Required<T extends TObject<TProperties>>(schema: T, options: ObjectOptions = {}): TObject<StaticProperties<TRequired<T['properties']>>> {
         const next = { ...clone(schema), ...options }
         next.required = Object.keys(next.properties)
         for(const key of Object.keys(next.properties)) {
@@ -416,7 +415,7 @@ export class TypeBuilder {
     }
     
     /** `STANDARD`  Make all properties in schema object optional. */
-    public Partial<T extends TObject<TProperties>>(schema: T, options: ObjectOptions = {}): TObject<TPartial<T['properties']>> {
+    public Partial<T extends TObject<TProperties>>(schema: T, options: ObjectOptions = {}): TObject<StaticProperties<TPartial<T['properties']>>> {
         const next = { ...clone(schema), ...options }
         delete next.required
         for(const key of Object.keys(next.properties)) {
@@ -432,7 +431,7 @@ export class TypeBuilder {
     }
 
     /** `STANDARD` Picks property keys from the given object schema. */
-    public Pick<T extends TObject<TProperties>, K extends PropertyKeys<T['properties']>[]>(schema: T, keys: [...K], options: ObjectOptions = {}): TObject<Pick<T['properties'], K[number]>> {
+    public Pick<T extends TObject<any>, K extends (keyof T['_infer'])[]>(schema: T, keys: [...K], options: ObjectOptions = {}): TObject<StaticProperties<Pick<T['properties'], K[number]>>> {
         const next = { ...clone(schema), ...options }
         next.required = next.required ? next.required.filter((key: string) => keys.includes(key)) : undefined
         for(const key of Object.keys(next.properties)) {
@@ -442,7 +441,7 @@ export class TypeBuilder {
     }
     
     /** `STANDARD` Omits property keys from the given object schema. */
-    public Omit<T extends TObject<TProperties>, K extends PropertyKeys<T['properties']>[]>(schema: T, keys: [...K], options: ObjectOptions = {}): TObject<Omit<T['properties'], K[number]>> {
+    public Omit<T extends TObject<any>, K extends (keyof T['_infer'])[]>(schema: T, keys: [...K], options: ObjectOptions = {}): TObject<Omit<T['_infer'], K[number]>> {
         const next = { ...clone(schema), ...options }
         next.required = next.required ? next.required.filter((key: string) => !keys.includes(key)) : undefined
         for(const key of Object.keys(next.properties)) {
@@ -457,28 +456,28 @@ export class TypeBuilder {
     }
     
     /** `EXTENDED` Creates a `constructor` schema. */
-    public Constructor<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TConstructor<T, U> {
-        return { ...options, kind: ConstructorKind, type: 'constructor', arguments: args, returns };
+    public Constructor<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TConstructor<StaticConstructor<T, U>> {
+        return { ...options, kind: ConstructorKind, type: 'constructor', arguments: args, returns } as any
     }
 
     /** `EXTENDED` Creates a `function` schema. */
-    public Function<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TFunction<T, U> {
-        return { ...options, kind: FunctionKind, type: 'function', arguments: args, returns };
+    public Function<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TFunction<StaticFunction<T, U>> {
+        return { ...options, kind: FunctionKind, type: 'function', arguments: args, returns } as any
     }
 
     /** `EXTENDED` Creates a `Promise<T>` schema. */
-    public Promise<T extends TSchema>(item: T, options: CustomOptions = {}): TPromise<T> {
-        return { ...options, type: 'promise', kind: PromiseKind, item }
+    public Promise<T extends TSchema>(item: T, options: CustomOptions = {}): TPromise<StaticPromise<T>> {
+        return { ...options, type: 'promise', kind: PromiseKind, item } as any
     }
 
     /** `EXTENDED` Creates a `undefined` schema. */
     public Undefined(options: CustomOptions = {}): TUndefined {
-        return { ...options, type: 'undefined', kind: UndefinedKind }
+        return { ...options, type: 'undefined', kind: UndefinedKind } as any
     }
 
     /** `EXTENDED` Creates a `void` schema. */
     public Void(options: CustomOptions = {}): TVoid {
-        return { ...options, type: 'void', kind: VoidKind }
+        return { ...options, type: 'void', kind: VoidKind } as any
     }
     
     /** `EXPERIMENTAL` Creates a recursive type. */
@@ -496,7 +495,7 @@ export class TypeBuilder {
 
     /** `EXPERIMENTAL` Creates a container for schema definitions. */
     public Box<T extends TDefinitions>(definitions: T, options: CustomOptions = {}): TBox<T> {
-        return { ...options, kind: BoxKind, definitions }
+        return { ...options, kind: BoxKind, definitions } as any
     }
     
     /** `EXPERIMENTAL` References a schema inside a box. The referenced box must specify an `$id`. */

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -115,31 +115,37 @@ export type TNamespace <T extends TDefinitions> = { kind: typeof BoxKind, defini
 export type TDefinitions            = { [key: string]: TSchema }
 
 // ------------------------------------------------------------------------
+// Infer<T>
+// ------------------------------------------------------------------------
+
+export type Infer<T> = { '_infer': T }
+
+// ------------------------------------------------------------------------
 // Schema Types
 // ------------------------------------------------------------------------
 
-export type TEnumType               = Record<string, string | number>
-export type TKey                    = string | number
-export type TValue                  = string | number | boolean
-export type TRecordKey              = TString | TNumber | TKeyOf<any>
-export type TEnumKey<T = TKey>      = { type: 'number' | 'string', const: T }
-export type TProperties             = { [key: string]: TSchema }
-export type TTuple     <I>          = { _infer: I, kind: typeof TupleKind, type: 'array', items?: TSchema[], additionalItems?: false, minItems: number, maxItems: number } & CustomOptions
-export type TObject    <I>          = { _infer: I, kind: typeof ObjectKind, type: 'object', properties: TProperties, required?: string[] } & ObjectOptions
-export type TUnion     <I>          = { _infer: I, kind: typeof UnionKind, anyOf: TSchema[] } & CustomOptions
-export type TIntersect <I>          = { _infer: I, kind: typeof IntersectKind, type: 'object', allOf: TSchema[] } & IntersectOptions
-export type TKeyOf     <I>          = { _infer: I, kind: typeof KeyOfKind, type: 'string', enum: string[] } & CustomOptions
-export type TRecord    <I>          = { _infer: I, kind: typeof RecordKind, type: 'object', patternProperties: { [pattern: string]: TSchema } } & ObjectOptions
-export type TArray     <I>          = { _infer: I, kind: typeof ArrayKind, type: 'array', items: any } & ArrayOptions
-export type TLiteral   <I>          = { _infer: I, kind: typeof LiteralKind, const: TSchema } & CustomOptions
-export type TEnum      <I>          = { _infer: I, kind: typeof EnumKind, anyOf: TSchema } & CustomOptions
-export type TString                 = { _infer: string, kind: typeof StringKind, type: 'string' } & StringOptions<string>
-export type TNumber                 = { _infer: number, kind: typeof NumberKind, type: 'number' } & NumberOptions
-export type TInteger                = { _infer: number, kind: typeof IntegerKind, type: 'integer' } & NumberOptions
-export type TBoolean                = { _infer: boolean, kind: typeof BooleanKind, type: 'boolean' } & CustomOptions
-export type TNull                   = { _infer: null, kind: typeof NullKind, type: 'null' } & CustomOptions
-export type TUnknown                = { _infer: unknown, kind: typeof UnknownKind } & CustomOptions
-export type TAny                    = { _infer: any, kind: typeof AnyKind } & CustomOptions
+export type TEnumType           = Record<string, string | number>
+export type TKey                = string | number
+export type TValue              = string | number | boolean
+export type TRecordKey          = TString | TNumber | TKeyOf<any>
+export type TEnumKey<T = TKey>  = { type: 'number' | 'string', const: T }
+export type TProperties         = { [key: string]: TSchema }
+export type TTuple     <T>      = Infer<T> & { kind: typeof TupleKind, type: 'array', items?: TSchema[], additionalItems?: false, minItems: number, maxItems: number } & CustomOptions
+export type TObject    <T>      = Infer<T> & { kind: typeof ObjectKind, type: 'object', properties: TProperties, required?: string[] } & ObjectOptions
+export type TUnion     <T>      = Infer<T> & { kind: typeof UnionKind, anyOf: TSchema[] } & CustomOptions
+export type TIntersect <T>      = Infer<T> & { kind: typeof IntersectKind, type: 'object', allOf: TSchema[] } & IntersectOptions
+export type TKeyOf     <T>      = Infer<T> & { kind: typeof KeyOfKind, type: 'string', enum: string[] } & CustomOptions
+export type TRecord    <T>      = Infer<T> & { kind: typeof RecordKind, type: 'object', patternProperties: { [pattern: string]: TSchema } } & ObjectOptions
+export type TArray     <T>      = Infer<T> & { kind: typeof ArrayKind, type: 'array', items: any } & ArrayOptions
+export type TLiteral   <T>      = Infer<T> & { kind: typeof LiteralKind, const: TSchema } & CustomOptions
+export type TEnum      <T>      = Infer<T> & { kind: typeof EnumKind, anyOf: TSchema } & CustomOptions
+export type TString             = Infer<string>  & { kind: typeof StringKind, type: 'string' } & StringOptions<string>
+export type TNumber             = Infer<number>  & { kind: typeof NumberKind, type: 'number' } & NumberOptions
+export type TInteger            = Infer<number>  & { kind: typeof IntegerKind, type: 'integer' } & NumberOptions
+export type TBoolean            = Infer<boolean> & { kind: typeof BooleanKind, type: 'boolean' } & CustomOptions
+export type TNull               = Infer<null>    & { kind: typeof NullKind, type: 'null' } & CustomOptions
+export type TUnknown            = Infer<unknown> & { kind: typeof UnknownKind } & CustomOptions
+export type TAny                = Infer<any>     & { kind: typeof AnyKind } & CustomOptions
 
 // ------------------------------------------------------------------------
 // Schema Extended
@@ -150,11 +156,11 @@ export const FunctionKind    = Symbol('FunctionKind')
 export const PromiseKind     = Symbol('PromiseKind')
 export const UndefinedKind   = Symbol('UndefinedKind')
 export const VoidKind        = Symbol('VoidKind')
-export type TConstructor <I> = { _infer: I, kind: typeof ConstructorKind, type: 'constructor', arguments: TSchema[], returns: TSchema } & CustomOptions
-export type TFunction    <I> = { _infer: I, kind: typeof FunctionKind,    type: 'function', arguments: TSchema[], returns: TSchema } & CustomOptions
-export type TPromise     <I> = { _infer: I, kind: typeof PromiseKind,     type: 'promise', item: TSchema } & CustomOptions
-export type TUndefined       = { _infer: undefined, kind: typeof UndefinedKind, type: 'undefined' } & CustomOptions
-export type TVoid            = { _indef: void, kind: typeof VoidKind, type: 'void' } & CustomOptions
+export type TConstructor <T> = Infer<T> & { kind: typeof ConstructorKind, type: 'constructor', arguments: TSchema[], returns: TSchema } & CustomOptions
+export type TFunction    <T> = Infer<T> & { kind: typeof FunctionKind,    type: 'function', arguments: TSchema[], returns: TSchema } & CustomOptions
+export type TPromise     <T> = Infer<T> & { kind: typeof PromiseKind,     type: 'promise', item: TSchema } & CustomOptions
+export type TUndefined       = Infer<undefined> & { kind: typeof UndefinedKind, type: 'undefined' } & CustomOptions
+export type TVoid            = Infer<void>      & { kind: typeof VoidKind, type: 'void' } & CustomOptions
 
 // ------------------------------------------------------------------------
 // Schema
@@ -188,8 +194,6 @@ export type TSchema =
 // ------------------------------------------------------------------------
 
 export type UnionToIntersect<U>                                  = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
-export type ObjectPropertyKeys           <T>                     = T extends TObject<any> ? keyof T['_infer'] : never
-export type PropertyKeys                 <T extends TProperties> = keyof T
 export type ReadonlyOptionalPropertyKeys <T extends TProperties> = { [K in keyof T]: T[K] extends TReadonlyOptional<TSchema> ? K : never }[keyof T]
 export type ReadonlyPropertyKeys         <T extends TProperties> = { [K in keyof T]: T[K] extends TReadonly<TSchema> ? K : never }[keyof T]
 export type OptionalPropertyKeys         <T extends TProperties> = { [K in keyof T]: T[K] extends TOptional<TSchema> ? K : never }[keyof T]
@@ -199,19 +203,18 @@ export type StaticProperties<T extends TProperties> =
     { readonly [K in ReadonlyPropertyKeys<T>]:          Static<T[K]> } &
     {          [K in OptionalPropertyKeys<T>]?:         Static<T[K]> } &
     {          [K in RequiredPropertyKeys<T>]:          Static<T[K]> }
-export type StaticEnum        <T>                                       = T extends TEnumKey<infer U>[] ? U : never
-export type StaticKeyOf       <T extends TKey[]>                        = T extends Array<infer K> ? K : never
-export type StaticIntersect   <T extends readonly TSchema[]>            = UnionToIntersect<StaticUnion<T>>
-export type StaticUnion       <T extends readonly TSchema[]>            = { [K in keyof T]: Static<T[K]> }[number]
-export type StaticTuple       <T extends readonly TSchema[]>            = { [K in keyof T]: Static<T[K]> }
-export type StaticObject      <T extends TProperties>                   = StaticProperties<StaticProperties<T>>
-export type StaticRecord      <K extends TRecordKey, T extends TSchema> = K extends TString ? Record<string, Static<T>> : K extends TNumber ? Record<number, Static<T>> : K extends TKeyOf<any> ? Record<K['_infer'], Static<T>> : never
+export type StaticEnum        <T>                                               = T extends TEnumKey<infer U>[] ? U : never
+export type StaticKeyOf       <T extends TKey[]>                                = T extends Array<infer K> ? K : never
+export type StaticIntersect   <T extends readonly TSchema[]>                    = UnionToIntersect<StaticUnion<T>>
+export type StaticUnion       <T extends readonly TSchema[]>                    = { [K in keyof T]: Static<T[K]> }[number]
+export type StaticTuple       <T extends readonly TSchema[]>                    = { [K in keyof T]: Static<T[K]> }
+export type StaticObject      <T extends TProperties>                           = StaticProperties<StaticProperties<T>>
+export type StaticRecord      <K extends TRecordKey, T extends TSchema>         = K extends TString ? Record<string, Static<T>> : K extends TNumber ? Record<number, Static<T>> : K extends TKeyOf<any> ? Record<K['_infer'], Static<T>> : never
 export type StaticArray       <T extends TSchema>                               = Array<Static<T>>
 export type StaticLiteral     <T extends TValue>                                = T
 export type StaticConstructor <T extends readonly TSchema[], U extends TSchema> = new (...args: [...{ [K in keyof T]: Static<T[K]> }]) => Static<U>
 export type StaticFunction    <T extends readonly TSchema[], U extends TSchema> = (...args: [...{ [K in keyof T]: Static<T[K]> }]) => Static<U>
 export type StaticPromise     <T extends TSchema>                               = Promise<Static<T>>
-
 export type Static<T> =
     T extends TKeyOf<infer I>        ? I :
     T extends TIntersect<infer I>    ? I : 
@@ -260,22 +263,22 @@ function clone(object: any): any {
 
 export class TypeBuilder {
 
-    /** `STANDARD` Modifies a schema object property to be `readonly` and `optional`. */
+    /** `standard` Modifies an object property to be both readonly and optional */
     public ReadonlyOptional<T extends TSchema>(item: T): TReadonlyOptional<T> {
         return { ...item, modifier: ReadonlyOptionalModifier }
     }
 
-    /** `STANDARD` Modifies a schema object property to be `readonly`. */
+    /** `standard` Modifies an object property to be readonly */
     public Readonly<T extends TSchema>(item: T): TReadonly<T> {
         return { ...item, modifier: ReadonlyModifier }
     }
 
-    /** `STANDARD` Modifies a schema object property to be `optional`. */
+     /** `standard` Modifies an object property to be optional */
     public Optional<T extends TSchema>(item: T): TOptional<T> {
         return { ...item, modifier: OptionalModifier }
     }
 
-    /** `STANDARD` Creates a Tuple schema. */
+    /** `standard` Creates a type type */
     public Tuple<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TTuple<StaticTuple<T>> {
         const additionalItems = false
         const minItems = items.length
@@ -285,7 +288,7 @@ export class TypeBuilder {
             : { ...options, kind: TupleKind, type: 'array', minItems, maxItems } as any
     }
 
-    /** `STANDARD` Creates a `object` schema with the given properties. */
+    /** `standard` Creates an object type with the given properties */
     public Object<T extends TProperties>(properties: T, options: ObjectOptions = {}): TObject<StaticProperties<T>> {
         const property_names = Object.keys(properties)
         const optional = property_names.filter(name => {
@@ -301,80 +304,80 @@ export class TypeBuilder {
             { ...options, kind: ObjectKind, type: 'object', properties } as any
     }
 
-    /** `STANDARD` Creates an intersection schema. Note this function requires draft `2019-09` to constrain with `unevaluatedProperties`. */
+    /** `standard` Creates an intersection type. Note this function requires draft `2019-09` to constrain with `unevaluatedProperties` */
     public Intersect<T extends TSchema[]>(items: [...T], options: IntersectOptions = {}): TIntersect<StaticIntersect<T>> {
         return { ...options, kind: IntersectKind, type: 'object', allOf: items } as any
     }
     
-    /** `STANDARD` Creates a Union schema. */
+    /** `standard` Creates a union type */
     public Union<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TUnion<StaticUnion<T>> {
         return { ...options, kind: UnionKind, anyOf: items } as any
     }
 
-    /** `STANDARD` Creates an `Array<T>` schema. */
+    /** `standard` Creates an array type */
     public Array<T extends TSchema>(items: T, options: ArrayOptions = {}): TArray<StaticArray<T>> {
         return { ...options, kind: ArrayKind, type: 'array', items } as any
     }
     
-    /** `STANDARD` Creates an `Enum<T>` schema from a TypeScript `enum` definition. */
+    /** `standard` Creates an enum type from a TypeScript enum */
     public Enum<T extends TEnumType>(item: T, options: CustomOptions = {}): TEnum<StaticEnum<TEnumKey<T[keyof T]>[]>> {
         const values = Object.keys(item).filter(key => isNaN(key as any)).map(key => item[key]) as T[keyof T][]
         const anyOf  = values.map(value => typeof value === 'string' ? { type: 'string' as const, const: value } : { type: 'number' as const, const: value })
         return { ...options, kind: EnumKind, anyOf } as any
     }
 
-    /** `STANDARD` Creates a literal schema. Supports `string | number | boolean` values. */
+    /** `standard` Creates a literal type. Supports string, number and boolean values only */
     public Literal<T extends TValue>(value: T, options: CustomOptions = {}): TLiteral<StaticLiteral<T>> {
         return { ...options, kind: LiteralKind, const: value, type: typeof value as 'string' | 'number' | 'boolean' } as any
     }
 
-    /** `STANDARD` Creates a `string` schema. */
+    /** `standard` Creates a string type */
     public String<TCustomFormatOption extends string>(options: StringOptions<StringFormatOption | TCustomFormatOption> = {}): TString {
         return { ...options, kind: StringKind, type: 'string' } as any
     }
 
-    /** `STANDARD` Creates a `string` schema from a regular expression. */
+    /** `standard` Creates a string type from a regular expression */
     public RegEx(regex: RegExp, options: CustomOptions = {}): TString {
         return this.String({ ...options, pattern: regex.source }) as any
     }
 
-    /** `STANDARD` Creates a `number` schema. */
+    /** `standard` Creates a number type */
     public Number(options: NumberOptions = {}): TNumber {
         return { ...options, kind: NumberKind, type: 'number' } as any
     }
 
-    /** `STANDARD` Creates a `integer` schema. */
+    /** `standard` Creates an integer type */
     public Integer(options: NumberOptions = {}): TInteger {
         return { ...options, kind: IntegerKind, type: 'integer' } as any
     }
 
-    /** `STANDARD` Creates a `boolean` schema. */
+    /** `standard` Creates a boolean type */
     public Boolean(options: CustomOptions = {}): TBoolean {
         return { ...options, kind: BooleanKind, type: 'boolean' } as any
     }
 
-    /** `STANDARD` Creates a `null` schema. */
+    /** `standard` Creates a null type */
     public Null(options: CustomOptions = {}): TNull {
         return { ...options, kind: NullKind, type: 'null' } as any
     }
 
-    /** `STANDARD` Creates an `unknown` schema. */
+    /** `standard` Creates an unknown type */
     public Unknown(options: CustomOptions = {}): TUnknown {
         return { ...options, kind: UnknownKind } as any
     }
 
-    /** `STANDARD` Creates an `any` schema. */
+    /** `standard` Creates an any type */
     public Any(options: CustomOptions = {}): TAny {
         return { ...options, kind: AnyKind } as any
     }
     
-    /** `STANDARD` Creates a `keyof` schema. */
+    /** `standard` Creates a keyof type from the given object */
     public KeyOf<T extends TObject<any>>(schema: T, options: CustomOptions = {}): TKeyOf<keyof T['_infer']> {
-        const keys = Object.keys(schema.properties) as ObjectPropertyKeys<T>[]
+        const keys = Object.keys(schema.properties)
         return {...options, kind: KeyOfKind, type: 'string', enum: keys } as any
     }
     
-    /** `STANDARD` Creates a `Record<Keys, Value>` schema. */
+    /** `standard` Creates a record type */
     public Record<K extends TRecordKey, T extends TSchema>(key: K, value: T, options: ObjectOptions = {}): TRecord<StaticRecord<K, T>> {
         // @ts-ignore
         const pattern = key.kind === UnionKind  ? `^${key.anyOf.map((literal: TLiteral<StaticLiteral<TValue>>) => literal.const).join('|')}$` :
@@ -383,7 +386,7 @@ export class TypeBuilder {
         return { ...options, kind: RecordKind, type: 'object', patternProperties: { [pattern]: value } } as any
     }
 
-    /** `STANDARD` Make all properties in schema object required. */
+    /** `standard` Makes all properties in the given object type required */
     public Required<T extends TObject<any>>(schema: T, options: ObjectOptions = {}): TObject<Required<T['_infer']>> {
         const next = { ...clone(schema), ...options }
         next.required = Object.keys(next.properties)
@@ -399,7 +402,7 @@ export class TypeBuilder {
         return next
     }
     
-    /** `STANDARD`  Make all properties in schema object optional. */
+    /** `standard` Makes all properties in the given object type optional */
     public Partial<T extends TObject<any>>(schema: T, options: ObjectOptions = {}): TObject<Partial<T['_infer']>> {
         const next = { ...clone(schema), ...options }
         delete next.required
@@ -415,8 +418,8 @@ export class TypeBuilder {
         return next
     }
 
-    /** `STANDARD` Picks property keys from the given object schema. */
-    public Pick<T extends TObject<any>, K extends (keyof T['_infer'])[]>(schema: T, keys: [...K], options: ObjectOptions = {}): TObject<StaticProperties<Pick<T['properties'], K[number]>>> {
+    /** `standard` Picks property keys from the given object type */
+    public Pick<T extends TObject<any>, K extends (keyof T['_infer'])[]>(schema: T, keys: [...K], options: ObjectOptions = {}): TObject<Pick<T['_infer'], K[number]>> {
         const next = { ...clone(schema), ...options }
         next.required = next.required ? next.required.filter((key: string) => keys.includes(key)) : undefined
         for(const key of Object.keys(next.properties)) {
@@ -425,7 +428,7 @@ export class TypeBuilder {
         return next
     }
     
-    /** `STANDARD` Omits property keys from the given object schema. */
+    /** `standard` Omits property keys from the given object type */
     public Omit<T extends TObject<any>, K extends (keyof T['_infer'])[]>(schema: T, keys: [...K], options: ObjectOptions = {}): TObject<Omit<T['_infer'], K[number]>> {
         const next = { ...clone(schema), ...options }
         next.required = next.required ? next.required.filter((key: string) => !keys.includes(key)) : undefined
@@ -435,61 +438,60 @@ export class TypeBuilder {
         return next
     }
 
-    /** `STANDARD` Omits the `kind` and `modifier` properties from the given schema. */
+    /** `standard` Omits the `kind` and `modifier` properties from the underlying schema */
     public Strict<T extends TSchema>(schema: T, options: CustomOptions = {}): T {
         return JSON.parse(JSON.stringify({ ...options, ...schema })) as T
     }
     
-    /** `EXTENDED` Creates a `constructor` schema. */
+    /** `extended` Creates a constructor type */
     public Constructor<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TConstructor<StaticConstructor<T, U>> {
         return { ...options, kind: ConstructorKind, type: 'constructor', arguments: args, returns } as any
     }
 
-    /** `EXTENDED` Creates a `function` schema. */
+    /** `extended` Creates a function type */
     public Function<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TFunction<StaticFunction<T, U>> {
         return { ...options, kind: FunctionKind, type: 'function', arguments: args, returns } as any
     }
 
-    /** `EXTENDED` Creates a `Promise<T>` schema. */
+    /** `extended` Creates a promise type */
     public Promise<T extends TSchema>(item: T, options: CustomOptions = {}): TPromise<StaticPromise<T>> {
         return { ...options, type: 'promise', kind: PromiseKind, item } as any
     }
 
-    /** `EXTENDED` Creates a `undefined` schema. */
+    /** `extended` Creates a undefined type */
     public Undefined(options: CustomOptions = {}): TUndefined {
         return { ...options, type: 'undefined', kind: UndefinedKind } as any
     }
 
-    /** `EXTENDED` Creates a `void` schema. */
+    /** `extended` Creates a void type */
     public Void(options: CustomOptions = {}): TVoid {
         return { ...options, type: 'void', kind: VoidKind } as any
     }
     
-    /** `EXPERIMENTAL` Creates a recursive type. */
+    /** `experimental` Creates a recursive type */
     public Rec<T extends TSchema>(callback: (self: TAny) => T, options: CustomOptions = {}): T {
         const $id = options.$id || ''
         const self = callback({ $ref: `${$id}#/definitions/self` } as any)
         return { ...options, $ref: `${$id}#/definitions/self`, definitions: { self } } as unknown as T
     }
 
-    /** `EXPERIMENTAL` Creates a recursive type. Pending https://github.com/ajv-validator/ajv/issues/1709 */
+    /** `experimental` Creates a recursive type. Pending https://github.com/ajv-validator/ajv/issues/1709 */
     // public Rec<T extends TProperties>($id: string, callback: (self: TAny) => T, options: ObjectOptions = {}): TObject<T> {
     //     const properties = callback({ $recursiveRef: `${$id}` } as any)
     //     return { ...options, kind: ObjectKind, $id, $recursiveAnchor: true, type: 'object', properties }
     // }
 
-    /** `EXPERIMENTAL` Creates a container for schema definitions. */
+    /** `experimental` Creates a namespace for a set of related types */
     public Namespace<T extends TDefinitions>(definitions: T, options: CustomOptions = {}): TNamespace<T> {
         return { ...options, kind: BoxKind, definitions } as any
     }
     
-    /** `EXPERIMENTAL` References a schema inside a box. The referenced box must specify an `$id`. */
+    /** `experimental` References a type within a namespace. The referenced namespace must specify an `$id` */
     public Ref<T extends TNamespace<TDefinitions>, K extends keyof T['definitions']>(box: T, key: K): T['definitions'][K] 
     
-    /** `EXPERIMENTAL` References a schema. The referenced schema must specify an `$id`. */
+    /** `experimental` References type. The referenced type must specify an `$id` */
     public Ref<T extends TSchema>(schema: T): T
     
-    /** `EXPERIMENTAL` References a schema. */
     public Ref(...args: any[]): any {
         const $id = args[0]['$id'] || '' as string 
         const key = args[1]              as string


### PR DESCRIPTION
Updates:

- TypeBox static inference has been updated inline with additional inference constraints added in TypeScript 4.5. All types now include a phantom `_infer` property which contains the inference TS type for a given schema. The type of this property is inferred at the construction of the schema, and referenced directly via `Static<T>`.
- `Type.Box(...)` has been renamed to `Type.Namespace(...)` to draw an analogy with XML's `xmlns:` XSD types.
- `Type.Record(...)` updated to accept `Type.KeyOf(...)` instead of `Type.Union([...Type.Literal(...)])`. 