### PR TITLE
Convert

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
         "node_modules": true,
         "package-lock.json": true
     },
-    "typescript.tsdk": "node_modules\\typescript\\lib"
+    "typescript.tsdk": "node_modules\\typescript\\lib",
+    "editor.suggest.showStatusBar": false
 }

--- a/example/index.ts
+++ b/example/index.ts
@@ -5,52 +5,12 @@ import { Format } from '@sinclair/typebox/format'
 import { Value } from '@sinclair/typebox/value'
 import { Type, Static } from '@sinclair/typebox'
 
-import * as ts from 'typescript'
-
-Format.Set('typescript', value => {
-  const filename = "test.ts";
-  const code = `const test: number = 1 + 2;`;
-  
-  const sourceFile = ts.createSourceFile(
-      filename, code, ts.ScriptTarget.Latest
-  );
-  
-  const defaultCompilerHost = ts.createCompilerHost({});
-  
-  const customCompilerHost: ts.CompilerHost = {
-      getSourceFile: (name, languageVersion) => {
-          console.log(`getSourceFile ${name}`);
-  
-          if (name === filename) {
-              return sourceFile;
-          } else {
-              return defaultCompilerHost.getSourceFile(
-                  name, languageVersion
-              );
-          }
-      },
-      writeFile: (filename, data) => {},
-      getDefaultLibFileName: () => "lib.d.ts",
-      useCaseSensitiveFileNames: () => false,
-      getCanonicalFileName: filename => filename,
-      getCurrentDirectory: () => "",
-      getNewLine: () => "\n",
-      getDirectories: () => [],
-      fileExists: () => true,
-      readFile: () => ""
-  };
-  
-  const program = ts.createProgram(
-      ["test.ts"], {}, customCompilerHost
-  );
-  const x = ts.getPreEmitDiagnostics(program);
-  console.log(x)
-  
-  return true
+const T = Type.Object({
+  x: Type.Number(),
+  y: Type.Number(),
+  z: Type.Number()
 })
-// ts.getPreEmitDiagnostics(program); // check these
-const T = Type.String({ format: 'typescript'})
 
-const A = Value.Check(T, 'const message: string = 10')
+type T = Static<typeof T>
 
-console.log(A, 1)
+console.log(T)

--- a/example/index.ts
+++ b/example/index.ts
@@ -5,10 +5,52 @@ import { Format } from '@sinclair/typebox/format'
 import { Value } from '@sinclair/typebox/value'
 import { Type, Static } from '@sinclair/typebox'
 
+import * as ts from 'typescript'
 
-const T = Type.RegEx(/foo/, { default: 'foo' })
+Format.Set('typescript', value => {
+  const filename = "test.ts";
+  const code = `const test: number = 1 + 2;`;
+  
+  const sourceFile = ts.createSourceFile(
+      filename, code, ts.ScriptTarget.Latest
+  );
+  
+  const defaultCompilerHost = ts.createCompilerHost({});
+  
+  const customCompilerHost: ts.CompilerHost = {
+      getSourceFile: (name, languageVersion) => {
+          console.log(`getSourceFile ${name}`);
+  
+          if (name === filename) {
+              return sourceFile;
+          } else {
+              return defaultCompilerHost.getSourceFile(
+                  name, languageVersion
+              );
+          }
+      },
+      writeFile: (filename, data) => {},
+      getDefaultLibFileName: () => "lib.d.ts",
+      useCaseSensitiveFileNames: () => false,
+      getCanonicalFileName: filename => filename,
+      getCurrentDirectory: () => "",
+      getNewLine: () => "\n",
+      getDirectories: () => [],
+      fileExists: () => true,
+      readFile: () => ""
+  };
+  
+  const program = ts.createProgram(
+      ["test.ts"], {}, customCompilerHost
+  );
+  const x = ts.getPreEmitDiagnostics(program);
+  console.log(x)
+  
+  return true
+})
+// ts.getPreEmitDiagnostics(program); // check these
+const T = Type.String({ format: 'typescript'})
 
+const A = Value.Check(T, 'const message: string = 10')
 
-const A = Value.Cast(T, 1)
-
-console.log(A)
+console.log(A, 1)

--- a/example/index.ts
+++ b/example/index.ts
@@ -5,12 +5,10 @@ import { Format } from '@sinclair/typebox/format'
 import { Value } from '@sinclair/typebox/value'
 import { Type, Static } from '@sinclair/typebox'
 
-const T = Type.Object({
-  x: Type.Number(),
-  y: Type.Number(),
-  z: Type.Number()
-})
 
-type T = Static<typeof T>
+const T = Type.RegEx(/foo/, { default: 'foo' })
 
-console.log(T)
+
+const A = Value.Cast(T, 1)
+
+console.log(A)

--- a/readme.md
+++ b/readme.md
@@ -864,18 +864,20 @@ console.log(C.Code())                                // return function check(va
 
 ## Formats
 
-Use the `Format` module to define custom string formats.
+Use the `Format` module to define custom string formats. Formats offer greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html), but may come at the cost of schema portability. The Format module is a shared registry that is accessed by the `TypeCompiler` and `Value` modules when runtime type checking. TypeBox does not provide any built in formats by default.
+
+The Format module is an optional import.
 
 ```typescript
 import { Format } from '@sinclair/typebox/format'
 ```
 
-Formats are shared between `Value` and the `TypeCompiler` modules.
+The following creates a format to validate Mongo ObjectId strings
 
 ```typescript
 //--------------------------------------------------------------------------------------------
 //
-// Use Format.Set(...) to define a format
+// Register format with Format.Set(...)
 //
 //--------------------------------------------------------------------------------------------
 
@@ -883,15 +885,19 @@ Format.Set('ObjectId', value => /^[0-9a-fA-F]{24}$/.test(value))
 
 //--------------------------------------------------------------------------------------------
 //
-// The format is now available to TypeCompiler and Value modules
+// The format can be used by TypeCompiler and Value modules
 //
 //--------------------------------------------------------------------------------------------
 
 const T = Type.String({ format: 'ObjectId' })
 
-const R1 = TypeCompiler.Compile(T).Check('507f1f77bcf86cd799439011')
+const V = '507f1f77bcf86cd799439011'
 
-const R2 = Value.Check(T, '507f1f77bcf86cd799439011')                
+const R1 = TypeCompiler.Compile(T).Check(V)          // R1 = true
+
+const R2 = Value.Check(T, V)                         // R2 = true
+
+
 ```
 
 ## Benchmark

--- a/readme.md
+++ b/readme.md
@@ -864,9 +864,9 @@ console.log(C.Code())                                // return function check(va
 
 ## Formats
 
-Use the `Format` module to define custom string formats. Formats provide greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html) to validate complex string encodings, but may come at a cost of schema portability. Formats are internally shared between the TypeCompiler and Value modules. TypeBox does not provide any built in formats by default.
+Use the `Format` module to create custom string formats. Formats provide much greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html) to validate complex string encodings, but may come at a cost of schema portability. Formats are internally shared between the TypeCompiler and Value modules. TypeBox does not provide any built in formats by default.
 
