### PR TITLE
next: Namespace `symbol`s to avoid collisions

### DIFF
--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -30,8 +30,8 @@ THE SOFTWARE.
 // Symbols
 // --------------------------------------------------------------------------
 
-export const Kind = Symbol.for('Kind')
-export const Modifier = Symbol.for('Modifier')
+export const Kind = Symbol.for('typebox.Kind')
+export const Modifier = Symbol.for('typebox.Modifier')
 
 // --------------------------------------------------------------------------
 // Modifiers


### PR DESCRIPTION
Because `Kind` and `Modifier` are common strings, it is reasonable that someone could accidentally get the same symbol for them via `Symbol.for()`.

This PR "namespaces" them by using a `typebox.` prefix, to avoid accidental collisions.