### PR TITLE
Namespace and Ref Types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,10 @@
 
 Updates:
 
-- The types `Type.Namespace()` and `Type.Ref()` are no longer experimental types and are promoted to `Standard`.
-- TypeBox now provides a specialized type named `TRef<TSchema>` that is returned on `Type.Ref()`. Previously the `Type.Ref()` function would return the same Schema that was passed in, this is no longer the case. The `TRef` also includes the `RefKind` symbol for introspection of reference types.
-- TypeBox now maintains an internal dictionary of all schemas that contain an `$id` property. This dictionary is checked whenever a user attempts to reference a type; mandating that all reference types contain a valid id.
-- The types `Type.Partial()` and `Type.Required()` now support reference types.
+- The types `Type.Namespace()` and `Type.Ref()` are promoted to `Standard`.
+- TypeBox adds a new type named `TRef<TSchema>` that is returned on calls to `Type.Ref(...)`. The `TRef` includes a `RefKind` symbol for introspection of the reference type.
+- TypeBox now maintains an internal dictionary of all schemas passed that contain an `$id` property. This dictionary is checked whenever a user attempts to reference a type and will throw if attempting to reference a target schema with no $id.
+- The types `Type.Partial(...)`, `Type.Required(...)`, `Type.Omit()` and `Type.Pick(...)` now support reference types. Note that when using these functions with references, TypeBox will replicate the source schema and apply the nessasary modifiers to the replication.
 
 ## [0.22.0](https://www.npmjs.com/package/@sinclair/typebox/v/0.22.0)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+## [0.23.0](https://www.npmjs.com/package/@sinclair/typebox/v/0.23.0)
+
+Updates:
+
+- The types `Type.Namespace()` and `Type.Ref()` are no longer experimental types and are promoted to `Standard`.
+- TypeBox now provides a specialized type named `TRef<TSchema>` that is returned on `Type.Ref()`. Previously the `Type.Ref()` function would return the same Schema that was passed in, this is no longer the case. The `TRef` also includes the `RefKind` symbol for introspection of reference types.
+- TypeBox now maintains an internal dictionary of all schemas that contain an `$id` property. This dictionary is checked whenever a user attempts to reference a type; mandating that all reference types contain a valid id.
+- The types `Type.Partial()` and `Type.Required()` now support reference types.
+
 ## [0.22.0](https://www.npmjs.com/package/@sinclair/typebox/v/0.22.0)
 
 Updates:

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,30 +1,15 @@
-import { TypeBuilder, TSchema, Static } from '@sinclair/typebox'
+import { Type, Static } from '@sinclair/typebox'
 
-// -----------------------------------------------------------
-// Open API Extended Types
-// -----------------------------------------------------------
+const T = Type.Object({
+    name:  Type.Optional(Type.String()),
+    order: Type.Number()
+}, { $id: 'T' })
 
-export type TNullable<T extends TSchema> = TSchema & {
-    ['$static']: Static<T> | null
-} & { nullable: true }
+const R = Type.Ref(T)
 
-export type TStringUnion<T extends string[]> = TSchema & {
-    ['$static']: {[K in keyof T]: T[K] }[number]
-    enum: T
-}
+const P = Type.Omit(T, ['name'])
 
-// -----------------------------------------------------------
-// Open API TypeBuilder
-// -----------------------------------------------------------
+console.log(P)
 
-export class OpenApiTypeBuilder extends TypeBuilder {
-    public Nullable<T extends TSchema>(schema: T): TNullable<T> {
-        return { ...schema, nullable: true } as any
-    }
+type T = Static<typeof P>
 
-    public StringUnion<T extends string[]>(values: [...T]): TStringUnion<T> {
-        return { enum: values } as any
-    }
-}
-
-const Type = new OpenApiTypeBuilder()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "json-schema",