-The Format module is an optional import.
+The format module is an optional import.
 
 ```typescript
 import { Format } from '@sinclair/typebox/format'
@@ -877,7 +877,7 @@ The following creates a custom format to validate Mongo `ObjectId` strings
 ```typescript
 //--------------------------------------------------------------------------------------------
 //
-// Register format with Format.Set(...)
+// Format.Set(...) to create the format
 //
 //--------------------------------------------------------------------------------------------
 
@@ -885,7 +885,7 @@ Format.Set('ObjectId', value => /^[0-9a-fA-F]{24}$/.test(value))
 
 //--------------------------------------------------------------------------------------------
 //
-// The format can be used by TypeCompiler and Value modules
+// The format can now be used by TypeCompiler and Value modules
 //
 //--------------------------------------------------------------------------------------------
 

--- a/readme.md
+++ b/readme.md
@@ -864,7 +864,7 @@ console.log(C.Code())                                // return function check(va
 
 ## Formats
 
-Use the `Format` module to define custom string formats. Formats offer greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html) to validate complex string encodings. This module is shared between the TypeCompiler and Value modules and may be accessed when calling `Check(...)` functions. TypeBox does not provide any built in formats by default.
+Use the `Format` module to define custom string formats. Formats offer greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html) to validate complex string encodings. This module is shared between the TypeCompiler and Value modules and may be accessed when calling respective `Check(...)` functions. TypeBox does not provide any built in formats by default.
 
 The Format module is an optional import.
 

