### PR TITLE
HKT Compatible TSchema Interface

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+## [0.22.2](https://www.npmjs.com/package/@sinclair/typebox/v/0.22.2)
+
+Updates:
+
+- The type `TSchema` is now expressed as an HKT compatible interface. All types now extend the `TSchema` interface and are themselves also expressed as interfaces.
+- The phantom property `_infer` has been renamed to `typebox:output`. Callers should not interact with this property as it is always `undefined` and used exclusively to optimize type inference.
+- TypeBox re-adds the ability to deeply introspect schema properties. This feature was temporarily removed on the `0.21.0` update to resolve deep instantiation errors on TypeScript 4.5.
+
 ## [0.21.2](https://www.npmjs.com/package/@sinclair/typebox/v/0.21.2)
 
 Updates:

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-## [0.22.2](https://www.npmjs.com/package/@sinclair/typebox/v/0.22.2)
+## [0.22.0](https://www.npmjs.com/package/@sinclair/typebox/v/0.22.0)
 
 Updates:
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,10 @@
 
 Updates:
 
-- The type `TSchema` is now expressed as an HKT compatible interface. All types now extend the `TSchema` interface and are themselves also expressed as interfaces.
-- The phantom property `_infer` has been renamed to `typebox:output`. Callers should not interact with this property as it is always `undefined` and used exclusively to optimize type inference.
-- TypeBox re-adds the ability to deeply introspect schema properties. This feature was temporarily removed on the `0.21.0` update to resolve deep instantiation errors on TypeScript 4.5.
-- The `Type.Box(...)` and `Type.Ref(...)` functions rename the property `definitions` to `$defs` inline with JSON schema convention.
+- The type `TSchema` is now expressed as an HKT compatible interface. All types now extend the `TSchema` interface and are themselves also expressed as interfaces. This work was undertaken to explore recursive type aliases in future releases.
+- The phantom property `_infer` has been renamed to `typebox:output`. Callers should not interact with this property as it will always be `undefined` and used exclusively for optimizing type inference in TypeScript 4.5 and above.
+- TypeBox re-adds the feature to deeply introspect schema properties. This feature was temporarily removed on the `0.21.0` update to resolve deep instantiation errors on TypeScript 4.5.
+- The `Type.Box(...)` and `Type.Rec(...)` functions internally rename the property `definitions` to `$defs` inline with JSON schema draft 2019-09 conventions. Reference [here](https://opis.io/json-schema/2.x/definitions.html).
 
 ## [0.21.2](https://www.npmjs.com/package/@sinclair/typebox/v/0.21.2)
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ Updates:
 - The type `TSchema` is now expressed as an HKT compatible interface. All types now extend the `TSchema` interface and are themselves also expressed as interfaces.
 - The phantom property `_infer` has been renamed to `typebox:output`. Callers should not interact with this property as it is always `undefined` and used exclusively to optimize type inference.
 - TypeBox re-adds the ability to deeply introspect schema properties. This feature was temporarily removed on the `0.21.0` update to resolve deep instantiation errors on TypeScript 4.5.
+- The `Type.Box(...)` and `Type.Ref(...)` functions rename the property `definitions` to `$defs` inline with JSON schema convention.
 
 ## [0.21.2](https://www.npmjs.com/package/@sinclair/typebox/v/0.21.2)
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -6,18 +6,14 @@ const T = Type.KeyOf(Type.Object({
     C: Type.Readonly(Type.String())
 }))
 
-const I = Type.Intersect([Type.String(), Type.Number()], {
-    
-})
+const K = Type.Union([Type.Literal('O'), Type.Literal('P')])
 
-// const T = Type.Union([Type.Number(), Type.String()])
+const R = Type.Record(T, Type.Number())
 
-// const A = Type.Object({ a: Type.String() })
-// const B = Type.Object({ b: Type.String() })
-// const C = Type.Object({ c: Type.String() })
-// const T = Type.Intersect([A, Type.Union([B, C])])
+type T = Static<typeof R>
 
-type A = Static<typeof T>
+
+
 
 
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,12 +1,24 @@
 import { Type, Static, TSchema } from '@sinclair/typebox';
 
+const T = Type.KeyOf(Type.Object({
+    A: Type.String(),
+    B: Type.String(),
+    C: Type.Readonly(Type.String())
+}))
 
-const A = Type.Object({ a: Type.String() })
-const B = Type.Object({ b: Type.String() })
-const C = Type.Object({ c: Type.String() })
-const E = Type.Object({ e: Type.String() })
-const F = Type.Object({ f: Type.String() })
-const T = Type.Intersect([A, Type.Union([Type.Intersect([B, C]), Type.Intersect([E, F])])])
+const I = Type.Intersect([Type.String(), Type.Number()], {
+    
+})
 
-console.log(JSON.stringify(T, null, 2))
+// const T = Type.Union([Type.Number(), Type.String()])
+
+// const A = Type.Object({ a: Type.String() })
+// const B = Type.Object({ b: Type.String() })
+// const C = Type.Object({ c: Type.String() })
+// const T = Type.Intersect([A, Type.Union([B, C])])
+
+type A = Static<typeof T>
+
+
+
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,17 +1,15 @@
-import { Type, Static, TSchema } from '@sinclair/typebox';
+import { Type, Static } from '@sinclair/typebox';
 
-const T = Type.KeyOf(Type.Object({
-    A: Type.String(),
-    B: Type.String(),
-    C: Type.Readonly(Type.String())
-}))
+const A = Type.Object({ a: Type.String() })
+const B = Type.Object({ b: Type.String() })
+const C = Type.Object({ c: Type.String() })
+const T = Type.Intersect([A, Type.Union([B, C])])
 
-const K = Type.Union([Type.Literal('O'), Type.Literal('P')])
+const N = Type.Constructor([Type.String(), Type.String()], Type.Null())
 
-const R = Type.Record(T, Type.Number())
+type T = Static<typeof T>
 
-type T = Static<typeof R>
-
+console.log(N)
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.15.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "json-schema",

--- a/readme.md
+++ b/readme.md
@@ -774,7 +774,9 @@ type T = Static<typeof T>                // type T = string | null
 //
 //--------------------------------------------------------------------------------------------
 
-function StringUnion<T extends string[]>(values: [...T]): TUnion<{[K in keyof T]: T[K] }[number]> {
+type IntoStringUnion<T> = {[K in keyof T]: T[K] extends string ? TLiteral<T[K]>: never }
+
+function StringUnion<T extends string[]>(values: [...T]): TUnion<IntoStringUnion<T>> {
     return { enum: values } as any
 }
 

--- a/spec/types/spec.ts
+++ b/spec/types/spec.ts
@@ -4,3 +4,5 @@ export const infer = <T extends TSchema>(_: T): Static<T> => null as any as Stat
 
 export * from 'tsd'
 
+
+

--- a/spec/types/typebox.d.ts
+++ b/spec/types/typebox.d.ts
@@ -68,9 +68,10 @@ export declare type TDefinitions = {
 };
 export declare type TNamespace<T extends TDefinitions> = {
     kind: typeof BoxKind;
-    definitions: T;
+    $defs: T;
 } & CustomOptions;
 export interface TSchema {
+    '#input': unknown;
     '#output': unknown;
 }
 export declare type TEnumType = Record<string, string | number>;
@@ -83,6 +84,14 @@ export declare type TEnumKey<T = TKey> = {
 };
 export interface TProperties {
     [key: string]: TSchema;
+}
+export interface TRecord<K extends TRecordKey, T extends TSchema> extends TSchema, ObjectOptions {
+    '#output': StaticRecord<K, T>;
+    kind: typeof RecordKind;
+    type: 'object';
+    patternProperties: {
+        [pattern: string]: T;
+    };
 }
 export interface TTuple<T extends TSchema[]> extends TSchema, CustomOptions {
     '#output': StaticTuple<T>;
@@ -116,14 +125,6 @@ export interface TKeyOf<T extends TKey[]> extends TSchema, CustomOptions {
     kind: typeof KeyOfKind;
     type: 'string';
     enum: T;
-}
-export interface TRecord<K extends TRecordKey, T extends TSchema> extends TSchema, ObjectOptions {
-    '#output': StaticRecord<K, T>;
-    kind: typeof RecordKind;
-    type: 'object';
-    patternProperties: {
-        [pattern: string]: T;
-    };
 }
 export interface TArray<T extends TSchema> extends TSchema, ArrayOptions {
     '#output': StaticArray<T>;
@@ -209,50 +210,49 @@ export interface TVoid extends TSchema, CustomOptions {
     kind: typeof VoidKind;
     type: 'void';
 }
-export declare type TRequired<T extends TProperties> = {
-    [K in keyof T]: T[K] extends TReadonlyOptional<infer U> ? TReadonly<U> : T[K] extends TReadonly<infer U> ? TReadonly<U> : T[K] extends TOptional<infer U> ? U : T[K];
-};
-export declare type TPartial<T extends TProperties> = {
-    [K in keyof T]: T[K] extends TReadonlyOptional<infer U> ? TReadonlyOptional<U> : T[K] extends TReadonly<infer U> ? TReadonlyOptional<U> : T[K] extends TOptional<infer U> ? TOptional<U> : TOptional<T[K]>;
-};
 export declare type UnionToIntersect<U> = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never;
-export declare type IntersectEvaluate<T extends readonly TSchema[]> = {
-    [K in keyof T]: Static<T[K]>;
-};
-export declare type IntersectReduce<I extends unknown, T extends readonly any[]> = T extends [infer A, ...infer B] ? IntersectReduce<I & A, B> : I;
-export declare type ReadonlyOptionalPropertyKeys<T extends TProperties> = {
+export declare type StaticReadonlyOptionalPropertyKeys<T extends TProperties> = {
     [K in keyof T]: T[K] extends TReadonlyOptional<TSchema> ? K : never;
 }[keyof T];
-export declare type ReadonlyPropertyKeys<T extends TProperties> = {
+export declare type StaticReadonlyPropertyKeys<T extends TProperties> = {
     [K in keyof T]: T[K] extends TReadonly<TSchema> ? K : never;
 }[keyof T];
-export declare type OptionalPropertyKeys<T extends TProperties> = {
+export declare type StaticOptionalPropertyKeys<T extends TProperties> = {
     [K in keyof T]: T[K] extends TOptional<TSchema> ? K : never;
 }[keyof T];
-export declare type RequiredPropertyKeys<T extends TProperties> = keyof Omit<T, ReadonlyOptionalPropertyKeys<T> | ReadonlyPropertyKeys<T> | OptionalPropertyKeys<T>>;
-export declare type ReduceStaticProperties<T> = {
-    [K in keyof T]: T[K];
+export declare type StaticRequiredPropertyKeys<T extends TProperties> = keyof Omit<T, StaticReadonlyOptionalPropertyKeys<T> | StaticReadonlyPropertyKeys<T> | StaticOptionalPropertyKeys<T>>;
+export declare type StaticIntersectEvaluate<T extends readonly TSchema[]> = {
+    [K in keyof T]: Static<T[K]>;
+};
+export declare type StaticIntersectReduce<I extends unknown, T extends readonly any[]> = T extends [infer A, ...infer B] ? StaticIntersectReduce<I & A, B> : I;
+export declare type StaticRequired<T extends TProperties> = {
+    [K in keyof T]: T[K] extends TReadonlyOptional<infer U> ? TReadonly<U> : T[K] extends TReadonly<infer U> ? TReadonly<U> : T[K] extends TOptional<infer U> ? U : T[K];
+};
+export declare type StaticPartial<T extends TProperties> = {
+    [K in keyof T]: T[K] extends TReadonlyOptional<infer U> ? TReadonlyOptional<U> : T[K] extends TReadonly<infer U> ? TReadonlyOptional<U> : T[K] extends TOptional<infer U> ? TOptional<U> : TOptional<T[K]>;
 };
 export declare type StaticProperties<T extends TProperties> = {
-    readonly [K in ReadonlyOptionalPropertyKeys<T>]?: Static<T[K]>;
+    readonly [K in StaticReadonlyOptionalPropertyKeys<T>]?: Static<T[K]>;
 } & {
-    readonly [K in ReadonlyPropertyKeys<T>]: Static<T[K]>;
+    readonly [K in StaticReadonlyPropertyKeys<T>]: Static<T[K]>;
 } & {
-    [K in OptionalPropertyKeys<T>]?: Static<T[K]>;
+    [K in StaticOptionalPropertyKeys<T>]?: Static<T[K]>;
 } & {
-    [K in RequiredPropertyKeys<T>]: Static<T[K]>;
+    [K in StaticRequiredPropertyKeys<T>]: Static<T[K]>;
 };
 export declare type StaticRecord<K extends TRecordKey, T extends TSchema> = K extends TString ? Record<string, Static<T>> : K extends TNumber ? Record<number, Static<T>> : K extends TKeyOf<TKey[]> ? Record<K['#output'], Static<T>> : K extends TUnion<TSchema[]> ? Record<K['#output'], Static<T>> : never;
 export declare type StaticEnum<T> = T extends TEnumKey<infer U>[] ? U : never;
 export declare type StaticKeyOf<T extends TKey[]> = T extends Array<infer K> ? K : never;
-export declare type StaticIntersect<T extends readonly TSchema[]> = IntersectReduce<unknown, IntersectEvaluate<T>>;
+export declare type StaticIntersect<T extends readonly TSchema[]> = StaticIntersectReduce<unknown, StaticIntersectEvaluate<T>>;
 export declare type StaticUnion<T extends readonly TSchema[]> = {
     [K in keyof T]: Static<T[K]>;
 }[number];
 export declare type StaticTuple<T extends readonly TSchema[]> = {
     [K in keyof T]: Static<T[K]>;
 };
-export declare type StaticObject<T extends TProperties> = ReduceStaticProperties<StaticProperties<T>>;
+export declare type StaticObject<T extends TProperties> = StaticProperties<T> extends infer I ? {
+    [K in keyof I]: I[K];
+} : never;
 export declare type StaticArray<T extends TSchema> = Array<Static<T>>;
 export declare type StaticLiteral<T extends TValue> = T;
 export declare type StaticParameters<T extends readonly TSchema[]> = {
@@ -263,76 +263,74 @@ export declare type StaticFunction<T extends readonly TSchema[], U extends TSche
 export declare type StaticPromise<T extends TSchema> = Promise<Static<T>>;
 export declare type Static<T> = T extends TSchema ? T['#output'] : never;
 export declare class TypeBuilder {
-    /** `standard` Modifies an object property to be both readonly and optional */
+    /** `Standard` Modifies an object property to be both readonly and optional */
     ReadonlyOptional<T extends TSchema>(item: T): TReadonlyOptional<T>;
-    /** `standard` Modifies an object property to be readonly */
+    /** `Standard` Modifies an object property to be readonly */
     Readonly<T extends TSchema>(item: T): TReadonly<T>;
-    /** `standard` Modifies an object property to be optional */
+    /** `Standard` Modifies an object property to be optional */
     Optional<T extends TSchema>(item: T): TOptional<T>;
-    /** `standard` Creates a type type */
+    /** `Standard` Creates a type type */
     Tuple<T extends TSchema[]>(items: [...T], options?: CustomOptions): TTuple<T>;
-    /** `standard` Creates an object type with the given properties */
+    /** `Standard` Creates an object type with the given properties */
     Object<T extends TProperties>(properties: T, options?: ObjectOptions): TObject<T>;
-    /** `standard` Creates an intersection type. Note this function requires draft `2019-09` to constrain with `unevaluatedProperties` */
+    /** `Standard` Creates an intersect type. */
     Intersect<T extends TSchema[]>(items: [...T], options?: IntersectOptions): TIntersect<T>;
-    /** `standard` Creates a union type */
+    /** `Standard` Creates a union type */
     Union<T extends TSchema[]>(items: [...T], options?: CustomOptions): TUnion<T>;
-    /** `standard` Creates an array type */
+    /** `Standard` Creates an array type */
     Array<T extends TSchema>(items: T, options?: ArrayOptions): TArray<T>;
-    /** `standard` Creates an enum type from a TypeScript enum */
+    /** `Standard` Creates an enum type from a TypeScript enum */
     Enum<T extends TEnumType>(item: T, options?: CustomOptions): TEnum<TEnumKey<T[keyof T]>[]>;
-    /** `standard` Creates a literal type. Supports string, number and boolean values only */
+    /** `Standard` Creates a literal type. Supports string, number and boolean values only */
     Literal<T extends TValue>(value: T, options?: CustomOptions): TLiteral<T>;
-    /** `standard` Creates a string type */
+    /** `Standard` Creates a string type */
     String<TCustomFormatOption extends string>(options?: StringOptions<StringFormatOption | TCustomFormatOption>): TString;
-    /** `standard` Creates a string type from a regular expression */
+    /** `Standard` Creates a string type from a regular expression */
     RegEx(regex: RegExp, options?: CustomOptions): TString;
-    /** `standard` Creates a number type */
+    /** `Standard` Creates a number type */
     Number(options?: NumberOptions): TNumber;
-    /** `standard` Creates an integer type */
+    /** `Standard` Creates an integer type */
     Integer(options?: NumberOptions): TInteger;
-    /** `standard` Creates a boolean type */
+    /** `Standard` Creates a boolean type */
     Boolean(options?: CustomOptions): TBoolean;
-    /** `standard` Creates a null type */
+    /** `Standard` Creates a null type */
     Null(options?: CustomOptions): TNull;
-    /** `standard` Creates an unknown type */
+    /** `Standard` Creates an unknown type */
     Unknown(options?: CustomOptions): TUnknown;
-    /** `standard` Creates an any type */
+    /** `Standard` Creates an any type */
     Any(options?: CustomOptions): TAny;
-    /** `standard` Creates a keyof type from the given object */
-    KeyOf<T extends TObject<TProperties>>(schema: T, options?: CustomOptions): TKeyOf<{
-        [K in keyof T['properties']]: K extends string ? K : never;
-    }[number]>;
-    /** `standard` Creates a record type */
+    /** `Standard` Creates a keyof type from the given object */
+    KeyOf<T extends TObject<TProperties>>(schema: T, options?: CustomOptions): TKeyOf<(keyof T['properties'])[]>;
+    /** `Standard` Creates a record type */
     Record<K extends TRecordKey, T extends TSchema>(key: K, value: T, options?: ObjectOptions): TRecord<K, T>;
-    /** `standard` Makes all properties in the given object type required */
-    Required<T extends TObject<any>>(schema: T, options?: ObjectOptions): TObject<TRequired<T['properties']>>;
-    /** `standard` Makes all properties in the given object type optional */
-    Partial<T extends TObject<any>>(schema: T, options?: ObjectOptions): TObject<TPartial<T['properties']>>;
-    /** `standard` Picks property keys from the given object type */
+    /** `Standard` Makes all properties in the given object type required */
+    Required<T extends TObject<any>>(schema: T, options?: ObjectOptions): TObject<StaticRequired<T['properties']>>;
+    /** `Standard` Makes all properties in the given object type optional */
+    Partial<T extends TObject<any>>(schema: T, options?: ObjectOptions): TObject<StaticPartial<T['properties']>>;
+    /** `Standard` Picks property keys from the given object type */
     Pick<T extends TObject<TProperties>, K extends (keyof T['properties'])[]>(schema: T, keys: [...K], options?: ObjectOptions): TObject<Pick<T['properties'], K[number]>>;
-    /** `standard` Omits property keys from the given object type */
+    /** `Standard` Omits property keys from the given object type */
     Omit<T extends TObject<any>, K extends (keyof T['properties'])[]>(schema: T, keys: [...K], options?: ObjectOptions): TObject<Omit<T['properties'], K[number]>>;
-    /** `standard` Omits the `kind` and `modifier` properties from the underlying schema */
+    /** `Standard` Omits the `kind` and `modifier` properties from the underlying schema */
     Strict<T extends TSchema>(schema: T, options?: CustomOptions): T;
-    /** `extended` Creates a constructor type */
+    /** `Extended` Creates a constructor type */
     Constructor<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options?: CustomOptions): TConstructor<T, U>;
-    /** `extended` Creates a function type */
+    /** `Extended` Creates a function type */
     Function<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options?: CustomOptions): TFunction<T, U>;
-    /** `extended` Creates a promise type */
+    /** `Extended` Creates a promise type */
     Promise<T extends TSchema>(item: T, options?: CustomOptions): TPromise<T>;
-    /** `extended` Creates a undefined type */
+    /** `Extended` Creates a undefined type */
     Undefined(options?: CustomOptions): TUndefined;
-    /** `extended` Creates a void type */
+    /** `Extended` Creates a void type */
     Void(options?: CustomOptions): TVoid;
-    /** `experimental` Creates a recursive type */
+    /** `Experimental` Creates a recursive type */
     Rec<T extends TSchema>(callback: (self: TAny) => T, options?: CustomOptions): T;
-    /** `experimental` Creates a recursive type. Pending https://github.com/ajv-validator/ajv/issues/1709 */
-    /** `experimental` Creates a namespace for a set of related types */
-    Namespace<T extends TDefinitions>(definitions: T, options?: CustomOptions): TNamespace<T>;
-    /** `experimental` References a type within a namespace. The referenced namespace must specify an `$id` */
-    Ref<T extends TNamespace<TDefinitions>, K extends keyof T['definitions']>(box: T, key: K): T['definitions'][K];
-    /** `experimental` References type. The referenced type must specify an `$id` */
+    /** `Experimental` Creates a recursive type. Pending https://github.com/ajv-validator/ajv/issues/1709 */
+    /** `Experimental` Creates a namespace for a set of related types */
+    Namespace<T extends TDefinitions>($defs: T, options?: CustomOptions): TNamespace<T>;
+    /** `Experimental` References a type within a namespace. The referenced namespace must specify an `$id` */
+    Ref<T extends TNamespace<TDefinitions>, K extends keyof T['$defs']>(box: T, key: K): T['$defs'][K];
+    /** `Experimental` References type. The referenced type must specify an `$id` */
     Ref<T extends TSchema>(schema: T): T;
 }
 export declare const Type: TypeBuilder;

--- a/spec/types/typebox.d.ts
+++ b/spec/types/typebox.d.ts
@@ -70,125 +70,151 @@ export declare type TNamespace<T extends TDefinitions> = {
     kind: typeof BoxKind;
     definitions: T;
 } & CustomOptions;
-export declare type Infer<T> = {
-    '_infer': T;
-};
+export interface TSchema {
+    '#output': unknown;
+}
 export declare type TEnumType = Record<string, string | number>;
-export declare type TKey = string | number;
+export declare type TKey = string | number | symbol;
 export declare type TValue = string | number | boolean;
-export declare type TRecordKey = TString | TNumber | TKeyOf<any> | TUnion<string | number>;
+export declare type TRecordKey = TString | TNumber | TKeyOf<any> | TUnion<any>;
 export declare type TEnumKey<T = TKey> = {
     type: 'number' | 'string';
     const: T;
 };
-export declare type TProperties = {
+export interface TProperties {
     [key: string]: TSchema;
-};
-export declare type TTuple<I> = Infer<I> & {
+}
+export interface TTuple<T extends TSchema[]> extends TSchema, CustomOptions {
+    '#output': StaticTuple<T>;
     kind: typeof TupleKind;
     type: 'array';
-    items?: TSchema[];
+    items?: T;
     additionalItems?: false;
     minItems: number;
     maxItems: number;
-} & CustomOptions;
-export declare type TObject<I> = Infer<I> & {
+}
+export interface TObject<T extends TProperties> extends TSchema, ObjectOptions {
+    '#output': StaticObject<T>;
     kind: typeof ObjectKind;
     type: 'object';
-    properties: TProperties;
+    properties: T;
     required?: string[];
-} & ObjectOptions;
-export declare type TUnion<I> = Infer<I> & {
+}
+export interface TUnion<T extends TSchema[]> extends TSchema, CustomOptions {
+    '#output': StaticUnion<T>;
     kind: typeof UnionKind;
-    anyOf: TSchema[];
-} & CustomOptions;
-export declare type TIntersect<I> = Infer<I> & {
+    anyOf: T;
+}
+export interface TIntersect<T extends TSchema[]> extends TSchema, IntersectOptions {
+    '#output': StaticIntersect<T>;
     kind: typeof IntersectKind;
     type: 'object';
-    allOf: TSchema[];
-} & IntersectOptions;
-export declare type TKeyOf<I> = Infer<I> & {
+    allOf: T;
+}
+export interface TKeyOf<T extends TKey[]> extends TSchema, CustomOptions {
+    '#output': StaticKeyOf<T>;
     kind: typeof KeyOfKind;
     type: 'string';
-    enum: string[];
-} & CustomOptions;
-export declare type TRecord<I> = Infer<I> & {
+    enum: T;
+}
+export interface TRecord<K extends TRecordKey, T extends TSchema> extends TSchema, ObjectOptions {
+    '#output': StaticRecord<K, T>;
     kind: typeof RecordKind;
     type: 'object';
     patternProperties: {
-        [pattern: string]: TSchema;
+        [pattern: string]: T;
     };
-} & ObjectOptions;
-export declare type TArray<I> = Infer<I> & {
+}
+export interface TArray<T extends TSchema> extends TSchema, ArrayOptions {
+    '#output': StaticArray<T>;
     kind: typeof ArrayKind;
     type: 'array';
-    items: any;
-} & ArrayOptions;
-export declare type TLiteral<I> = Infer<I> & {
+    items: T;
+}
+export interface TLiteral<T extends TValue> extends TSchema, CustomOptions {
+    '#output': StaticLiteral<T>;
     kind: typeof LiteralKind;
-    const: TValue;
-} & CustomOptions;
-export declare type TEnum<I> = Infer<I> & {
+    const: T;
+}
+export interface TEnum<T extends TEnumKey[]> extends TSchema, CustomOptions {
+    '#output': StaticEnum<T>;
     kind: typeof EnumKind;
-    anyOf: TSchema;
-} & CustomOptions;
-export declare type TString = Infer<string> & {
+    anyOf: T;
+}
+export interface TString extends TSchema, StringOptions<string> {
+    '#output': string;
     kind: typeof StringKind;
     type: 'string';
-} & StringOptions<string>;
-export declare type TNumber = Infer<number> & {
+}
+export interface TNumber extends TSchema, NumberOptions {
+    '#output': number;
     kind: typeof NumberKind;
     type: 'number';
-} & NumberOptions;
-export declare type TInteger = Infer<number> & {
+}
+export interface TInteger extends TSchema, NumberOptions {
+    '#output': number;
     kind: typeof IntegerKind;
     type: 'integer';
-} & NumberOptions;
-export declare type TBoolean = Infer<boolean> & {
+}
+export interface TBoolean extends TSchema, CustomOptions {
+    '#output': boolean;
     kind: typeof BooleanKind;
     type: 'boolean';
-} & CustomOptions;
-export declare type TNull = Infer<null> & {
+}
+export interface TNull extends TSchema, CustomOptions {
+    '#output': null;
     kind: typeof NullKind;
     type: 'null';
-} & CustomOptions;
-export declare type TUnknown = Infer<unknown> & {
+}
+export interface TUnknown extends TSchema, CustomOptions {
+    '#output': unknown;
     kind: typeof UnknownKind;
-} & CustomOptions;
-export declare type TAny = Infer<any> & {
+}
+export interface TAny extends TSchema, CustomOptions {
+    '#output': any;
     kind: typeof AnyKind;
-} & CustomOptions;
+}
 export declare const ConstructorKind: unique symbol;
 export declare const FunctionKind: unique symbol;
 export declare const PromiseKind: unique symbol;
 export declare const UndefinedKind: unique symbol;
 export declare const VoidKind: unique symbol;
-export declare type TConstructor<T> = Infer<T> & {
+export interface TConstructor<T extends TSchema[], U extends TSchema> extends TSchema, CustomOptions {
+    '#output': StaticConstructor<T, U>;
     kind: typeof ConstructorKind;
     type: 'constructor';
     arguments: TSchema[];
     returns: TSchema;
-} & CustomOptions;
-export declare type TFunction<T> = Infer<T> & {
+}
+export interface TFunction<T extends TSchema[], U extends TSchema> extends TSchema, CustomOptions {
+    '#output': StaticFunction<T, U>;
     kind: typeof FunctionKind;
     type: 'function';
     arguments: TSchema[];
     returns: TSchema;
-} & CustomOptions;
-export declare type TPromise<T> = Infer<T> & {
+}
+export interface TPromise<T extends TSchema> extends TSchema, CustomOptions {
+    '#output': StaticPromise<T>;
     kind: typeof PromiseKind;
     type: 'promise';
     item: TSchema;
-} & CustomOptions;
-export declare type TUndefined = Infer<undefined> & {
+}
+export interface TUndefined extends TSchema, CustomOptions {
+    '#output': undefined;
     kind: typeof UndefinedKind;
     type: 'undefined';
-} & CustomOptions;
-export declare type TVoid = Infer<void> & {
+}
+export interface TVoid extends TSchema, CustomOptions {
+    '#output': void;
     kind: typeof VoidKind;
     type: 'void';
-} & CustomOptions;
-export declare type TSchema = TIntersect<any> | TUnion<any> | TTuple<any> | TObject<any> | TKeyOf<any> | TRecord<any> | TArray<any> | TEnum<any> | TLiteral<any> | TString | TNumber | TInteger | TBoolean | TNull | TUnknown | TAny | TConstructor<any> | TFunction<any> | TPromise<any> | TUndefined | TVoid;
+}
+export declare type TRequired<T extends TProperties> = {
+    [K in keyof T]: T[K] extends TReadonlyOptional<infer U> ? TReadonly<U> : T[K] extends TReadonly<infer U> ? TReadonly<U> : T[K] extends TOptional<infer U> ? U : T[K];
+};
+export declare type TPartial<T extends TProperties> = {
+    [K in keyof T]: T[K] extends TReadonlyOptional<infer U> ? TReadonlyOptional<U> : T[K] extends TReadonly<infer U> ? TReadonlyOptional<U> : T[K] extends TOptional<infer U> ? TOptional<U> : TOptional<T[K]>;
+};
 export declare type UnionToIntersect<U> = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never;
 export declare type IntersectEvaluate<T extends readonly TSchema[]> = {
     [K in keyof T]: Static<T[K]>;
@@ -204,6 +230,9 @@ export declare type OptionalPropertyKeys<T extends TProperties> = {
     [K in keyof T]: T[K] extends TOptional<TSchema> ? K : never;
 }[keyof T];
 export declare type RequiredPropertyKeys<T extends TProperties> = keyof Omit<T, ReadonlyOptionalPropertyKeys<T> | ReadonlyPropertyKeys<T> | OptionalPropertyKeys<T>>;
+export declare type ReduceStaticProperties<T> = {
+    [K in keyof T]: T[K];
+};
 export declare type StaticProperties<T extends TProperties> = {
     readonly [K in ReadonlyOptionalPropertyKeys<T>]?: Static<T[K]>;
 } & {
@@ -213,7 +242,7 @@ export declare type StaticProperties<T extends TProperties> = {
 } & {
     [K in RequiredPropertyKeys<T>]: Static<T[K]>;
 };
-export declare type StaticRecord<K extends TRecordKey, T extends TSchema> = K extends TString ? Record<string, Static<T>> : K extends TNumber ? Record<number, Static<T>> : K extends TKeyOf<any> ? Record<K['_infer'], Static<T>> : K extends TUnion<any> ? Record<K['_infer'], Static<T>> : never;
+export declare type StaticRecord<K extends TRecordKey, T extends TSchema> = K extends TString ? Record<string, Static<T>> : K extends TNumber ? Record<number, Static<T>> : K extends TKeyOf<TKey[]> ? Record<K['#output'], Static<T>> : K extends TUnion<TSchema[]> ? Record<K['#output'], Static<T>> : never;
 export declare type StaticEnum<T> = T extends TEnumKey<infer U>[] ? U : never;
 export declare type StaticKeyOf<T extends TKey[]> = T extends Array<infer K> ? K : never;
 export declare type StaticIntersect<T extends readonly TSchema[]> = IntersectReduce<unknown, IntersectEvaluate<T>>;
@@ -223,19 +252,16 @@ export declare type StaticUnion<T extends readonly TSchema[]> = {
 export declare type StaticTuple<T extends readonly TSchema[]> = {
     [K in keyof T]: Static<T[K]>;
 };
-export declare type StaticObject<T extends TProperties> = StaticProperties<StaticProperties<T>>;
+export declare type StaticObject<T extends TProperties> = ReduceStaticProperties<StaticProperties<T>>;
 export declare type StaticArray<T extends TSchema> = Array<Static<T>>;
 export declare type StaticLiteral<T extends TValue> = T;
-export declare type StaticConstructor<T extends readonly TSchema[], U extends TSchema> = new (...args: [...{
+export declare type StaticParameters<T extends readonly TSchema[]> = {
     [K in keyof T]: Static<T[K]>;
-}]) => Static<U>;
-export declare type StaticFunction<T extends readonly TSchema[], U extends TSchema> = (...args: [...{
-    [K in keyof T]: Static<T[K]>;
-}]) => Static<U>;
+};
+export declare type StaticConstructor<T extends readonly TSchema[], U extends TSchema> = new (...args: [...StaticParameters<T>]) => Static<U>;
+export declare type StaticFunction<T extends readonly TSchema[], U extends TSchema> = (...args: [...StaticParameters<T>]) => Static<U>;
 export declare type StaticPromise<T extends TSchema> = Promise<Static<T>>;
-export declare type Static<T> = T extends TKeyOf<infer I> ? I : T extends TIntersect<infer I> ? I : T extends TUnion<infer I> ? I : T extends TTuple<infer I> ? I : T extends TObject<infer I> ? {
-    [K in keyof I]: I[K];
-} : T extends TRecord<infer I> ? I : T extends TArray<infer I> ? I : T extends TEnum<infer I> ? I : T extends TLiteral<infer I> ? I : T extends TString ? T['_infer'] : T extends TNumber ? T['_infer'] : T extends TInteger ? T['_infer'] : T extends TBoolean ? T['_infer'] : T extends TNull ? T['_infer'] : T extends TUnknown ? T['_infer'] : T extends TAny ? T['_infer'] : T extends TConstructor<infer I> ? I : T extends TFunction<infer I> ? I : T extends TPromise<infer I> ? I : T extends TUndefined ? T['_infer'] : T extends TVoid ? T['_infer'] : never;
+export declare type Static<T> = T extends TSchema ? T['#output'] : never;
 export declare class TypeBuilder {
     /** `standard` Modifies an object property to be both readonly and optional */
     ReadonlyOptional<T extends TSchema>(item: T): TReadonlyOptional<T>;
@@ -244,19 +270,19 @@ export declare class TypeBuilder {
     /** `standard` Modifies an object property to be optional */
     Optional<T extends TSchema>(item: T): TOptional<T>;
     /** `standard` Creates a type type */
-    Tuple<T extends TSchema[]>(items: [...T], options?: CustomOptions): TTuple<StaticTuple<T>>;
+    Tuple<T extends TSchema[]>(items: [...T], options?: CustomOptions): TTuple<T>;
     /** `standard` Creates an object type with the given properties */
-    Object<T extends TProperties>(properties: T, options?: ObjectOptions): TObject<StaticProperties<T>>;
+    Object<T extends TProperties>(properties: T, options?: ObjectOptions): TObject<T>;
     /** `standard` Creates an intersection type. Note this function requires draft `2019-09` to constrain with `unevaluatedProperties` */
-    Intersect<T extends TSchema[]>(items: [...T], options?: IntersectOptions): TIntersect<StaticIntersect<T>>;
+    Intersect<T extends TSchema[]>(items: [...T], options?: IntersectOptions): TIntersect<T>;
     /** `standard` Creates a union type */
-    Union<T extends TSchema[]>(items: [...T], options?: CustomOptions): TUnion<StaticUnion<T>>;
+    Union<T extends TSchema[]>(items: [...T], options?: CustomOptions): TUnion<T>;
     /** `standard` Creates an array type */
-    Array<T extends TSchema>(items: T, options?: ArrayOptions): TArray<StaticArray<T>>;
+    Array<T extends TSchema>(items: T, options?: ArrayOptions): TArray<T>;
     /** `standard` Creates an enum type from a TypeScript enum */
-    Enum<T extends TEnumType>(item: T, options?: CustomOptions): TEnum<StaticEnum<TEnumKey<T[keyof T]>[]>>;
+    Enum<T extends TEnumType>(item: T, options?: CustomOptions): TEnum<TEnumKey<T[keyof T]>[]>;
     /** `standard` Creates a literal type. Supports string, number and boolean values only */
-    Literal<T extends TValue>(value: T, options?: CustomOptions): TLiteral<StaticLiteral<T>>;
+    Literal<T extends TValue>(value: T, options?: CustomOptions): TLiteral<T>;
     /** `standard` Creates a string type */
     String<TCustomFormatOption extends string>(options?: StringOptions<StringFormatOption | TCustomFormatOption>): TString;
     /** `standard` Creates a string type from a regular expression */
@@ -274,25 +300,27 @@ export declare class TypeBuilder {
     /** `standard` Creates an any type */
     Any(options?: CustomOptions): TAny;
     /** `standard` Creates a keyof type from the given object */
-    KeyOf<T extends TObject<any>>(schema: T, options?: CustomOptions): TKeyOf<keyof T['_infer']>;
+    KeyOf<T extends TObject<TProperties>>(schema: T, options?: CustomOptions): TKeyOf<{
+        [K in keyof T['properties']]: K extends string ? K : never;
+    }[number]>;
     /** `standard` Creates a record type */
-    Record<K extends TRecordKey, T extends TSchema>(key: K, value: T, options?: ObjectOptions): TRecord<StaticRecord<K, T>>;
+    Record<K extends TRecordKey, T extends TSchema>(key: K, value: T, options?: ObjectOptions): TRecord<K, T>;
     /** `standard` Makes all properties in the given object type required */
-    Required<T extends TObject<any>>(schema: T, options?: ObjectOptions): TObject<Required<T['_infer']>>;
+    Required<T extends TObject<any>>(schema: T, options?: ObjectOptions): TObject<TRequired<T['properties']>>;
     /** `standard` Makes all properties in the given object type optional */
-    Partial<T extends TObject<any>>(schema: T, options?: ObjectOptions): TObject<Partial<T['_infer']>>;
+    Partial<T extends TObject<any>>(schema: T, options?: ObjectOptions): TObject<TPartial<T['properties']>>;
     /** `standard` Picks property keys from the given object type */
-    Pick<T extends TObject<any>, K extends (keyof T['_infer'])[]>(schema: T, keys: [...K], options?: ObjectOptions): TObject<Pick<T['_infer'], K[number]>>;
+    Pick<T extends TObject<TProperties>, K extends (keyof T['properties'])[]>(schema: T, keys: [...K], options?: ObjectOptions): TObject<Pick<T['properties'], K[number]>>;
     /** `standard` Omits property keys from the given object type */
-    Omit<T extends TObject<any>, K extends (keyof T['_infer'])[]>(schema: T, keys: [...K], options?: ObjectOptions): TObject<Omit<T['_infer'], K[number]>>;
+    Omit<T extends TObject<any>, K extends (keyof T['properties'])[]>(schema: T, keys: [...K], options?: ObjectOptions): TObject<Omit<T['properties'], K[number]>>;
     /** `standard` Omits the `kind` and `modifier` properties from the underlying schema */
     Strict<T extends TSchema>(schema: T, options?: CustomOptions): T;
     /** `extended` Creates a constructor type */
-    Constructor<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options?: CustomOptions): TConstructor<StaticConstructor<T, U>>;
+    Constructor<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options?: CustomOptions): TConstructor<T, U>;
     /** `extended` Creates a function type */
-    Function<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options?: CustomOptions): TFunction<StaticFunction<T, U>>;
+    Function<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options?: CustomOptions): TFunction<T, U>;
     /** `extended` Creates a promise type */
-    Promise<T extends TSchema>(item: T, options?: CustomOptions): TPromise<StaticPromise<T>>;
+    Promise<T extends TSchema>(item: T, options?: CustomOptions): TPromise<T>;
     /** `extended` Creates a undefined type */
     Undefined(options?: CustomOptions): TUndefined;
     /** `extended` Creates a void type */

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -246,22 +246,22 @@ function clone(object: any): any {
 
 export class TypeBuilder {
 
-    /** `standard` Modifies an object property to be both readonly and optional */
+    /** `Standard` Modifies an object property to be both readonly and optional */
     public ReadonlyOptional<T extends TSchema>(item: T): TReadonlyOptional<T> {
         return { ...item, modifier: ReadonlyOptionalModifier }
     }
 
-    /** `standard` Modifies an object property to be readonly */
+    /** `Standard` Modifies an object property to be readonly */
     public Readonly<T extends TSchema>(item: T): TReadonly<T> {
         return { ...item, modifier: ReadonlyModifier }
     }
 
-     /** `standard` Modifies an object property to be optional */
+     /** `Standard` Modifies an object property to be optional */
     public Optional<T extends TSchema>(item: T): TOptional<T> {
         return { ...item, modifier: OptionalModifier }
     }
 
-    /** `standard` Creates a type type */
+    /** `Standard` Creates a type type */
     public Tuple<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TTuple<T> {
         const additionalItems = false
         const minItems = items.length
@@ -271,7 +271,7 @@ export class TypeBuilder {
             : { ...options, kind: TupleKind, type: 'array', minItems, maxItems }) as any
     }
 
-    /** `standard` Creates an object type with the given properties */
+    /** `Standard` Creates an object type with the given properties */
     public Object<T extends TProperties>(properties: T, options: ObjectOptions = {}): TObject<T> {
         const property_names = Object.keys(properties)
         const optional = property_names.filter(name => {
@@ -287,80 +287,80 @@ export class TypeBuilder {
             : { ...options, kind: ObjectKind, type: 'object', properties }) as any
     }
 
-    /** `standard` Creates an intersection type. */
+    /** `Standard` Creates an intersection type. */
     public Intersect<T extends TSchema[]>(items: [...T], options: IntersectOptions = {}): TIntersect<T> {
         return { ...options, kind: IntersectKind, type: 'object', allOf: items } as any
     }
     
-    /** `standard` Creates a union type */
+    /** `Standard` Creates a union type */
     public Union<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TUnion<T> {
         return { ...options, kind: UnionKind, anyOf: items } as any
     }
 
-    /** `standard` Creates an array type */
+    /** `Standard` Creates an array type */
     public Array<T extends TSchema>(items: T, options: ArrayOptions = {}): TArray<T> {
         return { ...options, kind: ArrayKind, type: 'array', items } as any
     }
     
-    /** `standard` Creates an enum type from a TypeScript enum */
+    /** `Standard` Creates an enum type from a TypeScript enum */
     public Enum<T extends TEnumType>(item: T, options: CustomOptions = {}): TEnum<TEnumKey<T[keyof T]>[]> {
         const values = Object.keys(item).filter(key => isNaN(key as any)).map(key => item[key]) as T[keyof T][]
         const anyOf  = values.map(value => typeof value === 'string' ? { type: 'string' as const, const: value } : { type: 'number' as const, const: value })
         return { ...options, kind: EnumKind, anyOf } as any
     }
 
-    /** `standard` Creates a literal type. Supports string, number and boolean values only */
+    /** `Standard` Creates a literal type. Supports string, number and boolean values only */
     public Literal<T extends TValue>(value: T, options: CustomOptions = {}): TLiteral<T> {
         return { ...options, kind: LiteralKind, const: value, type: typeof value as 'string' | 'number' | 'boolean' } as any
     }
 
-    /** `standard` Creates a string type */
+    /** `Standard` Creates a string type */
     public String<TCustomFormatOption extends string>(options: StringOptions<StringFormatOption | TCustomFormatOption> = {}): TString {
         return { ...options, kind: StringKind, type: 'string' } as any
     }
 
-    /** `standard` Creates a string type from a regular expression */
+    /** `Standard` Creates a string type from a regular expression */
     public RegEx(regex: RegExp, options: CustomOptions = {}): TString {
         return this.String({ ...options, pattern: regex.source }) as any
     }
 
-    /** `standard` Creates a number type */
+    /** `Standard` Creates a number type */
     public Number(options: NumberOptions = {}): TNumber {
         return { ...options, kind: NumberKind, type: 'number' } as any
     }
 
-    /** `standard` Creates an integer type */
+    /** `Standard` Creates an integer type */
     public Integer(options: NumberOptions = {}): TInteger {
         return { ...options, kind: IntegerKind, type: 'integer' } as any
     }
 
-    /** `standard` Creates a boolean type */
+    /** `Standard` Creates a boolean type */
     public Boolean(options: CustomOptions = {}): TBoolean {
         return { ...options, kind: BooleanKind, type: 'boolean' } as any
     }
 
-    /** `standard` Creates a null type */
+    /** `Standard` Creates a null type */
     public Null(options: CustomOptions = {}): TNull {
         return { ...options, kind: NullKind, type: 'null' } as any
     }
 
-    /** `standard` Creates an unknown type */
+    /** `Standard` Creates an unknown type */
     public Unknown(options: CustomOptions = {}): TUnknown {
         return { ...options, kind: UnknownKind } as any
     }
 
-    /** `standard` Creates an any type */
+    /** `Standard` Creates an any type */
     public Any(options: CustomOptions = {}): TAny {
         return { ...options, kind: AnyKind } as any
     }
-    
-    /** `standard` Creates a keyof type from the given object */
-    public KeyOf<T extends TObject<TProperties>>(schema: T, options: CustomOptions = {}): TKeyOf<{[K in keyof T['properties']]: K extends string ? K : never}[number]> {
+
+    /** `Standard` Creates a keyof type from the given object */
+    public KeyOf<T extends TObject<TProperties>>(schema: T, options: CustomOptions = {}): TKeyOf<(keyof T['properties'])[]> {
         const keys = Object.keys(schema.properties)
         return {...options, kind: KeyOfKind, type: 'string', enum: keys } as any
     }
     
-    /** `standard` Creates a record type */
+    /** `Standard` Creates a record type */
     public Record<K extends TRecordKey, T extends TSchema>(key: K, value: T, options: ObjectOptions = {}): TRecord<K, T> {
         const pattern = (() => {
             switch(key.kind) {
@@ -374,7 +374,7 @@ export class TypeBuilder {
         return { ...options, kind: RecordKind, type: 'object', patternProperties: { [pattern]: value } } as any
     }
 
-    /** `standard` Makes all properties in the given object type required */
+    /** `Standard` Makes all properties in the given object type required */
     public Required<T extends TObject<any>>(schema: T, options: ObjectOptions = {}): TObject<TRequired<T['properties']>> {
         const next = { ...clone(schema), ...options }
         next.required = Object.keys(next.properties)
@@ -390,7 +390,7 @@ export class TypeBuilder {
         return next
     }
     
-    /** `standard` Makes all properties in the given object type optional */
+    /** `Standard` Makes all properties in the given object type optional */
     public Partial<T extends TObject<any>>(schema: T, options: ObjectOptions = {}): TObject<TPartial<T['properties']>> {
         const next = { ...clone(schema), ...options }
         delete next.required
@@ -406,7 +406,7 @@ export class TypeBuilder {
         return next
     }
 
-    /** `standard` Picks property keys from the given object type */
+    /** `Standard` Picks property keys from the given object type */
     public Pick<T extends TObject<TProperties>, K extends (keyof T['properties'])[]>(schema: T, keys: [...K], options: ObjectOptions = {}): TObject<Pick<T['properties'], K[number]>> {
         const next = { ...clone(schema), ...options }
         next.required = next.required ? next.required.filter((key: string) => keys.includes(key)) : undefined
@@ -416,7 +416,7 @@ export class TypeBuilder {
         return next
     }
     
-    /** `standard` Omits property keys from the given object type */
+    /** `Standard` Omits property keys from the given object type */
     public Omit<T extends TObject<any>, K extends (keyof T['properties'])[]>(schema: T, keys: [...K], options: ObjectOptions = {}):TObject<Omit<T['properties'], K[number]>> {
         const next = { ...clone(schema), ...options }
         next.required = next.required ? next.required.filter((key: string) => !keys.includes(key)) : undefined
@@ -426,58 +426,58 @@ export class TypeBuilder {
         return next
     }
 
-    /** `standard` Omits the `kind` and `modifier` properties from the underlying schema */
+    /** `Standard` Omits the `kind` and `modifier` properties from the underlying schema */
     public Strict<T extends TSchema>(schema: T, options: CustomOptions = {}): T {
         return JSON.parse(JSON.stringify({ ...options, ...schema })) as T
     }
     
-    /** `extended` Creates a constructor type */
+    /** `Extended` Creates a constructor type */
     public Constructor<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TConstructor<T, U> {
         return { ...options, kind: ConstructorKind, type: 'constructor', arguments: args, returns } as any
     }
 
-    /** `extended` Creates a function type */
+    /** `Extended` Creates a function type */
     public Function<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TFunction<T, U> {
         return { ...options, kind: FunctionKind, type: 'function', arguments: args, returns } as any
     }
 
-    /** `extended` Creates a promise type */
+    /** `Extended` Creates a promise type */
     public Promise<T extends TSchema>(item: T, options: CustomOptions = {}): TPromise<T> {
         return { ...options, type: 'promise', kind: PromiseKind, item } as any
     }
 
-    /** `extended` Creates a undefined type */
+    /** `Extended` Creates a undefined type */
     public Undefined(options: CustomOptions = {}): TUndefined {
         return { ...options, type: 'undefined', kind: UndefinedKind } as any
     }
 
-    /** `extended` Creates a void type */
+    /** `Extended` Creates a void type */
     public Void(options: CustomOptions = {}): TVoid {
         return { ...options, type: 'void', kind: VoidKind } as any
     }
     
-    /** `experimental` Creates a recursive type */
+    /** `Experimental` Creates a recursive type */
     public Rec<T extends TSchema>(callback: (self: TAny) => T, options: CustomOptions = {}): T {
         const $id = options.$id || ''
         const self = callback({ $ref: `${$id}#/definitions/self` } as any)
         return { ...options, $ref: `${$id}#/definitions/self`, definitions: { self } } as unknown as T
     }
 
-    /** `experimental` Creates a recursive type. Pending https://github.com/ajv-validator/ajv/issues/1709 */
+    /** `Experimental` Creates a recursive type. Pending https://github.com/ajv-validator/ajv/issues/1709 */
     // public Rec<T extends TProperties>($id: string, callback: (self: TAny) => T, options: ObjectOptions = {}): TObject<T> {
     //     const properties = callback({ $recursiveRef: `${$id}` } as any)
     //     return { ...options, kind: ObjectKind, $id, $recursiveAnchor: true, type: 'object', properties }
     // }
 
-    /** `experimental` Creates a namespace for a set of related types */
+    /** `Experimental` Creates a namespace for a set of related types */
     public Namespace<T extends TDefinitions>(definitions: T, options: CustomOptions = {}): TNamespace<T> {
         return { ...options, kind: BoxKind, definitions } as any
     }
     
-    /** `experimental` References a type within a namespace. The referenced namespace must specify an `$id` */
+    /** `Experimental` References a type within a namespace. The referenced namespace must specify an `$id` */
     public Ref<T extends TNamespace<TDefinitions>, K extends keyof T['definitions']>(box: T, key: K): T['definitions'][K] 
     
-    /** `experimental` References type. The referenced type must specify an `$id` */
+    /** `Experimental` References type. The referenced type must specify an `$id` */
     public Ref<T extends TSchema>(schema: T): T
     
     public Ref(...args: any[]): any {

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -193,7 +193,6 @@ export type ReadonlyOptionalPropertyKeys <T extends TProperties> = { [K in keyof
 export type ReadonlyPropertyKeys         <T extends TProperties> = { [K in keyof T]: T[K] extends TReadonly<TSchema> ? K : never }[keyof T]
 export type OptionalPropertyKeys         <T extends TProperties> = { [K in keyof T]: T[K] extends TOptional<TSchema> ? K : never }[keyof T]
 export type RequiredPropertyKeys         <T extends TProperties> = keyof Omit<T, ReadonlyOptionalPropertyKeys<T> | ReadonlyPropertyKeys<T> | OptionalPropertyKeys<T>>
-
 export type ReduceStaticProperties<T> = {[K in keyof T]: T[K] }
 export type StaticProperties<T extends TProperties> =
     { readonly [K in ReadonlyOptionalPropertyKeys<T>]?: Static<T[K]> } &

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -43,23 +43,23 @@ export type TReadonly<T extends TSchema>         = T & { modifier: typeof Readon
 // Schema Standard
 // ------------------------------------------------------------------------
 
-export const BoxKind         = Symbol('BoxKind')
-export const KeyOfKind       = Symbol('KeyOfKind')
-export const IntersectKind   = Symbol('IntersectKind')
-export const UnionKind       = Symbol('UnionKind')
-export const TupleKind       = Symbol('TupleKind')
-export const ObjectKind      = Symbol('ObjectKind')
-export const RecordKind      = Symbol('RecordKind')
-export const ArrayKind       = Symbol('ArrayKind')
-export const EnumKind        = Symbol('EnumKind')
-export const LiteralKind     = Symbol('LiteralKind')
-export const StringKind      = Symbol('StringKind')
-export const NumberKind      = Symbol('NumberKind')
-export const IntegerKind     = Symbol('IntegerKind')
-export const BooleanKind     = Symbol('BooleanKind')
-export const NullKind        = Symbol('NullKind')
-export const UnknownKind     = Symbol('UnknownKind')
-export const AnyKind         = Symbol('AnyKind')
+export const BoxKind       = Symbol('BoxKind')
+export const KeyOfKind     = Symbol('KeyOfKind')
+export const IntersectKind = Symbol('IntersectKind')
+export const UnionKind     = Symbol('UnionKind')
+export const TupleKind     = Symbol('TupleKind')
+export const ObjectKind    = Symbol('ObjectKind')
+export const RecordKind    = Symbol('RecordKind')
+export const ArrayKind     = Symbol('ArrayKind')
+export const EnumKind      = Symbol('EnumKind')
+export const LiteralKind   = Symbol('LiteralKind')
+export const StringKind    = Symbol('StringKind')
+export const NumberKind    = Symbol('NumberKind')
+export const IntegerKind   = Symbol('IntegerKind')
+export const BooleanKind   = Symbol('BooleanKind')
+export const NullKind      = Symbol('NullKind')
+export const UnknownKind   = Symbol('UnknownKind')
+export const AnyKind       = Symbol('AnyKind')
 
 export interface CustomOptions {
     $id?: string
@@ -115,37 +115,37 @@ export type TDefinitions                       = { [key: string]: TSchema }
 export type TNamespace<T extends TDefinitions> = { kind: typeof BoxKind, definitions: T } & CustomOptions
 
 // ------------------------------------------------------------------------
-// Infer<T>
+// TSchema<T>
 // ------------------------------------------------------------------------
 
-export type Infer<T> = { '_infer': T }
+export interface TSchema { '#output': unknown }
 
 // ------------------------------------------------------------------------
 // Standard Schema Types
 // ------------------------------------------------------------------------
 
 export type TEnumType          = Record<string, string | number>
-export type TKey               = string | number
+export type TKey               = string | number | symbol
 export type TValue             = string | number | boolean
-export type TRecordKey         = TString | TNumber | TKeyOf<any> | TUnion<string | number>
+export type TRecordKey         = TString | TNumber | TKeyOf<any> | TUnion<any>
 export type TEnumKey<T = TKey> = { type: 'number' | 'string', const: T }
-export type TProperties        = { [key: string]: TSchema }
-export type TTuple<I>          = Infer<I> & { kind: typeof TupleKind, type: 'array', items?: TSchema[], additionalItems?: false, minItems: number, maxItems: number } & CustomOptions
-export type TObject<I>         = Infer<I> & { kind: typeof ObjectKind, type: 'object', properties: TProperties, required?: string[] } & ObjectOptions
-export type TUnion<I>          = Infer<I> & { kind: typeof UnionKind, anyOf: TSchema[] } & CustomOptions
-export type TIntersect<I>      = Infer<I> & { kind: typeof IntersectKind, type: 'object', allOf: TSchema[] } & IntersectOptions
-export type TKeyOf<I>          = Infer<I> & { kind: typeof KeyOfKind, type: 'string', enum: string[] } & CustomOptions
-export type TRecord<I>         = Infer<I> & { kind: typeof RecordKind, type: 'object', patternProperties: { [pattern: string]: TSchema } } & ObjectOptions
-export type TArray<I>          = Infer<I> & { kind: typeof ArrayKind, type: 'array', items: any } & ArrayOptions
-export type TLiteral<I>        = Infer<I> & { kind: typeof LiteralKind, const: TValue } & CustomOptions
-export type TEnum<I>           = Infer<I> & { kind: typeof EnumKind, anyOf: TSchema } & CustomOptions
-export type TString            = Infer<string>  & { kind: typeof StringKind, type: 'string' } & StringOptions<string>
-export type TNumber            = Infer<number>  & { kind: typeof NumberKind, type: 'number' } & NumberOptions
-export type TInteger           = Infer<number>  & { kind: typeof IntegerKind, type: 'integer' } & NumberOptions
-export type TBoolean           = Infer<boolean> & { kind: typeof BooleanKind, type: 'boolean' } & CustomOptions
-export type TNull              = Infer<null>    & { kind: typeof NullKind, type: 'null' } & CustomOptions
-export type TUnknown           = Infer<unknown> & { kind: typeof UnknownKind } & CustomOptions
-export type TAny               = Infer<any>     & { kind: typeof AnyKind } & CustomOptions
+export interface TProperties   { [key: string]: TSchema }
+export interface TTuple    <T extends TSchema[]>   extends TSchema, CustomOptions                   { '#output': StaticTuple<T>, kind: typeof TupleKind, type: 'array', items?: T, additionalItems?: false, minItems: number, maxItems: number }
+export interface TObject   <T extends TProperties> extends TSchema, ObjectOptions                   { '#output': StaticObject<T>, kind: typeof ObjectKind, type: 'object', properties: T, required?: string[] } 
+export interface TUnion    <T extends TSchema[]>   extends TSchema, CustomOptions                   { '#output': StaticUnion<T>, kind: typeof UnionKind, anyOf: T }
+export interface TIntersect<T extends TSchema[]>   extends TSchema, IntersectOptions                { '#output': StaticIntersect<T>, kind: typeof IntersectKind, type: 'object', allOf: T }
+export interface TKeyOf    <T extends TKey[]>      extends  TSchema, CustomOptions                  { '#output': StaticKeyOf<T>,kind: typeof KeyOfKind, type: 'string', enum: T }
+export interface TRecord   <K extends TRecordKey, T extends TSchema> extends TSchema, ObjectOptions { '#output': StaticRecord<K, T>, kind: typeof RecordKind, type: 'object', patternProperties: { [pattern: string]: T } }
+export interface TArray    <T extends TSchema>     extends TSchema, ArrayOptions                    { '#output': StaticArray<T>, kind: typeof ArrayKind, type: 'array', items: T } 
+export interface TLiteral  <T extends TValue>      extends TSchema, CustomOptions                   { '#output': StaticLiteral<T>, kind: typeof LiteralKind, const: T }
+export interface TEnum     <T extends TEnumKey[]>  extends TSchema, CustomOptions                   { '#output': StaticEnum<T>, kind: typeof EnumKind, anyOf: T }
+export interface TString   extends TSchema, StringOptions<string>                                   { '#output': string, kind: typeof StringKind, type: 'string' }
+export interface TNumber   extends TSchema, NumberOptions                                           { '#output': number, kind: typeof NumberKind, type: 'number' }
+export interface TInteger  extends TSchema, NumberOptions                                           { '#output': number, kind: typeof IntegerKind, type: 'integer' } 
+export interface TBoolean  extends TSchema, CustomOptions                                           { '#output': boolean, kind: typeof BooleanKind, type: 'boolean' } 
+export interface TNull     extends TSchema, CustomOptions                                           { '#output': null, kind: typeof NullKind, type: 'null' }
+export interface TUnknown  extends TSchema, CustomOptions                                           { '#output': unknown, kind: typeof UnknownKind }
+export interface TAny      extends TSchema, CustomOptions                                           { '#output': any, kind: typeof AnyKind }
 
 // ------------------------------------------------------------------------
 // Extended Schema Types
@@ -156,41 +156,34 @@ export const FunctionKind    = Symbol('FunctionKind')
 export const PromiseKind     = Symbol('PromiseKind')
 export const UndefinedKind   = Symbol('UndefinedKind')
 export const VoidKind        = Symbol('VoidKind')
-export type TConstructor <T> = Infer<T> & { kind: typeof ConstructorKind, type: 'constructor', arguments: TSchema[], returns: TSchema } & CustomOptions
-export type TFunction    <T> = Infer<T> & { kind: typeof FunctionKind,    type: 'function', arguments: TSchema[], returns: TSchema } & CustomOptions
-export type TPromise     <T> = Infer<T> & { kind: typeof PromiseKind,     type: 'promise', item: TSchema } & CustomOptions
-export type TUndefined       = Infer<undefined> & { kind: typeof UndefinedKind, type: 'undefined' } & CustomOptions
-export type TVoid            = Infer<void>      & { kind: typeof VoidKind, type: 'void' } & CustomOptions
+export interface TConstructor<T extends TSchema[], U extends TSchema> extends TSchema, CustomOptions { '#output': StaticConstructor<T, U>, kind: typeof ConstructorKind, type: 'constructor', arguments: TSchema[], returns: TSchema }
+export interface TFunction   <T extends TSchema[], U extends TSchema> extends TSchema, CustomOptions { '#output': StaticFunction<T, U>, kind: typeof FunctionKind,    type: 'function', arguments: TSchema[], returns: TSchema }
+export interface TPromise    <T extends TSchema> extends TSchema, CustomOptions                      { '#output': StaticPromise<T>, kind: typeof PromiseKind,     type: 'promise', item: TSchema }
+export interface TUndefined extends TSchema, CustomOptions                                           { '#output': undefined, kind: typeof UndefinedKind, type: 'undefined' }
+export interface TVoid      extends TSchema, CustomOptions                                           { '#output': void, kind: typeof VoidKind, type: 'void' }
+
 
 // ------------------------------------------------------------------------
-// Schema
+// Utility Types
 // ------------------------------------------------------------------------
 
-export type TSchema =
-    | TIntersect<any>
-    | TUnion<any>
-    | TTuple<any>
-    | TObject<any>
-    | TKeyOf<any>
-    | TRecord<any>
-    | TArray<any>
-    | TEnum<any>
-    | TLiteral<any>
-    | TString
-    | TNumber
-    | TInteger
-    | TBoolean
-    | TNull
-    | TUnknown
-    | TAny
-    | TConstructor<any>
-    | TFunction<any>
-    | TPromise<any>
-    | TUndefined
-    | TVoid
+export type TRequired<T extends TProperties> = {
+    [K in keyof T]: 
+        T[K] extends TReadonlyOptional<infer U> ? TReadonly<U> :  
+        T[K] extends TReadonly<infer U>         ? TReadonly<U> :
+        T[K] extends TOptional<infer U>         ? U :  
+        T[K]
+}
+export type TPartial<T extends TProperties> = {
+    [K in keyof T]:
+        T[K] extends TReadonlyOptional<infer U> ? TReadonlyOptional<U> :  
+        T[K] extends TReadonly<infer U>         ? TReadonlyOptional<U> :
+        T[K] extends TOptional<infer U>         ? TOptional<U> :
+        TOptional<T[K]>
+}
 
 // ------------------------------------------------------------------------
-// Static Inference
+// Static TSchemaence
 // ------------------------------------------------------------------------
 
 export type UnionToIntersect<U>                             = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
@@ -200,51 +193,34 @@ export type ReadonlyOptionalPropertyKeys <T extends TProperties> = { [K in keyof
 export type ReadonlyPropertyKeys         <T extends TProperties> = { [K in keyof T]: T[K] extends TReadonly<TSchema> ? K : never }[keyof T]
 export type OptionalPropertyKeys         <T extends TProperties> = { [K in keyof T]: T[K] extends TOptional<TSchema> ? K : never }[keyof T]
 export type RequiredPropertyKeys         <T extends TProperties> = keyof Omit<T, ReadonlyOptionalPropertyKeys<T> | ReadonlyPropertyKeys<T> | OptionalPropertyKeys<T>>
+
+export type ReduceStaticProperties<T> = {[K in keyof T]: T[K] }
 export type StaticProperties<T extends TProperties> =
     { readonly [K in ReadonlyOptionalPropertyKeys<T>]?: Static<T[K]> } &
     { readonly [K in ReadonlyPropertyKeys<T>]:          Static<T[K]> } &
     {          [K in OptionalPropertyKeys<T>]?:         Static<T[K]> } &
     {          [K in RequiredPropertyKeys<T>]:          Static<T[K]> }
 export type StaticRecord      <K extends TRecordKey, T extends TSchema> = 
-    K extends TString     ? Record<string, Static<T>> : 
-    K extends TNumber     ? Record<number, Static<T>> : 
-    K extends TKeyOf<any> ? Record<K['_infer'], Static<T>> : 
-    K extends TUnion<any> ? Record<K['_infer'], Static<T>> :
+    K extends TString           ? Record<string, Static<T>> : 
+    K extends TNumber           ? Record<number, Static<T>> : 
+    K extends TKeyOf<TKey[]>    ? Record<K['#output'], Static<T>> : 
+    K extends TUnion<TSchema[]> ? Record<K['#output'], Static<T>> :
     never
-export type StaticEnum        <T>                                       = T extends TEnumKey<infer U>[] ? U : never
-export type StaticKeyOf       <T extends TKey[]>                        = T extends Array<infer K> ? K : never
-export type StaticIntersect   <T extends readonly TSchema[]>            = IntersectReduce<unknown, IntersectEvaluate<T>>
-export type StaticUnion       <T extends readonly TSchema[]>            = { [K in keyof T]: Static<T[K]> }[number]
-export type StaticTuple       <T extends readonly TSchema[]>            = { [K in keyof T]: Static<T[K]> }
-export type StaticObject      <T extends TProperties>                   = StaticProperties<StaticProperties<T>>
+export type StaticEnum        <T>                                               = T extends TEnumKey<infer U>[] ? U : never
+export type StaticKeyOf       <T extends TKey[]>                                = T extends Array<infer K> ? K : never
+export type StaticIntersect   <T extends readonly TSchema[]>                    = IntersectReduce<unknown, IntersectEvaluate<T>>
+export type StaticUnion       <T extends readonly TSchema[]>                    = { [K in keyof T]: Static<T[K]> }[number]
+export type StaticTuple       <T extends readonly TSchema[]>                    = { [K in keyof T]: Static<T[K]> }
+export type StaticObject      <T extends TProperties>                           = ReduceStaticProperties<StaticProperties<T>>
 export type StaticArray       <T extends TSchema>                               = Array<Static<T>>
 export type StaticLiteral     <T extends TValue>                                = T
-export type StaticConstructor <T extends readonly TSchema[], U extends TSchema> = new (...args: [...{ [K in keyof T]: Static<T[K]> }]) => Static<U>
-export type StaticFunction    <T extends readonly TSchema[], U extends TSchema> = (...args: [...{ [K in keyof T]: Static<T[K]> }]) => Static<U>
+
+export type StaticParameters  <T extends readonly TSchema[]> = {[K in keyof T]: Static<T[K]> }
+export type StaticConstructor <T extends readonly TSchema[], U extends TSchema> = new (...args: [...StaticParameters<T>]) => Static<U>
+export type StaticFunction    <T extends readonly TSchema[], U extends TSchema> = (...args: [...StaticParameters<T>]) => Static<U>
 export type StaticPromise     <T extends TSchema>                               = Promise<Static<T>>
-export type Static<T> =
-    T extends TKeyOf<infer I>       ? I :
-    T extends TIntersect<infer I>   ? I : 
-    T extends TUnion<infer I>       ? I :
-    T extends TTuple<infer I>       ? I :
-    T extends TObject<infer I>      ? { [K in keyof I]: I[K] } : // Reduce Modifiers
-    T extends TRecord<infer I>      ? I :
-    T extends TArray<infer I>       ? I :
-    T extends TEnum<infer I>        ? I :
-    T extends TLiteral<infer I>     ? I :
-    T extends TString               ? T['_infer'] :
-    T extends TNumber               ? T['_infer'] :
-    T extends TInteger              ? T['_infer'] :
-    T extends TBoolean              ? T['_infer'] : 
-    T extends TNull                 ? T['_infer'] :
-    T extends TUnknown              ? T['_infer'] :
-    T extends TAny                  ? T['_infer'] :
-    T extends TConstructor<infer I> ? I :
-    T extends TFunction<infer I>    ? I :
-    T extends TPromise<infer I>     ? I :
-    T extends TUndefined            ? T['_infer'] :
-    T extends TVoid                 ? T['_infer'] :
-    never
+
+export type Static<T> = T extends TSchema ? T['#output'] : never
 
 // ------------------------------------------------------------------------
 // Utility
@@ -286,17 +262,17 @@ export class TypeBuilder {
     }
 
     /** `standard` Creates a type type */
-    public Tuple<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TTuple<StaticTuple<T>> {
+    public Tuple<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TTuple<T> {
         const additionalItems = false
         const minItems = items.length
         const maxItems = items.length
-        return (items.length > 0)
+        return ((items.length > 0)
             ? { ...options, kind: TupleKind, type: 'array', items, additionalItems, minItems, maxItems }
-            : { ...options, kind: TupleKind, type: 'array', minItems, maxItems } as any
+            : { ...options, kind: TupleKind, type: 'array', minItems, maxItems }) as any
     }
 
     /** `standard` Creates an object type with the given properties */
-    public Object<T extends TProperties>(properties: T, options: ObjectOptions = {}): TObject<StaticProperties<T>> {
+    public Object<T extends TProperties>(properties: T, options: ObjectOptions = {}): TObject<T> {
         const property_names = Object.keys(properties)
         const optional = property_names.filter(name => {
             const candidate = properties[name] as TModifier
@@ -306,35 +282,35 @@ export class TypeBuilder {
         })
         const required_names = property_names.filter(name => !optional.includes(name))
         const required = (required_names.length > 0) ? required_names : undefined
-        return (required) ?
-            { ...options, kind: ObjectKind, type: 'object', properties, required } : 
-            { ...options, kind: ObjectKind, type: 'object', properties } as any
+        return ((required) 
+            ? { ...options, kind: ObjectKind, type: 'object', properties, required } 
+            : { ...options, kind: ObjectKind, type: 'object', properties }) as any
     }
 
-    /** `standard` Creates an intersection type. Note this function requires draft `2019-09` to constrain with `unevaluatedProperties` */
-    public Intersect<T extends TSchema[]>(items: [...T], options: IntersectOptions = {}): TIntersect<StaticIntersect<T>> {
+    /** `standard` Creates an intersection type. */
+    public Intersect<T extends TSchema[]>(items: [...T], options: IntersectOptions = {}): TIntersect<T> {
         return { ...options, kind: IntersectKind, type: 'object', allOf: items } as any
     }
     
     /** `standard` Creates a union type */
-    public Union<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TUnion<StaticUnion<T>> {
+    public Union<T extends TSchema[]>(items: [...T], options: CustomOptions = {}): TUnion<T> {
         return { ...options, kind: UnionKind, anyOf: items } as any
     }
 
     /** `standard` Creates an array type */
-    public Array<T extends TSchema>(items: T, options: ArrayOptions = {}): TArray<StaticArray<T>> {
+    public Array<T extends TSchema>(items: T, options: ArrayOptions = {}): TArray<T> {
         return { ...options, kind: ArrayKind, type: 'array', items } as any
     }
     
     /** `standard` Creates an enum type from a TypeScript enum */
-    public Enum<T extends TEnumType>(item: T, options: CustomOptions = {}): TEnum<StaticEnum<TEnumKey<T[keyof T]>[]>> {
+    public Enum<T extends TEnumType>(item: T, options: CustomOptions = {}): TEnum<TEnumKey<T[keyof T]>[]> {
         const values = Object.keys(item).filter(key => isNaN(key as any)).map(key => item[key]) as T[keyof T][]
         const anyOf  = values.map(value => typeof value === 'string' ? { type: 'string' as const, const: value } : { type: 'number' as const, const: value })
         return { ...options, kind: EnumKind, anyOf } as any
     }
 
     /** `standard` Creates a literal type. Supports string, number and boolean values only */
-    public Literal<T extends TValue>(value: T, options: CustomOptions = {}): TLiteral<StaticLiteral<T>> {
+    public Literal<T extends TValue>(value: T, options: CustomOptions = {}): TLiteral<T> {
         return { ...options, kind: LiteralKind, const: value, type: typeof value as 'string' | 'number' | 'boolean' } as any
     }
 
@@ -379,16 +355,16 @@ export class TypeBuilder {
     }
     
     /** `standard` Creates a keyof type from the given object */
-    public KeyOf<T extends TObject<any>>(schema: T, options: CustomOptions = {}): TKeyOf<keyof T['_infer']> {
+    public KeyOf<T extends TObject<TProperties>>(schema: T, options: CustomOptions = {}): TKeyOf<{[K in keyof T['properties']]: K extends string ? K : never}[number]> {
         const keys = Object.keys(schema.properties)
         return {...options, kind: KeyOfKind, type: 'string', enum: keys } as any
     }
     
     /** `standard` Creates a record type */
-    public Record<K extends TRecordKey, T extends TSchema>(key: K, value: T, options: ObjectOptions = {}): TRecord<StaticRecord<K, T>> {
+    public Record<K extends TRecordKey, T extends TSchema>(key: K, value: T, options: ObjectOptions = {}): TRecord<K, T> {
         const pattern = (() => {
             switch(key.kind) {
-                case UnionKind:  return `^${key.anyOf.map(literal => literal.const as TValue).join('|')}$`
+                case UnionKind:  return `^${key.anyOf.map((literal: any) => literal.const as TValue).join('|')}$`
                 case KeyOfKind:  return `^${key.enum.join('|')}$`
                 case NumberKind: return '^(0|[1-9][0-9]*)$'
                 case StringKind: return key.pattern ? key.pattern : '^.*$'
@@ -399,7 +375,7 @@ export class TypeBuilder {
     }
 
     /** `standard` Makes all properties in the given object type required */
-    public Required<T extends TObject<any>>(schema: T, options: ObjectOptions = {}): TObject<Required<T['_infer']>> {
+    public Required<T extends TObject<any>>(schema: T, options: ObjectOptions = {}): TObject<TRequired<T['properties']>> {
         const next = { ...clone(schema), ...options }
         next.required = Object.keys(next.properties)
         for(const key of Object.keys(next.properties)) {
@@ -415,7 +391,7 @@ export class TypeBuilder {
     }
     
     /** `standard` Makes all properties in the given object type optional */
-    public Partial<T extends TObject<any>>(schema: T, options: ObjectOptions = {}): TObject<Partial<T['_infer']>> {
+    public Partial<T extends TObject<any>>(schema: T, options: ObjectOptions = {}): TObject<TPartial<T['properties']>> {
         const next = { ...clone(schema), ...options }
         delete next.required
         for(const key of Object.keys(next.properties)) {
@@ -431,7 +407,7 @@ export class TypeBuilder {
     }
 
     /** `standard` Picks property keys from the given object type */
-    public Pick<T extends TObject<any>, K extends (keyof T['_infer'])[]>(schema: T, keys: [...K], options: ObjectOptions = {}): TObject<Pick<T['_infer'], K[number]>> {
+    public Pick<T extends TObject<TProperties>, K extends (keyof T['properties'])[]>(schema: T, keys: [...K], options: ObjectOptions = {}): TObject<Pick<T['properties'], K[number]>> {
         const next = { ...clone(schema), ...options }
         next.required = next.required ? next.required.filter((key: string) => keys.includes(key)) : undefined
         for(const key of Object.keys(next.properties)) {
@@ -441,7 +417,7 @@ export class TypeBuilder {
     }
     
     /** `standard` Omits property keys from the given object type */
-    public Omit<T extends TObject<any>, K extends (keyof T['_infer'])[]>(schema: T, keys: [...K], options: ObjectOptions = {}): TObject<Omit<T['_infer'], K[number]>> {
+    public Omit<T extends TObject<any>, K extends (keyof T['properties'])[]>(schema: T, keys: [...K], options: ObjectOptions = {}):TObject<Omit<T['properties'], K[number]>> {
         const next = { ...clone(schema), ...options }
         next.required = next.required ? next.required.filter((key: string) => !keys.includes(key)) : undefined
         for(const key of Object.keys(next.properties)) {
@@ -456,17 +432,17 @@ export class TypeBuilder {
     }
     
     /** `extended` Creates a constructor type */
-    public Constructor<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TConstructor<StaticConstructor<T, U>> {
+    public Constructor<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TConstructor<T, U> {
         return { ...options, kind: ConstructorKind, type: 'constructor', arguments: args, returns } as any
     }
 
     /** `extended` Creates a function type */
-    public Function<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TFunction<StaticFunction<T, U>> {
+    public Function<T extends TSchema[], U extends TSchema>(args: [...T], returns: U, options: CustomOptions = {}): TFunction<T, U> {
         return { ...options, kind: FunctionKind, type: 'function', arguments: args, returns } as any
     }
 
     /** `extended` Creates a promise type */
-    public Promise<T extends TSchema>(item: T, options: CustomOptions = {}): TPromise<StaticPromise<T>> {
+    public Promise<T extends TSchema>(item: T, options: CustomOptions = {}): TPromise<T> {
         return { ...options, type: 'promise', kind: PromiseKind, item } as any
     }
 

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -115,10 +115,10 @@ export type TDefinitions                       = { [key: string]: TSchema }
 export type TNamespace<T extends TDefinitions> = { kind: typeof BoxKind, definitions: T } & CustomOptions
 
 // ------------------------------------------------------------------------
-// TSchema<T>
+// TSchema
 // ------------------------------------------------------------------------
 
-export interface TSchema { '#output': unknown }
+export interface TSchema { '#input': unknown, '#output': unknown }
 
 // ------------------------------------------------------------------------
 // Standard Schema Types
@@ -130,12 +130,12 @@ export type TValue             = string | number | boolean
 export type TRecordKey         = TString | TNumber | TKeyOf<any> | TUnion<any>
 export type TEnumKey<T = TKey> = { type: 'number' | 'string', const: T }
 export interface TProperties   { [key: string]: TSchema }
+export interface TRecord   <K extends TRecordKey, T extends TSchema> extends TSchema, ObjectOptions { '#output': StaticRecord<K, T>, kind: typeof RecordKind, type: 'object', patternProperties: { [pattern: string]: T } }
 export interface TTuple    <T extends TSchema[]>   extends TSchema, CustomOptions                   { '#output': StaticTuple<T>, kind: typeof TupleKind, type: 'array', items?: T, additionalItems?: false, minItems: number, maxItems: number }
 export interface TObject   <T extends TProperties> extends TSchema, ObjectOptions                   { '#output': StaticObject<T>, kind: typeof ObjectKind, type: 'object', properties: T, required?: string[] } 
 export interface TUnion    <T extends TSchema[]>   extends TSchema, CustomOptions                   { '#output': StaticUnion<T>, kind: typeof UnionKind, anyOf: T }
 export interface TIntersect<T extends TSchema[]>   extends TSchema, IntersectOptions                { '#output': StaticIntersect<T>, kind: typeof IntersectKind, type: 'object', allOf: T }
 export interface TKeyOf    <T extends TKey[]>      extends  TSchema, CustomOptions                  { '#output': StaticKeyOf<T>,kind: typeof KeyOfKind, type: 'string', enum: T }
-export interface TRecord   <K extends TRecordKey, T extends TSchema> extends TSchema, ObjectOptions { '#output': StaticRecord<K, T>, kind: typeof RecordKind, type: 'object', patternProperties: { [pattern: string]: T } }
 export interface TArray    <T extends TSchema>     extends TSchema, ArrayOptions                    { '#output': StaticArray<T>, kind: typeof ArrayKind, type: 'array', items: T } 
 export interface TLiteral  <T extends TValue>      extends TSchema, CustomOptions                   { '#output': StaticLiteral<T>, kind: typeof LiteralKind, const: T }
 export interface TEnum     <T extends TEnumKey[]>  extends TSchema, CustomOptions                   { '#output': StaticEnum<T>, kind: typeof EnumKind, anyOf: T }

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -26,9 +26,9 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 // Modifiers
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 
 export const ReadonlyOptionalModifier            = Symbol('ReadonlyOptionalModifier')
 export const OptionalModifier                    = Symbol('OptionalModifier')
@@ -39,9 +39,9 @@ export type TReadonlyOptional<T extends TSchema> = T & { modifier: typeof Readon
 export type TOptional<T extends TSchema>         = T & { modifier: typeof OptionalModifier }
 export type TReadonly<T extends TSchema>         = T & { modifier: typeof ReadonlyModifier }
 
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 // Schema Standard
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 
 export const BoxKind       = Symbol('BoxKind')
 export const KeyOfKind     = Symbol('KeyOfKind')
@@ -107,22 +107,24 @@ export type ObjectOptions = {
     additionalProperties?: boolean
 } & CustomOptions
 
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 // Namespacing
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 
 export type TDefinitions                       = { [key: string]: TSchema }
-export type TNamespace<T extends TDefinitions> = { kind: typeof BoxKind, definitions: T } & CustomOptions
+export type TNamespace<T extends TDefinitions> = { kind: typeof BoxKind, $defs: T } & CustomOptions
 
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 // TSchema
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 
-export interface TSchema { '#input': unknown, '#output': unknown }
+export interface TSchema {
+    'typebox:output': unknown 
+}
 
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 // Standard Schema Types
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 
 export type TEnumType          = Record<string, string | number>
 export type TKey               = string | number | symbol
@@ -130,51 +132,58 @@ export type TValue             = string | number | boolean
 export type TRecordKey         = TString | TNumber | TKeyOf<any> | TUnion<any>
 export type TEnumKey<T = TKey> = { type: 'number' | 'string', const: T }
 export interface TProperties   { [key: string]: TSchema }
-export interface TRecord   <K extends TRecordKey, T extends TSchema> extends TSchema, ObjectOptions { '#output': StaticRecord<K, T>, kind: typeof RecordKind, type: 'object', patternProperties: { [pattern: string]: T } }
-export interface TTuple    <T extends TSchema[]>   extends TSchema, CustomOptions                   { '#output': StaticTuple<T>, kind: typeof TupleKind, type: 'array', items?: T, additionalItems?: false, minItems: number, maxItems: number }
-export interface TObject   <T extends TProperties> extends TSchema, ObjectOptions                   { '#output': StaticObject<T>, kind: typeof ObjectKind, type: 'object', properties: T, required?: string[] } 
-export interface TUnion    <T extends TSchema[]>   extends TSchema, CustomOptions                   { '#output': StaticUnion<T>, kind: typeof UnionKind, anyOf: T }
-export interface TIntersect<T extends TSchema[]>   extends TSchema, IntersectOptions                { '#output': StaticIntersect<T>, kind: typeof IntersectKind, type: 'object', allOf: T }
-export interface TKeyOf    <T extends TKey[]>      extends  TSchema, CustomOptions                  { '#output': StaticKeyOf<T>,kind: typeof KeyOfKind, type: 'string', enum: T }
-export interface TArray    <T extends TSchema>     extends TSchema, ArrayOptions                    { '#output': StaticArray<T>, kind: typeof ArrayKind, type: 'array', items: T } 
-export interface TLiteral  <T extends TValue>      extends TSchema, CustomOptions                   { '#output': StaticLiteral<T>, kind: typeof LiteralKind, const: T }
-export interface TEnum     <T extends TEnumKey[]>  extends TSchema, CustomOptions                   { '#output': StaticEnum<T>, kind: typeof EnumKind, anyOf: T }
-export interface TString   extends TSchema, StringOptions<string>                                   { '#output': string, kind: typeof StringKind, type: 'string' }
-export interface TNumber   extends TSchema, NumberOptions                                           { '#output': number, kind: typeof NumberKind, type: 'number' }
-export interface TInteger  extends TSchema, NumberOptions                                           { '#output': number, kind: typeof IntegerKind, type: 'integer' } 
-export interface TBoolean  extends TSchema, CustomOptions                                           { '#output': boolean, kind: typeof BooleanKind, type: 'boolean' } 
-export interface TNull     extends TSchema, CustomOptions                                           { '#output': null, kind: typeof NullKind, type: 'null' }
-export interface TUnknown  extends TSchema, CustomOptions                                           { '#output': unknown, kind: typeof UnknownKind }
-export interface TAny      extends TSchema, CustomOptions                                           { '#output': any, kind: typeof AnyKind }
+export interface TRecord   <K extends TRecordKey, T extends TSchema> extends TSchema, ObjectOptions { 'typebox:output': StaticRecord<K, T>, kind: typeof RecordKind, type: 'object', patternProperties: { [pattern: string]: T } }
+export interface TTuple    <T extends TSchema[]>   extends TSchema, CustomOptions                   { 'typebox:output': StaticTuple<T>, kind: typeof TupleKind, type: 'array', items?: T, additionalItems?: false, minItems: number, maxItems: number }
+export interface TObject   <T extends TProperties> extends TSchema, ObjectOptions                   { 'typebox:output': StaticObject<T>, kind: typeof ObjectKind, type: 'object', properties: T, required?: string[] } 
+export interface TUnion    <T extends TSchema[]>   extends TSchema, CustomOptions                   { 'typebox:output': StaticUnion<T>, kind: typeof UnionKind, anyOf: T }
+export interface TIntersect<T extends TSchema[]>   extends TSchema, IntersectOptions                { 'typebox:output': StaticIntersect<T>, kind: typeof IntersectKind, type: 'object', allOf: T }
+export interface TKeyOf    <T extends TKey[]>      extends  TSchema, CustomOptions                  { 'typebox:output': StaticKeyOf<T>,kind: typeof KeyOfKind, type: 'string', enum: T }
+export interface TArray    <T extends TSchema>     extends TSchema, ArrayOptions                    { 'typebox:output': StaticArray<T>, kind: typeof ArrayKind, type: 'array', items: T } 
+export interface TLiteral  <T extends TValue>      extends TSchema, CustomOptions                   { 'typebox:output': StaticLiteral<T>, kind: typeof LiteralKind, const: T }
+export interface TEnum     <T extends TEnumKey[]>  extends TSchema, CustomOptions                   { 'typebox:output': StaticEnum<T>, kind: typeof EnumKind, anyOf: T }
+export interface TString   extends TSchema, StringOptions<string>                                   { 'typebox:output': string, kind: typeof StringKind, type: 'string' }
+export interface TNumber   extends TSchema, NumberOptions                                           { 'typebox:output': number, kind: typeof NumberKind, type: 'number' }
+export interface TInteger  extends TSchema, NumberOptions                                           { 'typebox:output': number, kind: typeof IntegerKind, type: 'integer' } 
+export interface TBoolean  extends TSchema, CustomOptions                                           { 'typebox:output': boolean, kind: typeof BooleanKind, type: 'boolean' } 
+export interface TNull     extends TSchema, CustomOptions                                           { 'typebox:output': null, kind: typeof NullKind, type: 'null' }
+export interface TUnknown  extends TSchema, CustomOptions                                           { 'typebox:output': unknown, kind: typeof UnknownKind }
+export interface TAny      extends TSchema, CustomOptions                                           { 'typebox:output': any, kind: typeof AnyKind }
 
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 // Extended Schema Types
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 
 export const ConstructorKind = Symbol('ConstructorKind')
 export const FunctionKind    = Symbol('FunctionKind')
 export const PromiseKind     = Symbol('PromiseKind')
 export const UndefinedKind   = Symbol('UndefinedKind')
 export const VoidKind        = Symbol('VoidKind')
-export interface TConstructor<T extends TSchema[], U extends TSchema> extends TSchema, CustomOptions { '#output': StaticConstructor<T, U>, kind: typeof ConstructorKind, type: 'constructor', arguments: TSchema[], returns: TSchema }
-export interface TFunction   <T extends TSchema[], U extends TSchema> extends TSchema, CustomOptions { '#output': StaticFunction<T, U>, kind: typeof FunctionKind,    type: 'function', arguments: TSchema[], returns: TSchema }
-export interface TPromise    <T extends TSchema> extends TSchema, CustomOptions                      { '#output': StaticPromise<T>, kind: typeof PromiseKind,     type: 'promise', item: TSchema }
-export interface TUndefined extends TSchema, CustomOptions                                           { '#output': undefined, kind: typeof UndefinedKind, type: 'undefined' }
-export interface TVoid      extends TSchema, CustomOptions                                           { '#output': void, kind: typeof VoidKind, type: 'void' }
+export interface TConstructor<T extends TSchema[], U extends TSchema> extends TSchema, CustomOptions { 'typebox:output': StaticConstructor<T, U>, kind: typeof ConstructorKind, type: 'constructor', arguments: TSchema[], returns: TSchema }
+export interface TFunction   <T extends TSchema[], U extends TSchema> extends TSchema, CustomOptions { 'typebox:output': StaticFunction<T, U>, kind: typeof FunctionKind,    type: 'function', arguments: TSchema[], returns: TSchema }
+export interface TPromise    <T extends TSchema> extends TSchema, CustomOptions                      { 'typebox:output': StaticPromise<T>, kind: typeof PromiseKind,     type: 'promise', item: TSchema }
+export interface TUndefined extends TSchema, CustomOptions                                           { 'typebox:output': undefined, kind: typeof UndefinedKind, type: 'undefined' }
+export interface TVoid      extends TSchema, CustomOptions                                           { 'typebox:output': void, kind: typeof VoidKind, type: 'void' }
 
 
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 // Utility Types
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 
-export type TRequired<T extends TProperties> = {
+export type UnionToIntersect<U>                                         = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+export type StaticReadonlyOptionalPropertyKeys <T extends TProperties>  = { [K in keyof T]: T[K] extends TReadonlyOptional<TSchema> ? K : never }[keyof T]
+export type StaticReadonlyPropertyKeys         <T extends TProperties>  = { [K in keyof T]: T[K] extends TReadonly<TSchema> ? K : never }[keyof T]
+export type StaticOptionalPropertyKeys         <T extends TProperties>  = { [K in keyof T]: T[K] extends TOptional<TSchema> ? K : never }[keyof T]
+export type StaticRequiredPropertyKeys         <T extends TProperties>  = keyof Omit<T, StaticReadonlyOptionalPropertyKeys<T> | StaticReadonlyPropertyKeys<T> | StaticOptionalPropertyKeys<T>>
+export type StaticIntersectEvaluate<T extends readonly TSchema[]> = {[K in keyof T]: Static<T[K]> }
+export type StaticIntersectReduce<I extends unknown, T extends readonly any[]> = T extends [infer A, ...infer B] ? StaticIntersectReduce<I & A, B> : I
+export type StaticRequired<T extends TProperties> = {
     [K in keyof T]: 
         T[K] extends TReadonlyOptional<infer U> ? TReadonly<U> :  
         T[K] extends TReadonly<infer U>         ? TReadonly<U> :
         T[K] extends TOptional<infer U>         ? U :  
         T[K]
 }
-export type TPartial<T extends TProperties> = {
+export type StaticPartial<T extends TProperties> = {
     [K in keyof T]:
         T[K] extends TReadonlyOptional<infer U> ? TReadonlyOptional<U> :  
         T[K] extends TReadonly<infer U>         ? TReadonlyOptional<U> :
@@ -183,47 +192,36 @@ export type TPartial<T extends TProperties> = {
 }
 
 // ------------------------------------------------------------------------
-// Static TSchemaence
+// Static Schema
 // ------------------------------------------------------------------------
-
-export type UnionToIntersect<U>                             = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
-export type IntersectEvaluate<T extends readonly TSchema[]> = {[K in keyof T]: Static<T[K]> }
-export type IntersectReduce<I extends unknown, T extends readonly any[]> = T extends [infer A, ...infer B] ? IntersectReduce<I & A, B> : I
-export type ReadonlyOptionalPropertyKeys <T extends TProperties> = { [K in keyof T]: T[K] extends TReadonlyOptional<TSchema> ? K : never }[keyof T]
-export type ReadonlyPropertyKeys         <T extends TProperties> = { [K in keyof T]: T[K] extends TReadonly<TSchema> ? K : never }[keyof T]
-export type OptionalPropertyKeys         <T extends TProperties> = { [K in keyof T]: T[K] extends TOptional<TSchema> ? K : never }[keyof T]
-export type RequiredPropertyKeys         <T extends TProperties> = keyof Omit<T, ReadonlyOptionalPropertyKeys<T> | ReadonlyPropertyKeys<T> | OptionalPropertyKeys<T>>
-export type ReduceStaticProperties<T> = {[K in keyof T]: T[K] }
 export type StaticProperties<T extends TProperties> =
-    { readonly [K in ReadonlyOptionalPropertyKeys<T>]?: Static<T[K]> } &
-    { readonly [K in ReadonlyPropertyKeys<T>]:          Static<T[K]> } &
-    {          [K in OptionalPropertyKeys<T>]?:         Static<T[K]> } &
-    {          [K in RequiredPropertyKeys<T>]:          Static<T[K]> }
+    { readonly [K in StaticReadonlyOptionalPropertyKeys<T>]?: Static<T[K]> } &
+    { readonly [K in StaticReadonlyPropertyKeys<T>]:          Static<T[K]> } &
+    {          [K in StaticOptionalPropertyKeys<T>]?:         Static<T[K]> } &
+    {          [K in StaticRequiredPropertyKeys<T>]:          Static<T[K]> }
 export type StaticRecord      <K extends TRecordKey, T extends TSchema> = 
     K extends TString           ? Record<string, Static<T>> : 
     K extends TNumber           ? Record<number, Static<T>> : 
-    K extends TKeyOf<TKey[]>    ? Record<K['#output'], Static<T>> : 
-    K extends TUnion<TSchema[]> ? Record<K['#output'], Static<T>> :
+    K extends TKeyOf<TKey[]>    ? Record<K['typebox:output'], Static<T>> : 
+    K extends TUnion<TSchema[]> ? Record<K['typebox:output'], Static<T>> :
     never
 export type StaticEnum        <T>                                               = T extends TEnumKey<infer U>[] ? U : never
 export type StaticKeyOf       <T extends TKey[]>                                = T extends Array<infer K> ? K : never
-export type StaticIntersect   <T extends readonly TSchema[]>                    = IntersectReduce<unknown, IntersectEvaluate<T>>
+export type StaticIntersect   <T extends readonly TSchema[]>                    = StaticIntersectReduce<unknown, StaticIntersectEvaluate<T>>
 export type StaticUnion       <T extends readonly TSchema[]>                    = { [K in keyof T]: Static<T[K]> }[number]
 export type StaticTuple       <T extends readonly TSchema[]>                    = { [K in keyof T]: Static<T[K]> }
-export type StaticObject      <T extends TProperties>                           = ReduceStaticProperties<StaticProperties<T>>
+export type StaticObject      <T extends TProperties>                           = StaticProperties<T> extends infer I ? {[K in keyof I]: I[K]}: never
 export type StaticArray       <T extends TSchema>                               = Array<Static<T>>
 export type StaticLiteral     <T extends TValue>                                = T
-
 export type StaticParameters  <T extends readonly TSchema[]> = {[K in keyof T]: Static<T[K]> }
 export type StaticConstructor <T extends readonly TSchema[], U extends TSchema> = new (...args: [...StaticParameters<T>]) => Static<U>
 export type StaticFunction    <T extends readonly TSchema[], U extends TSchema> = (...args: [...StaticParameters<T>]) => Static<U>
 export type StaticPromise     <T extends TSchema>                               = Promise<Static<T>>
+export type Static<T>                                                           = T extends TSchema ? T['typebox:output'] : never
 
-export type Static<T> = T extends TSchema ? T['#output'] : never
-
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 // Utility
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 
 function isObject(object: any) {
     return typeof object === 'object' && object !== null && !Array.isArray(object)
@@ -239,9 +237,9 @@ function clone(object: any): any {
     return object
 }
 
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 // TypeBuilder
-// ------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 
 export class TypeBuilder {
 
@@ -286,7 +284,7 @@ export class TypeBuilder {
             : { ...options, kind: ObjectKind, type: 'object', properties }) as any
     }
 
-    /** `Standard` Creates an intersection type. */
+    /** `Standard` Creates an intersect type. */
     public Intersect<T extends TSchema[]>(items: [...T], options: IntersectOptions = {}): TIntersect<T> {
         return { ...options, kind: IntersectKind, type: 'object', allOf: items } as any
     }
@@ -374,7 +372,7 @@ export class TypeBuilder {
     }
 
     /** `Standard` Makes all properties in the given object type required */
-    public Required<T extends TObject<any>>(schema: T, options: ObjectOptions = {}): TObject<TRequired<T['properties']>> {
+    public Required<T extends TObject<any>>(schema: T, options: ObjectOptions = {}): TObject<StaticRequired<T['properties']>> {
         const next = { ...clone(schema), ...options }
         next.required = Object.keys(next.properties)
         for(const key of Object.keys(next.properties)) {
@@ -390,7 +388,7 @@ export class TypeBuilder {
     }
     
     /** `Standard` Makes all properties in the given object type optional */
-    public Partial<T extends TObject<any>>(schema: T, options: ObjectOptions = {}): TObject<TPartial<T['properties']>> {
+    public Partial<T extends TObject<any>>(schema: T, options: ObjectOptions = {}): TObject<StaticPartial<T['properties']>> {
         const next = { ...clone(schema), ...options }
         delete next.required
         for(const key of Object.keys(next.properties)) {
@@ -458,8 +456,8 @@ export class TypeBuilder {
     /** `Experimental` Creates a recursive type */
     public Rec<T extends TSchema>(callback: (self: TAny) => T, options: CustomOptions = {}): T {
         const $id = options.$id || ''
-        const self = callback({ $ref: `${$id}#/definitions/self` } as any)
-        return { ...options, $ref: `${$id}#/definitions/self`, definitions: { self } } as unknown as T
+        const self = callback({ $ref: `${$id}#/$defs/self` } as any)
+        return { ...options, $ref: `${$id}#/$defs/self`, $defs: { self } } as unknown as T
     }
 
     /** `Experimental` Creates a recursive type. Pending https://github.com/ajv-validator/ajv/issues/1709 */
@@ -469,12 +467,12 @@ export class TypeBuilder {
     // }
 
     /** `Experimental` Creates a namespace for a set of related types */
-    public Namespace<T extends TDefinitions>(definitions: T, options: CustomOptions = {}): TNamespace<T> {
-        return { ...options, kind: BoxKind, definitions } as any
+    public Namespace<T extends TDefinitions>($defs: T, options: CustomOptions = {}): TNamespace<T> {
+        return { ...options, kind: BoxKind, $defs } as any
     }
     
     /** `Experimental` References a type within a namespace. The referenced namespace must specify an `$id` */
-    public Ref<T extends TNamespace<TDefinitions>, K extends keyof T['definitions']>(box: T, key: K): T['definitions'][K] 
+    public Ref<T extends TNamespace<TDefinitions>, K extends keyof T['$defs']>(box: T, key: K): T['$defs'][K] 
     
     /** `Experimental` References type. The referenced type must specify an `$id` */
     public Ref<T extends TSchema>(schema: T): T
@@ -482,7 +480,7 @@ export class TypeBuilder {
     public Ref(...args: any[]): any {
         const $id = args[0]['$id'] || '' as string 
         const key = args[1]              as string
-        return (args.length === 2) ? { $ref: `${$id}#/definitions/${key}` } : { $ref: $id }
+        return (args.length === 2) ? { $ref: `${$id}#/$defs/${key}` } : { $ref: $id }
     }
 }
 


### PR DESCRIPTION
## [0.22.0](https://www.npmjs.com/package/@sinclair/typebox/v/0.22.0)

Updates:

- The type `TSchema` is now expressed as an HKT compatible interface. All types now extend the `TSchema` interface and are themselves also expressed as interfaces. This work was undertaken to explore recursive type aliases in future releases.
- The phantom property `_infer` has been renamed to `typebox:output`. Callers should not interact with this property as it will always be `undefined` and used exclusively for optimizing type inference in TypeScript 4.5 and above.
- TypeBox re-adds the feature to deeply introspect schema properties. This feature was temporarily removed on the `0.21.0` update to resolve deep instantiation errors on TypeScript 4.5.
- The `Type.Box(...)` and `Type.Rec(...)` functions internally rename the property `definitions` to `$defs` inline with JSON schema draft 2019-09 conventions. Reference [here](https://opis.io/json-schema/2.x/definitions.html).