--- a/spec/schema/omit.ts
+++ b/spec/schema/omit.ts
@@ -33,4 +33,12 @@ describe('Omit', () => {
         strictEqual(A.additionalProperties, false)
         strictEqual(T.additionalProperties, false)
     })
+    
+    it('Should construct new object when targetting reference', () => {
+        const T = Type.Object({ a: Type.String(), b: Type.String() }, { $id: 'T' })
+        const R = Type.Ref(T)
+        const P = Type.Omit(R, [])
+        strictEqual(P.properties.a.type, 'string')
+        strictEqual(P.properties.b.type, 'string')
+     })
 })

--- a/spec/schema/partial.ts
+++ b/spec/schema/partial.ts
@@ -41,6 +41,7 @@ describe('Partial', () => {
         strictEqual(A.additionalProperties, false)
         strictEqual(T.additionalProperties, false)
     })
+
     it('Should construct new object when targetting reference', () => {
         const T = Type.Object({ a: Type.String(), b: Type.String() }, { $id: 'T' })
         const R = Type.Ref(T)

--- a/spec/schema/partial.ts
+++ b/spec/schema/partial.ts
@@ -41,4 +41,11 @@ describe('Partial', () => {
         strictEqual(A.additionalProperties, false)
         strictEqual(T.additionalProperties, false)
     })
+    it('Should construct new object when targetting reference', () => {
+        const T = Type.Object({ a: Type.String(), b: Type.String() }, { $id: 'T' })
+        const R = Type.Ref(T)
+        const P = Type.Partial(R)
+        strictEqual(P.properties.a.type, 'string')
+        strictEqual(P.properties.b.type, 'string')
+     })
 })

--- a/spec/schema/pick.ts
+++ b/spec/schema/pick.ts
@@ -33,4 +33,11 @@ describe('Pick', () => {
         strictEqual(A.additionalProperties, false)
         strictEqual(T.additionalProperties, false)
     })
+    it('Should construct new object when targetting reference', () => {
+        const T = Type.Object({ a: Type.String(), b: Type.String() }, { $id: 'T' })
+        const R = Type.Ref(T)
+        const P = Type.Pick(R, ['a', 'b'])
+        strictEqual(P.properties.a.type, 'string')
+        strictEqual(P.properties.b.type, 'string')
+     })
 })

--- a/spec/schema/ref.ts
+++ b/spec/schema/ref.ts
@@ -30,18 +30,18 @@ describe('Ref', () => {
         }, [T])
     })
 