--- a/readme.md
+++ b/readme.md
@@ -898,7 +898,7 @@ console.log(C.Code())                                // return function check(va
 
 ## Formats
 
-Use the `Format` module to create custom string formats. Formats provide much greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html), but may come at a cost of schema portability. Formats are internally shared between the TypeCompiler and Value modules. TypeBox does not provide any built in formats by default.
+Use the `Format` module to create custom string formats. Formats provide greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html), but may come at a cost of schema portability. Formats are internally shared between the TypeCompiler and Value modules. TypeBox does not provide any built in formats by default.
 
 The format module is an optional import.
 

--- a/readme.md
+++ b/readme.md
@@ -864,7 +864,7 @@ console.log(C.Code())                                // return function check(va
 
 ## Formats
 
-Use the `Format` module to define custom string formats. Formats offer greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html) to validate complex string encodings. Formats are shared between the TypeCompiler and Value modules. TypeBox does not provide any built in formats by default.
+Use the `Format` module to define custom string formats. Formats provide greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html) to validate complex string encodings, but may come at a cost of schema portability. Formats are internally shared between the TypeCompiler and Value modules. TypeBox does not provide any built in formats by default.
 
 The Format module is an optional import.
 

--- a/readme.md
+++ b/readme.md
@@ -872,7 +872,7 @@ The Format module is an optional import.
 import { Format } from '@sinclair/typebox/format'
 ```
 
-The following creates a format to validate Mongo ObjectId strings
+The following creates a custom format to validate Mongo `ObjectId` strings
 
 ```typescript
 //--------------------------------------------------------------------------------------------

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ import { Static, Type } from '@sinclair/typebox'
 const T = Type.String()     // const T = { type: 'string' }
 
 type T = Static<typeof T>   // type T = string
+
+
 ```
 
 <a name="Overview"></a>
@@ -146,6 +148,8 @@ function receive(value: T) {                         // ... as a Type
     // ok...
   }
 }
+
+
 ```
 
 ## Types
@@ -340,6 +344,8 @@ The following table outlines the TypeBox mappings between TypeScript and JSON sc
 │                                │                             │ }                              │
 │                                │                             │                                │
 └────────────────────────────────┴─────────────────────────────┴────────────────────────────────┘
+
+
 ```
 
 ## Modifiers
@@ -382,6 +388,8 @@ TypeBox provides modifiers that can be applied to an objects properties. This al
 │                                │                             │ }                              │
 │                                │                             │                                │
 └────────────────────────────────┴─────────────────────────────┴────────────────────────────────┘
+
+
 ```
 
 ## Options
@@ -397,6 +405,8 @@ const T = Type.Number({ multipleOf: 2 })
 
 // array must have at least 5 integer values
 const T = Type.Array(Type.Integer(), { minItems: 5 })
+
+
 ```
 
 ## Extended Types
@@ -459,6 +469,8 @@ In addition to JSON schema types, TypeBox provides several extended types that a
 │                                │                             │ }                              │
 │                                │                             │                                │
 └────────────────────────────────┴─────────────────────────────┴────────────────────────────────┘
+
+
 ```
 
 ## Reference Types
