### PR TITLE
Pick/Omit: delete the `required` property if empty

### DIFF
--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -743,7 +743,10 @@ export class TypeBuilder {
   public Omit(schema: any, keys: any, options: ObjectOptions = {}) {
     const select: string[] = keys[Kind] === 'Union' ? keys.anyOf.map((schema: TLiteral) => schema.const) : keys
     const next = { ...this.Clone(schema), ...options, [Hint]: 'Omit' }
-    next.required = next.required ? next.required.filter((key: string) => !select.includes(key as any)) : undefined
+    if (next.required) {
+      next.required = next.required.filter((key: string) => !select.includes(key as any))
+      if (next.required.length === 0) delete next.required
+    }
     for (const key of Object.keys(next.properties)) {
       if (select.includes(key as any)) delete next.properties[key]
     }
@@ -790,7 +793,10 @@ export class TypeBuilder {
   public Pick<T extends TObject, K extends ObjectPropertyKeys<T>[]>(schema: any, keys: any, options: ObjectOptions = {}) {
     const select: string[] = keys[Kind] === 'Union' ? keys.anyOf.map((schema: TLiteral) => schema.const) : keys
     const next = { ...this.Clone(schema), ...options, [Hint]: 'Pick' }
-    next.required = next.required ? next.required.filter((key: any) => select.includes(key)) : undefined
+    if (next.required) {
+      next.required = next.required.filter((key: any) => select.includes(key))
+      if (next.required.length === 0) delete next.required
+    }
     for (const key of Object.keys(next.properties)) {
       if (!select.includes(key as any)) delete next.properties[key]
     }

--- a/test/runtime/schema/omit.ts
+++ b/test/runtime/schema/omit.ts
@@ -29,6 +29,19 @@ describe('type/schema/Omit', () => {
     strictEqual(T.required!.includes('z'), false)
   })
 
+  it('Should delete the required property if no required properties remain', () => {
+    const A = Type.Object(
+      {
+        x: Type.Optional(Type.Number()),
+        y: Type.ReadonlyOptional(Type.Number()),
+        z: Type.Number(),
+      },
+      { additionalProperties: false },
+    )
+    const T = Type.Omit(A, ['z'])
+    strictEqual(T.required, undefined)
+  })
+
   it('Should inherit options from the source object', () => {
     const A = Type.Object(
       {

--- a/test/runtime/schema/pick.ts
+++ b/test/runtime/schema/pick.ts
@@ -29,6 +29,19 @@ describe('type/schema/Pick', () => {
     strictEqual(T.required!.includes('z'), false)
   })
 
+  it('Should delete the required property if no required properties remain', () => {
+    const A = Type.Object(
+      {
+        x: Type.Optional(Type.Number()),
+        y: Type.ReadonlyOptional(Type.Number()),
+        z: Type.Number(),
+      },
+      { additionalProperties: false },
+    )
+    const T = Type.Pick(A, ['x', 'y'])
+    strictEqual(T.required, undefined)
+  })
+
   it('Should inherit options from the source object', () => {
     const A = Type.Object(
       {


### PR DESCRIPTION
If there are no required properties as a result of `Type.Pick` or `Type.Omit`, produce an object without `required` instead of `required: []`.

```ts
const O = Type.Object({
  x: Type.Optional(Type.Number()),
  y: Type.Number(),
})
const T = Type.Pick(O, ['x'])

// before:
const T = {
  type: 'object',
  properties: {
    x: { type: 'number' }
  },
  required: [],
}

// after:
const T = {
  type: 'object',
  properties: {
    x: { type: 'number' }
  },
}
```
This is relevant to OpenAPI 3.0.3 which refers to [an older JSON Schema Specification](https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-00#section-5.15):
> required
> The value of this keyword MUST be an array.  This array MUST have at least one element.

It's also consistent with `Type.Object`, which only adds `required` if non-empty.