### PR TITLE
Pick and Omit with KeyOf

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,28 +1,14 @@
 import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Conditional } from '@sinclair/typebox/conditional'
 import { Value } from '@sinclair/typebox/value'
-import { Type, Static, TObject, TOmit, TUnion, TTuple, TLiteral, ObjectOptions, TPick, ObjectPropertyKeys, UnionToTuple } from '@sinclair/typebox'
+import { Type, Static } from '@sinclair/typebox'
 
-
-const S = Type.Object({
-  x: Type.Number(),
-  y: Type.Number(),
-  z: Type.Number(),
-  a: Type.Number(),
-  b: Type.Number(),
-  c: Type.Number()
-})
-
-const A = Type.Object({
+const T = Type.Object({
   x: Type.Number(),
   y: Type.Number(),
   z: Type.Number()
 })
 
-
-
-const T = Type.Omit(S, Type.KeyOf(A))
+type T = Static<typeof T>
 
 console.log(T)
-
-type T = Static<typeof T>

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,14 +1,28 @@
 import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Conditional } from '@sinclair/typebox/conditional'
 import { Value } from '@sinclair/typebox/value'
-import { Type, Static } from '@sinclair/typebox'
+import { Type, Static, TObject, TOmit, TUnion, TTuple, TLiteral, ObjectOptions, TPick, ObjectPropertyKeys, UnionToTuple } from '@sinclair/typebox'
 
-const T = Type.Object({
+
+const S = Type.Object({
+  x: Type.Number(),
+  y: Type.Number(),
+  z: Type.Number(),
+  a: Type.Number(),
+  b: Type.Number(),
+  c: Type.Number()
+})
+
+const A = Type.Object({
   x: Type.Number(),
   y: Type.Number(),
   z: Type.Number()
 })
 
-type T = Static<typeof T>
+
+
+const T = Type.Omit(S, Type.KeyOf(A))
 
 console.log(T)
+
+type T = Static<typeof T>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.24.18",
+  "version": "0.24.19",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "json-schema",

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -227,14 +227,13 @@ export interface TIntersect<T extends TObject[] = TObject[]> extends TObject {
 // KeyOf: Implemented by way of Union<TLiteral<string>>
 // --------------------------------------------------------------------------
 
-
 export type UnionToIntersect<U> = (U extends unknown ? (arg: U) => 0 : never) extends (arg: infer I) => 0 ? I : never
 
 export type UnionLast<U> = UnionToIntersect<U extends unknown ? (x: U) => 0 : never> extends (x: infer L) => 0 ? L : never
 
 export type UnionToTuple<U, L = UnionLast<U>> = [U] extends [never] ? [] : [...UnionToTuple<Exclude<U, L>>, L]
 
-export type UnionStringLiteralToTuple<T> = T extends TUnion<infer L> ? ({[I in keyof L]: L[I] extends TLiteral<infer C> ? C : never }) : never
+export type UnionStringLiteralToTuple<T> = T extends TUnion<infer L> ? { [I in keyof L]: L[I] extends TLiteral<infer C> ? C : never } : never
 
 export type TKeyOf<T extends TObject> = { [K in ObjectPropertyKeys<T>]: TLiteral<K> } extends infer R ? UnionToTuple<R[keyof R]> : never
 
@@ -703,7 +702,7 @@ export class TypeBuilder {
 
   /** Creates a new object whose properties are omitted from the given object */
   public Omit<T extends TObject, K extends TUnion<TLiteral<string>[]>>(schema: T, keys: K, options?: ObjectOptions): TOmit<T, UnionStringLiteralToTuple<K>>
-  
+
   /** Creates a new object whose properties are omitted from the given object */
   public Omit<T extends TObject, K extends ObjectPropertyKeys<T>[]>(schema: T, keys: [...K], options?: ObjectOptions): TOmit<T, K>
 
@@ -750,7 +749,7 @@ export class TypeBuilder {
 
   /** Creates a object whose properties are picked from the given object */
   public Pick<T extends TObject, K extends TUnion<TLiteral<string>[]>>(schema: T, keys: K, options?: ObjectOptions): TPick<T, UnionStringLiteralToTuple<K>>
-  
+
   /** Creates a object whose properties are picked from the given object */
   public Pick<T extends TObject, K extends ObjectPropertyKeys<T>[]>(schema: T, keys: [...K], options?: ObjectOptions): TPick<T, K>
 

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -227,11 +227,14 @@ export interface TIntersect<T extends TObject[] = TObject[]> extends TObject {
 // KeyOf: Implemented by way of Union<TLiteral<string>>
 // --------------------------------------------------------------------------
 
-type UnionToIntersect<U> = (U extends unknown ? (arg: U) => 0 : never) extends (arg: infer I) => 0 ? I : never
 
-type UnionLast<U> = UnionToIntersect<U extends unknown ? (x: U) => 0 : never> extends (x: infer L) => 0 ? L : never
+export type UnionToIntersect<U> = (U extends unknown ? (arg: U) => 0 : never) extends (arg: infer I) => 0 ? I : never
 
-type UnionToTuple<U, L = UnionLast<U>> = [U] extends [never] ? [] : [...UnionToTuple<Exclude<U, L>>, L]
+export type UnionLast<U> = UnionToIntersect<U extends unknown ? (x: U) => 0 : never> extends (x: infer L) => 0 ? L : never
+
+export type UnionToTuple<U, L = UnionLast<U>> = [U] extends [never] ? [] : [...UnionToTuple<Exclude<U, L>>, L]
+
+export type UnionStringLiteralToTuple<T> = T extends TUnion<infer L> ? ({[I in keyof L]: L[I] extends TLiteral<infer C> ? C : never }) : never
 
 export type TKeyOf<T extends TObject> = { [K in ObjectPropertyKeys<T>]: TLiteral<K> } extends infer R ? UnionToTuple<R[keyof R]> : never
 
@@ -441,7 +444,7 @@ export interface TString extends TSchema, StringOptions<string> {
 // Tuple
 // --------------------------------------------------------------------------
 
-export type TupleToArray<T extends TTuple<TSchema[]>> = T extends TTuple<infer R> ? R : never // how to get at inner generic parameter
+export type TupleToArray<T extends TTuple<TSchema[]>> = T extends TTuple<infer R> ? R : never
 
 export interface TTuple<T extends TSchema[] = TSchema[]> extends TSchema {
   [Kind]: 'Tuple'
@@ -699,11 +702,18 @@ export class TypeBuilder {
   }
 
   /** Creates a new object whose properties are omitted from the given object */
-  public Omit<T extends TObject, Properties extends Array<ObjectPropertyKeys<T>>>(schema: T, keys: [...Properties], options: ObjectOptions = {}): TOmit<T, Properties> {
+  public Omit<T extends TObject, K extends TUnion<TLiteral<string>[]>>(schema: T, keys: K, options?: ObjectOptions): TOmit<T, UnionStringLiteralToTuple<K>>
+  
+  /** Creates a new object whose properties are omitted from the given object */
+  public Omit<T extends TObject, K extends ObjectPropertyKeys<T>[]>(schema: T, keys: [...K], options?: ObjectOptions): TOmit<T, K>
+
+  /** Creates a new object whose properties are omitted from the given object */
+  public Omit(schema: any, keys: any, options: ObjectOptions = {}) {
+    const select: string[] = keys[Kind] === 'Union' ? keys.anyOf.map((schema: TLiteral) => schema.const) : keys
     const next = { ...this.Clone(schema), ...options, [Hint]: 'Omit' }
-    next.required = next.required ? next.required.filter((key: string) => !keys.includes(key as any)) : undefined
+    next.required = next.required ? next.required.filter((key: string) => !select.includes(key as any)) : undefined
     for (const key of Object.keys(next.properties)) {
-      if (keys.includes(key as any)) delete next.properties[key]
+      if (select.includes(key as any)) delete next.properties[key]
     }
     return this.Create(next)
   }
@@ -738,12 +748,19 @@ export class TypeBuilder {
     return this.Create(next)
   }
 
-  /** Creates a new object whose properties are picked from the given object */
-  public Pick<T extends TObject, Properties extends Array<ObjectPropertyKeys<T>>>(schema: T, keys: [...Properties], options: ObjectOptions = {}): TPick<T, Properties> {
+  /** Creates a object whose properties are picked from the given object */
+  public Pick<T extends TObject, K extends TUnion<TLiteral<string>[]>>(schema: T, keys: K, options?: ObjectOptions): TPick<T, UnionStringLiteralToTuple<K>>
+  
+  /** Creates a object whose properties are picked from the given object */
+  public Pick<T extends TObject, K extends ObjectPropertyKeys<T>[]>(schema: T, keys: [...K], options?: ObjectOptions): TPick<T, K>
+
+  /** Creates a object whose properties are picked from the given object */
+  public Pick<T extends TObject, K extends ObjectPropertyKeys<T>[]>(schema: any, keys: any, options: ObjectOptions = {}) {
+    const select: string[] = keys[Kind] === 'Union' ? keys.anyOf.map((schema: TLiteral) => schema.const) : keys
     const next = { ...this.Clone(schema), ...options, [Hint]: 'Pick' }
-    next.required = next.required ? next.required.filter((key: any) => keys.includes(key)) : undefined
+    next.required = next.required ? next.required.filter((key: any) => select.includes(key)) : undefined
     for (const key of Object.keys(next.properties)) {
-      if (!keys.includes(key as any)) delete next.properties[key]
+      if (!select.includes(key as any)) delete next.properties[key]
     }
     return this.Create(next)
   }

--- a/test/runtime/compiler/omit.ts
+++ b/test/runtime/compiler/omit.ts
@@ -42,4 +42,19 @@ describe('type/compiler/Omit', () => {
     strictEqual(A.additionalProperties, false)
     strictEqual(T.additionalProperties, false)
   })
+
+  it('Should omit with keyof object', () => {
+    const A = Type.Object({
+      x: Type.Number(),
+      y: Type.Number(),
+      z: Type.Number(),
+    })
+    const B = Type.Object({
+      x: Type.Number(),
+      y: Type.Number(),
+    })
+    const T = Type.Omit(A, Type.KeyOf(B), { additionalProperties: false })
+    ok(T, { z: 0 })
+    fail(T, { x: 0, y: 0, z: 0 })
+  })
 })

--- a/test/runtime/compiler/pick.ts
+++ b/test/runtime/compiler/pick.ts
@@ -42,4 +42,19 @@ describe('type/compiler/Pick', () => {
     strictEqual(A.additionalProperties, false)
     strictEqual(T.additionalProperties, false)
   })
+
+  it('Should pick with keyof object', () => {
+    const A = Type.Object({
+      x: Type.Number(),
+      y: Type.Number(),
+      z: Type.Number(),
+    })
+    const B = Type.Object({
+      x: Type.Number(),
+      y: Type.Number(),
+    })
+    const T = Type.Pick(A, Type.KeyOf(B), { additionalProperties: false })
+    ok(T, { x: 0, y: 0 })
+    fail(T, { x: 0, y: 0, z: 0 })
+  })
 })

--- a/test/runtime/schema/omit.ts
+++ b/test/runtime/schema/omit.ts
@@ -42,4 +42,19 @@ describe('type/schema/Omit', () => {
     strictEqual(A.additionalProperties, false)
     strictEqual(T.additionalProperties, false)
   })
+
+  it('Should omit with keyof object', () => {
+    const A = Type.Object({
+      x: Type.Number(),
+      y: Type.Number(),
+      z: Type.Number(),
+    })
+    const B = Type.Object({
+      x: Type.Number(),
+      y: Type.Number(),
+    })
+    const T = Type.Omit(A, Type.KeyOf(B), { additionalProperties: false })
+    ok(T, { z: 0 })
+    fail(T, { x: 0, y: 0, z: 0 })
+  })
 })

--- a/test/runtime/schema/pick.ts
+++ b/test/runtime/schema/pick.ts
@@ -42,4 +42,19 @@ describe('type/schema/Pick', () => {
     strictEqual(A.additionalProperties, false)
     strictEqual(T.additionalProperties, false)
   })
+
+  it('Should pick with keyof object', () => {
+    const A = Type.Object({
+      x: Type.Number(),
+      y: Type.Number(),
+      z: Type.Number(),
+    })
+    const B = Type.Object({
+      x: Type.Number(),
+      y: Type.Number(),
+    })
+    const T = Type.Pick(A, Type.KeyOf(B), { additionalProperties: false })
+    ok(T, { x: 0, y: 0 })
+    fail(T, { x: 0, y: 0, z: 0 })
+  })
 })

--- a/test/static/omit.ts
+++ b/test/static/omit.ts
@@ -2,19 +2,36 @@ import { Expect } from './assert'
 import { Type, Static } from '@sinclair/typebox'
 
 {
-  const T = Type.Omit(
-    Type.Object({
-      A: Type.String(),
-      B: Type.String(),
-      C: Type.String(),
-    }),
-    ['C'],
-  )
+  const A = Type.Object({
+    A: Type.String(),
+    B: Type.String(),
+    C: Type.String(),
+  })
+
+  const T = Type.Omit(A, ['A', 'B'])
 
   type T = Static<typeof T>
 
   Expect(T).ToBe<{
-    A: string
-    B: string
+    C: string
+  }>()
+}
+{
+  const A = Type.Object({
+    A: Type.String(),
+    B: Type.String(),
+    C: Type.String(),
+  })
+  const B = Type.Object({
+    A: Type.String(),
+    B: Type.String(),
+  })
+
+  const T = Type.Omit(A, Type.KeyOf(B))
+
+  type T = Static<typeof T>
+
+  Expect(T).ToBe<{
+    C: string
   }>()
 }

--- a/test/static/pick.ts
+++ b/test/static/pick.ts
@@ -2,18 +2,39 @@ import { Expect } from './assert'
 import { Type, Static } from '@sinclair/typebox'
 
 {
-  const T = Type.Pick(
-    Type.Object({
-      A: Type.String(),
-      B: Type.String(),
-      C: Type.String(),
-    }),
-    ['C'],
-  )
+  const A = Type.Object({
+    A: Type.String(),
+    B: Type.String(),
+    C: Type.String(),
+  })
+
+  const T = Type.Pick(A, ['A', 'B'])
 
   type T = Static<typeof T>
 
   Expect(T).ToBe<{
-    C: string
+    A: string
+    B: string
+  }>()
+}
+
+{
+  const A = Type.Object({
+    A: Type.String(),
+    B: Type.String(),
+    C: Type.String(),
+  })
+  const B = Type.Object({
+    A: Type.String(),
+    B: Type.String(),
+  })
+
+  const T = Type.Pick(A, Type.KeyOf(B))
+
+  type T = Static<typeof T>
+
+  Expect(T).ToBe<{
+    A: string
+    B: string
   }>()
 }


### PR DESCRIPTION
This PR adds an additional `TUnion<TLiteral<string>[]>` overload for the `Pick` and `Omit` utility types. This enables new objects to compose from keys of another object. As `KeyOf` is expressed via `TUnion<TLiteral<string>[]>` this update now permits the following implementation.

```typescript
// ------------------------------------------------------------
// TypeScript
// ------------------------------------------------------------
{
  type A = {
    x: number,
    y: number,
    z: number
  }
  type B = {
    x: number,
    y: number
  }
  type T = Omit<A, keyof B>

  // type T = { z: number }
}
// ------------------------------------------------------------
// TypeBox
// ------------------------------------------------------------
{
  const A = Type.Object({
    x: Type.Number(),
    y: Type.Number(),
    z: Type.Number(),
  })

  const B = Type.Object({
    x: Type.Number(),
    y: Type.Number(),
  })

  const T = Type.Omit(A, Type.KeyOf(B))

  type T = Static<typeof T>

  // type T = { z: number }
}
```