@@ -474,6 +486,8 @@ const T = Type.String({ $id: 'T' })                  // const T = {
 const R = Type.Ref(T)                                // const R = {
                                                      //    $ref: 'T'
                                                      // }
+
+
 ```
 
 ## Recursive Types
@@ -511,6 +525,8 @@ function test(node: Node) {
                  .nodes[0].nodes[0]
                  .id
 }
+
+
 ```
 
 ## Generic Types
@@ -541,6 +557,8 @@ const U = Nullable(Type.Number())                    // const U = {
                                                      // }
 
 type U = Static<typeof U>                            // type U = number | null
+
+
 ```
 
 ## Unsafe Types
@@ -553,6 +571,8 @@ const T = Type.Unsafe<string>({ type: 'number' })    // const T = {
                                                      // }
 
 type T = Static<typeof T>                            // type T = string
+
+
 ```
 
 This function can be used to create custom schemas for validators that require specific schema representations. An example of this might be OpenAPI's `nullable` and `enum` schemas which are not provided by TypeBox. The following demonstrates using `Type.Unsafe(...)` to create these types.
@@ -593,6 +613,8 @@ const T = StringEnum(['A', 'B', 'C'])                // const T = {
                                                      // }
 
 type T = Static<typeof T>                            // type T = 'A' | 'B' | 'C'
+
+
 ```
 
 ## Conditional Types
@@ -644,6 +666,8 @@ The following table shows the TypeBox mappings between TypeScript and JSON schem
 │ )                              │                             │                                │
 │                                │                             │                                │
 └────────────────────────────────┴─────────────────────────────┴────────────────────────────────┘
+
+
 ```
 
 ## Values
@@ -705,6 +729,8 @@ if(TypeGuard.TString(T)) {
     
   // T is TString
 }
+
+
 ```
 
 ## Strict
@@ -732,6 +758,8 @@ const U = Type.Strict(T)                             // const U = {
                                                      //     } 
                                                      //   } 
                                                      // }
+
+
 ```
 
 ## Validation