-    it('Should should not validate when not specifying an $id', () => {
-        const T = Type.Object({
-            x: Type.Number(),
-            y: Type.Number(),
-            z: Type.Number()
-        }, { })
-        const R = Type.Ref(T)
-        fail(R, { 
-            x: 1, 
-            y: 2, 
-            z: 3 
-        }, [T])
+    it('Should throw when not specifying an $id on target schema', () => {
+        try {
+            const T = Type.Object({
+                x: Type.Number(),
+                y: Type.Number(),
+                z: Type.Number()
+            }, { })
+            const R = Type.Ref(T)
+        } catch {
+            return
+        }
+        throw Error('Expected throw')
     })
 
     it('Should not validate when not adding additional schema', () => {

--- a/spec/schema/required.ts
+++ b/spec/schema/required.ts
@@ -41,4 +41,12 @@ describe('Required', () => {
         strictEqual(A.additionalPropeties, false)
         strictEqual(T.additionalPropeties, false)
     })
+
+    it('Should construct new object when targetting reference', () => {
+        const T = Type.Object({ a: Type.String(), b: Type.String() }, { $id: 'T' })
+        const R = Type.Ref(T)
+        const P = Type.Required(R)
+        strictEqual(P.properties.a.type, 'string')
+        strictEqual(P.properties.b.type, 'string')
+     })
 })

--- a/spec/types/ref.ts
+++ b/spec/types/ref.ts
@@ -2,7 +2,7 @@ import * as Spec from './spec'
 import { Type } from './typebox'
 
 {
-    const T = Type.String()
+    const T = Type.String({ $id: 'T' })
 
     const R = Type.Ref(T)
 

--- a/spec/types/typebox.d.ts
+++ b/spec/types/typebox.d.ts
@@ -28,6 +28,7 @@ export declare const BooleanKind: unique symbol;
 export declare const NullKind: unique symbol;
 export declare const UnknownKind: unique symbol;
 export declare const AnyKind: unique symbol;
+export declare const RefKind: unique symbol;
 export interface CustomOptions {
     $id?: string;
     title?: string;
@@ -174,6 +175,11 @@ export interface TAny extends TSchema, CustomOptions {
     $static: any;
     kind: typeof AnyKind;
 }
+export interface TRef<T extends TSchema> extends TSchema, CustomOptions {
+    $static: Static<T>;
+    kind: typeof RefKind;
+    $ref: string;
+}
 export declare const ConstructorKind: unique symbol;
 export declare const FunctionKind: unique symbol;
 export declare const PromiseKind: unique symbol;
@@ -209,6 +215,9 @@ export interface TVoid extends TSchema, CustomOptions {
     kind: typeof VoidKind;
     type: 'void';
 }
+export declare type Pickable = TObject<TProperties> | TRef<TObject<TProperties>>;
+export declare type PickablePropertyKeys<T extends Pickable> = T extends TObject<infer U> ? keyof U : T extends TRef<TObject<infer U>> ? keyof U : never;
+export declare type PickableProperties<T extends Pickable> = T extends TObject<infer U> ? U : T extends TRef<TObject<infer U>> ? U : never;
 export declare type UnionToIntersect<U> = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never;
 export declare type StaticReadonlyOptionalPropertyKeys<T extends TProperties> = {
     [K in keyof T]: T[K] extends TReadonlyOptional<TSchema> ? K : never;
@@ -262,6 +271,7 @@ export declare type StaticFunction<T extends readonly TSchema[], U extends TSche
 export declare type StaticPromise<T extends TSchema> = Promise<Static<T>>;
 export declare type Static<T extends TSchema> = T['$static'];
 export declare class TypeBuilder {
+    private readonly schemas;
     /** `Standard` Modifies an object property to be both readonly and optional */
     ReadonlyOptional<T extends TSchema>(item: T): TReadonlyOptional<T>;
     /** `Standard` Modifies an object property to be readonly */
@@ -299,17 +309,17 @@ export declare class TypeBuilder {
     /** `Standard` Creates an any type */
     Any(options?: CustomOptions): TAny;
     /** `Standard` Creates a keyof type from the given object */
-    KeyOf<T extends TObject<TProperties>>(schema: T, options?: CustomOptions): TKeyOf<(keyof T['properties'])[]>;
+    KeyOf<T extends TObject<TProperties>>(object: T, options?: CustomOptions): TKeyOf<(keyof T['properties'])[]>;
     /** `Standard` Creates a record type */
     Record<K extends TRecordKey, T extends TSchema>(key: K, value: T, options?: ObjectOptions): TRecord<K, T>;
     /** `Standard` Makes all properties in the given object type required */
-    Required<T extends TObject<any>>(schema: T, options?: ObjectOptions): TObject<StaticRequired<T['properties']>>;
+    Required<T extends TObject<TProperties> | TRef<TObject<TProperties>>>(object: T, options?: ObjectOptions): TObject<StaticRequired<T['properties']>>;
     /** `Standard` Makes all properties in the given object type optional */
-    Partial<T extends TObject<any>>(schema: T, options?: ObjectOptions): TObject<StaticPartial<T['properties']>>;
+    Partial<T extends TObject<TProperties> | TRef<TObject<TProperties>>>(object: T, options?: ObjectOptions): TObject<StaticPartial<T['properties']>>;
     /** `Standard` Picks property keys from the given object type */
-    Pick<T extends TObject<TProperties>, K extends (keyof T['properties'])[]>(schema: T, keys: [...K], options?: ObjectOptions): TObject<Pick<T['properties'], K[number]>>;
+    Pick<T extends TObject<TProperties> | TRef<TObject<TProperties>>, K extends PickablePropertyKeys<T>[]>(object: T, keys: [...K], options?: ObjectOptions): TObject<Pick<PickableProperties<T>, K[number]>>;
     /** `Standard` Omits property keys from the given object type */
-    Omit<T extends TObject<any>, K extends (keyof T['properties'])[]>(schema: T, keys: [...K], options?: ObjectOptions): TObject<Omit<T['properties'], K[number]>>;
+    Omit<T extends TObject<TProperties> | TRef<TObject<TProperties>>, K extends PickablePropertyKeys<T>[]>(object: T, keys: [...K], options?: ObjectOptions): TObject<Omit<PickableProperties<T>, K[number]>>;
     /** `Standard` Omits the `kind` and `modifier` properties from the underlying schema */
     Strict<T extends TSchema>(schema: T, options?: CustomOptions): T;
     /** `Extended` Creates a constructor type */
@@ -322,14 +332,17 @@ export declare class TypeBuilder {
     Undefined(options?: CustomOptions): TUndefined;
     /** `Extended` Creates a void type */
     Void(options?: CustomOptions): TVoid;
+    /** `Standard` Creates a namespace for a set of related types */
+    Namespace<T extends TDefinitions>($defs: T, options?: CustomOptions): TNamespace<T>;
+    /** `Standard` References a type within a namespace. The referenced namespace must specify an `$id` */
+    Ref<T extends TNamespace<TDefinitions>, K extends keyof T['$defs']>(box: T, key: K): TRef<T['$defs'][K]>;
+    /** `Standard` References type. The referenced type must specify an `$id` */
+    Ref<T extends TSchema>(schema: T): TRef<T>;
     /** `Experimental` Creates a recursive type */
     Rec<T extends TSchema>(callback: (self: TAny) => T, options?: CustomOptions): T;
-    /** `Experimental` Creates a recursive type. Pending https://github.com/ajv-validator/ajv/issues/1709 */
-    /** `Experimental` Creates a namespace for a set of related types */
-    Namespace<T extends TDefinitions>($defs: T, options?: CustomOptions): TNamespace<T>;
-    /** `Experimental` References a type within a namespace. The referenced namespace must specify an `$id` */
-    Ref<T extends TNamespace<TDefinitions>, K extends keyof T['$defs']>(box: T, key: K): T['$defs'][K];
-    /** `Experimental` References type. The referenced type must specify an `$id` */
-    Ref<T extends TSchema>(schema: T): T;
+    /** Stores this schema if it contains an $id. This function is used for later referencing. */
+    private Store;
+    /** Resolves a schema by $id. May resolve recursively if the target is a TRef. */
+    private Resolve;
 }
 export declare const Type: TypeBuilder;


### PR DESCRIPTION
## [0.23.0](https://www.npmjs.com/package/@sinclair/typebox/v/0.23.0)

Updates:

- The types `Type.Namespace()` and `Type.Ref()` are promoted to `Standard`.
- TypeBox adds a new type named `TRef<TSchema>` that is returned on calls to `Type.Ref(...)`. The `TRef` includes a `RefKind` symbol for introspection of the reference type.
- TypeBox now maintains an internal dictionary of all schemas passed that contain an `$id` property. This dictionary is checked whenever a user attempts to reference a type and will throw if attempting to reference a target schema with no $id.
- The types `Type.Partial(...)`, `Type.Required(...)`, `Type.Omit()` and `Type.Pick(...)` now support reference types. Note that when using these functions with references, TypeBox will replicate the source schema and apply the nessasary modifiers to the replication.
