### PR TITLE
Allow object size properties

### DIFF
--- a/spec/schema/object.ts
+++ b/spec/schema/object.ts
@@ -74,6 +74,31 @@ describe('Object', () => {
         })
     })
 
+    it('Should not allow an empty object if minProperties is set to 1', () => {
+        const T = Type.Object({
+            a: Type.Optional(Type.Number()),
+            b: Type.Optional(Type.String())
+        }, { additionalProperties: false, minProperties: 1 })
+        ok(T, { a: 1 })
+        ok(T, { b: 'hello' })
+        fail(T, {})
+    })
+
+    it('Should not allow 3 properties if maxProperties is set to 2', () => {
+        const T = Type.Object({
+            a: Type.Optional(Type.Number()),
+            b: Type.Optional(Type.String()),
+            c: Type.Optional(Type.Boolean()),
+        }, { additionalProperties: false, maxProperties: 2 })
+        ok(T, { a: 1 })
+        ok(T, { a: 1, b: 'hello' })
+        fail(T, {
+            a: 1,
+            b: 'hello',
+            c: true
+        })
+    })
+
     it('Should not allow additionalProperties if additionalProperties is false', () => {
         const T = Type.Object({
             a: Type.Number(),

--- a/spec/types/typebox.d.ts
+++ b/spec/types/typebox.d.ts
@@ -63,6 +63,8 @@ export declare type IntersectOptions = {
 } & CustomOptions;
 export declare type ObjectOptions = {
     additionalProperties?: boolean;
+    minProperties?: number;
+    maxProperties?: number;
 } & CustomOptions;
 export declare type TDefinitions = {
     [key: string]: TSchema;

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -110,6 +110,8 @@ export type IntersectOptions = {
 
 export type ObjectOptions = {
     additionalProperties?: boolean
+    minProperties?: number;
+    maxProperties?: number;
 } & CustomOptions
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds support for `minProperties` and `maxProperties` in accordance to the JSON schema spec: https://json-schema.org/understanding-json-schema/reference/object.html#size

Fixes https://github.com/sinclairzx81/typebox/issues/152