@@ -795,6 +823,8 @@ const T = Type.Object({
 //--------------------------------------------------------------------------------------------
 
 const R = ajv.validate(T, { x: 1, y: 2, z: 3 })      // const R = true
+
+
 ```
 
 Please refer to the official Ajv [documentation](https://ajv.js.org/guide/getting-started.html) for additional information on using Ajv.
@@ -819,6 +849,8 @@ const C = TypeCompiler.Compile(Type.Object({         // const C: TypeCheck<TObje
 }))                                                  // }>>
 
 const R = C.Check({ x: 1, y: 2, z: 3 })              // const R = true 
+
+
 ```
 
 Validation errors can be read with the `Errors(...)` function.
@@ -860,6 +892,8 @@ console.log(C.Code())                                // return function check(va
                                                      //     (typeof value === 'string')
                                                      //   )
                                                      // }
+
+
 ```
 
 ## Formats

--- a/readme.md
+++ b/readme.md
@@ -864,7 +864,7 @@ console.log(C.Code())                                // return function check(va
 
 ## Formats
 
-Use the `Format` module to define custom string formats. Formats offer greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html), but may come at the cost of schema portability. The Format module is a shared registry that is accessed by the `TypeCompiler` and `Value` modules when runtime type checking. TypeBox does not provide any built in formats by default.
+Use the `Format` module to define custom string formats. Formats offer greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html) to validate complex string encodings. This module is shared between the TypeCompiler and Value modules and may be accessed when calling `Check(...)` functions. TypeBox does not provide any built in formats by default.
 
 The Format module is an optional import.
 

--- a/readme.md
+++ b/readme.md
@@ -898,7 +898,7 @@ console.log(C.Code())                                // return function check(va
 
 ## Formats
 
-Use the `Format` module to create custom string formats. Formats provide much greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html) to validate complex string encodings, but may come at a cost of schema portability. Formats are internally shared between the TypeCompiler and Value modules. TypeBox does not provide any built in formats by default.
+Use the `Format` module to create custom string formats. Formats provide much greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html), but may come at a cost of schema portability. Formats are internally shared between the TypeCompiler and Value modules. TypeBox does not provide any built in formats by default.
 
 The format module is an optional import.
 

--- a/readme.md
+++ b/readme.md
@@ -864,7 +864,7 @@ console.log(C.Code())                                // return function check(va
 
 ## Formats
 
-Use the `Format` module to define custom string formats. Formats offer greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html) to validate complex string encodings. This module is shared between the TypeCompiler and Value modules and may be accessed when calling respective `Check(...)` functions. TypeBox does not provide any built in formats by default.
+Use the `Format` module to define custom string formats. Formats offer greater flexibility over [string patterns](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html) to validate complex string encodings. Formats are shared between the TypeCompiler and Value modules. TypeBox does not provide any built in formats by default.
 
 The Format module is an optional import.
 

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -33,7 +33,7 @@ export namespace Format {
   const formats = new Map<string, FormatValidationFunction>()
 
   /** Clears all formats */
-  export function Clear(format: string) {
+  export function Clear() {
     return formats.clear()
   }
 

--- a/src/value/value.ts
+++ b/src/value/value.ts
@@ -52,9 +52,9 @@ export namespace Value {
     return ValueCheck.Check(schema, references, value)
   }
 
-  /** Casts a value into a structure matching the given type. The result will be a new value that retains as much information of the original value as possible. */
+  /** Casts a value into a given type. The return value will retain as much information of the original value as possible. Cast will convert string, number and boolean values if a reasonable conversion is possible. */
   export function Cast<T extends Types.TSchema, R extends Types.TSchema[]>(schema: T, references: [...R], value: unknown): Types.Static<T>
-  /** Casts a value into a structure matching the given type. The result will be a new value that retains as much information of the original value as possible. */
+  /** Casts a value into a given type. The return value will retain as much information of the original value as possible. Cast will convert string, number and boolean values if a reasonable conversion is possible. */
   export function Cast<T extends Types.TSchema>(schema: T, value: unknown): Types.Static<T>
   export function Cast(...args: any[]) {
     const [schema, references, value] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], [], args[1]]

--- a/test/runtime/value/cast/boolean.ts
+++ b/test/runtime/value/cast/boolean.ts
@@ -13,7 +13,7 @@ describe('value/cast/Boolean', () => {
   })
 
   it('Should upcast from number', () => {
-    const value = 1
+    const value = 0
     const result = Value.Cast(T, value)
     Assert.deepEqual(result, E)
   })
@@ -49,5 +49,81 @@ describe('value/cast/Boolean', () => {
     const value = true
     const result = Value.Cast(T, value)
     Assert.deepEqual(result, true)
+  })
+
+  // ------------------------------------------------------
+  // Conversion
+  // ------------------------------------------------------
+
+  it('Should convert string', () => {
+    const T = Type.Boolean()
+    {
+      const result = Value.Cast(T, 'true')
+      Assert.deepEqual(result, true)
+    }
+    {
+      const result = Value.Cast(T, 'TRUE')
+      Assert.deepEqual(result, true)
+    }
+    {
+      const result = Value.Cast(T, 'True')
+      Assert.deepEqual(result, true)
+    }
+    {
+      const result = Value.Cast(T, 'Foo')
+      Assert.deepEqual(result, false)
+    }
+  })
+
+  it('Should convert number', () => {
+    const T = Type.Boolean()
+    {
+      const result = Value.Cast(T, 1)
+      Assert.deepEqual(result, true)
+    }
+    {
+      const result = Value.Cast(T, 0)
+      Assert.deepEqual(result, false)
+    }
+    {
+      const result = Value.Cast(T, 2)
+      Assert.deepEqual(result, false)
+    }
+  })
+
+  it('Should convert boolean', () => {
+    const T = Type.Boolean()
+    {
+      const result = Value.Cast(T, true)
+      Assert.deepEqual(result, true)
+    }
+    {
+      const result = Value.Cast(T, false)
+      Assert.deepEqual(result, false)
+    }
+  })
+
+  it('Should convert null', () => {
+    const T = Type.Boolean()
+    const result = Value.Cast(T, null)
+    Assert.deepEqual(result, false)
+  })
+
+  it('Should convert undefined', () => {
+    const T = Type.Boolean()
+    const result = Value.Cast(T, null)
+    Assert.deepEqual(result, false)
+  })
+
+  it('Should convert object', () => {
+    const T = Type.Boolean()
+    const result = Value.Cast(T, {})
+    Assert.deepEqual(result, false)
+  })
+
+  it('Should convert array', () => {
+    const T = Type.Boolean()
+    const result = Value.Cast(T, [])
+    Assert.deepEqual(result, false)
   })
 })

--- a/test/runtime/value/cast/integer.ts
+++ b/test/runtime/value/cast/integer.ts
@@ -44,4 +44,80 @@ describe('value/cast/Integer', () => {
     const result = Value.Cast(T, value)
     Assert.deepEqual(result, E)
   })
+
+  // ------------------------------------------------------
+  // Conversion
+  // ------------------------------------------------------
+
+  it('Should convert string', () => {
+    const T = Type.Integer()
+    {
+      const result = Value.Cast(T, '1')
+      Assert.deepEqual(result, 1)
+    }
+    {
+      const result = Value.Cast(T, '3.14')
+      Assert.deepEqual(result, 3)
+    }
+    {
+      const result = Value.Cast(T, 'Foo')
+      Assert.deepEqual(result, 0)
+    }
+    {
+      const result = Value.Cast(T, '-100')
+      Assert.deepEqual(result, '-100')
+    }
+  })
+
+  it('Should convert number', () => {
+    const T = Type.Integer()
+    {
+      const result = Value.Cast(T, 0)
+      Assert.deepEqual(result, 0)
+    }
+    {
+      const result = Value.Cast(T, 1)
+      Assert.deepEqual(result, 1)
+    }
+    {
+      const result = Value.Cast(T, 2)
+      Assert.deepEqual(result, 2)
+    }
+  })
+
+  it('Should convert boolean', () => {
+    const T = Type.Integer()
+    {
+      const result = Value.Cast(T, true)
+      Assert.deepEqual(result, 0)
+    }
+    {
+      const result = Value.Cast(T, false)
+      Assert.deepEqual(result, 0)
+    }
+  })
+
+  it('Should convert null', () => {
+    const T = Type.Integer()
+    const result = Value.Cast(T, null)
+    Assert.deepEqual(result, 0)
+  })
+
+  it('Should convert undefined', () => {
+    const T = Type.Integer()
+    const result = Value.Cast(T, null)
+    Assert.deepEqual(result, 0)
+  })
+
+  it('Should convert object', () => {
+    const T = Type.Integer()
+    const result = Value.Cast(T, {})
+    Assert.deepEqual(result, 0)
+  })
+
+  it('Should convert array', () => {
+    const T = Type.Integer()
+    const result = Value.Cast(T, [])
+    Assert.deepEqual(result, 0)
+  })
 })

--- a/test/runtime/value/cast/number.ts
+++ b/test/runtime/value/cast/number.ts
@@ -50,4 +50,80 @@ describe('value/cast/Number', () => {
     const result = Value.Cast(T, value)
     Assert.deepEqual(result, 123)
   })
+
+  // ------------------------------------------------------
+  // Conversion
+  // ------------------------------------------------------
+
+  it('Should convert string', () => {
+    const T = Type.Number()
+    {
+      const result = Value.Cast(T, '1')
+      Assert.deepEqual(result, 1)
+    }
+    {
+      const result = Value.Cast(T, '3.14')
+      Assert.deepEqual(result, 3.14)
+    }
+    {
+      const result = Value.Cast(T, 'Foo')
+      Assert.deepEqual(result, 0)
+    }
+    {
+      const result = Value.Cast(T, '-100')
+      Assert.deepEqual(result, '-100')
+    }
+  })
+
+  it('Should convert number', () => {
+    const T = Type.Number()
+    {
+      const result = Value.Cast(T, 0)
+      Assert.deepEqual(result, 0)
+    }
+    {
+      const result = Value.Cast(T, 1)
+      Assert.deepEqual(result, 1)
+    }
+    {
+      const result = Value.Cast(T, 2)
+      Assert.deepEqual(result, 2)
+    }
+  })
+
+  it('Should convert boolean', () => {
+    const T = Type.Number()
+    {
+      const result = Value.Cast(T, true)
+      Assert.deepEqual(result, 0)
+    }
+    {
+      const result = Value.Cast(T, false)
+      Assert.deepEqual(result, 0)
+    }
+  })
+
+  it('Should convert null', () => {
+    const T = Type.Number()
+    const result = Value.Cast(T, null)
+    Assert.deepEqual(result, 0)
+  })
+
+  it('Should convert undefined', () => {
+    const T = Type.Number()
+    const result = Value.Cast(T, null)
+    Assert.deepEqual(result, 0)
+  })
+
+  it('Should convert object', () => {
+    const T = Type.Number()
+    const result = Value.Cast(T, {})
+    Assert.deepEqual(result, 0)
+  })
+
+  it('Should convert array', () => {
+    const T = Type.Number()
+    const result = Value.Cast(T, [])
+    Assert.deepEqual(result, 0)
+  })
 })

--- a/test/runtime/value/cast/regex.ts
+++ b/test/runtime/value/cast/regex.ts
@@ -3,13 +3,13 @@ import { Type } from '@sinclair/typebox'
 import { Assert } from '../../assert/index'
 
 describe('value/cast/RegEx', () => {
-  const T = Type.RegEx(/.*/, { default: 'foo' })
+  const T = Type.RegEx(/foo/, { default: 'foo' })
   const E = 'foo'
 
   it('Should upcast from string', () => {
     const value = 'hello'
     const result = Value.Cast(T, value)
-    Assert.deepEqual(result, value) // this matches the wildcard, and is preserved
+    Assert.deepEqual(result, 'foo')
   })
 
   it('Should upcast from number', () => {
@@ -46,8 +46,60 @@ describe('value/cast/RegEx', () => {
   })
 
   it('Should preserve', () => {
-    const value = 'bar'
+    const value = 'foo'
     const result = Value.Cast(T, value)
     Assert.deepEqual(result, value)
+  })
+
+  // ---------------------------------------------------
+  // Conversion
+  // ---------------------------------------------------
+
+  it('Should convert bigint', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, 1n)
+    Assert.deepEqual(result, '1')
+  })
+
+  it('Should convert number', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, 1)
+    Assert.deepEqual(result, '1')
+  })
+
+  it('Should convert true', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, true)
+    Assert.deepEqual(result, 'true')
+  })
+
+  it('Should convert false', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, false)
+    Assert.deepEqual(result, 'false')
+  })
+
+  it('Should convert null', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, null)
+    Assert.deepEqual(result, '')
+  })
+
+  it('Should convert undefined', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, undefined)
+    Assert.deepEqual(result, '')
+  })
+
+  it('Should convert object', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, {})
+    Assert.deepEqual(result, '')
+  })
+
+  it('Should convert array', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, [])
+    Assert.deepEqual(result, '')
   })
 })

--- a/test/runtime/value/cast/string.ts
+++ b/test/runtime/value/cast/string.ts
@@ -1,0 +1,107 @@
+import { Value } from '@sinclair/typebox/value'
+import { Type } from '@sinclair/typebox'
+import { Assert } from '../../assert/index'
+
+describe('value/cast/String', () => {
+  const T = Type.String()
+  const E = ''
+
+  it('Should upcast from string', () => {
+    const value = 'hello'
+    const result = Value.Cast(T, value)
+    Assert.deepEqual(result, 'hello')
+  })
+
+  it('Should upcast from number', () => {
+    const value = 1
+    const result = Value.Cast(T, value)
+    Assert.deepEqual(result, '1') // conversion
+  })
+
+  it('Should upcast from boolean', () => {
+    const value = true
+    const result = Value.Cast(T, value)
+    Assert.deepEqual(result, 'true') // conversion
+  })
+
+  it('Should upcast from object', () => {
+    const value = {}
+    const result = Value.Cast(T, value)
+    Assert.deepEqual(result, E)
+  })
+  it('Should upcast from array', () => {
+    const value = [1]
+    const result = Value.Cast(T, value)
+    Assert.deepEqual(result, E)
+  })
+
+  it('Should upcast from undefined', () => {
+    const value = undefined
+    const result = Value.Cast(T, value)
+    Assert.deepEqual(result, E)
+  })
+
+  it('Should upcast from null', () => {
+    const value = null
+    const result = Value.Cast(T, value)
+    Assert.deepEqual(result, E)
+  })
+
+  it('Should preserve', () => {
+    const value = 'foo'
+    const result = Value.Cast(T, value)
+    Assert.deepEqual(result, value)
+  })
+
+  // ---------------------------------------------------
+  // Conversion
+  // ---------------------------------------------------
+
+  it('Should convert bigint', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, 1n)
+    Assert.deepEqual(result, '1')
+  })
+
+  it('Should convert number', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, 1)
+    Assert.deepEqual(result, '1')
+  })
+
+  it('Should convert true', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, true)
+    Assert.deepEqual(result, 'true')
+  })
+
+  it('Should convert false', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, false)
+    Assert.deepEqual(result, 'false')
+  })
+
+  it('Should convert null', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, null)
+    Assert.deepEqual(result, '')
+  })
+
+  it('Should convert undefined', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, undefined)
+    Assert.deepEqual(result, '')
+  })
+
+  it('Should convert object', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, {})
+    Assert.deepEqual(result, '')
+  })
+
+  it('Should convert array', () => {
+    const T = Type.String()
+    const result = Value.Cast(T, [])
+    Assert.deepEqual(result, '')
+  })
+})

--- a/test/runtime/value/cast/union.ts
+++ b/test/runtime/value/cast/union.ts
@@ -88,7 +88,7 @@ describe('value/cast/Union', () => {
   })
 
   it('Should infer A into B through heuristics and fix property', () => {
-    const value = { type: 'A', a: 'a', b: 'b', c: true }
+    const value = { type: 'A', a: 'a', b: 'b', c: null }
     const result = Value.Cast(T, value)
     Assert.deepEqual(result, { type: 'B', a: 'a', b: 'b', c: '' })
   })


### PR DESCRIPTION
This PR adds automatic type conversion to `Value.Cast(...)` for string, number, boolean and integer values. This functionality is considered standard as it falls under the "retain as much information as possible" intent of `Value.Cast(...)`.

The following are the conversion rules

```typescript
// ---
const T = Type.String()
Value.Cast(T, null)   // ''
Value.Cast(T, 1)      // '1'
Value.Cast(T, '2')    // '2'
Value.Cast(T, 3.14)   // '3.14'
// ---
const T = Type.Number()
Value.Cast(T, null)   // 0
Value.Cast(T, 1)      // 1
Value.Cast(T, '2')    // 2
Value.Cast(T, '3.14') // 3.14
// ---
const T = Type.Integer()
Value.Cast(T, null)   // 0
Value.Cast(T, 1)      // 1
Value.Cast(T, '2')    // 2
Value.Cast(T, '3.14') // 3
// ---
const T = Type.Boolean()
Value.Cast(T, null)   // false
Value.Cast(T, 1)      // true
Value.Cast(T, 0)      // false
Value.Cast(T, 2)      // false
Value.Cast(T, 'true') // true
Value.Cast(T, 'TRUE') // true
Value.Cast(T, 'True') // true
Value.Cast(T, 'TruE') // false
```