### PR TITLE
Non-Boolean Additional Properties

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,10 @@
 Updates:
 - [264](https://github.com/sinclairzx81/typebox/pull/264) TypeBox now provides preliminary support for non-boolean `additionalProperties`. This allows existing `TObject` schemas to be augmented with additional properties of a known type.
 
+Additional:
+
+- TypeBox provides an additional reference `codegen` module for generating raw JSON Schema from TypeScript types via the TS compiler API. This generator may be used in future tooling.
+
 ## [0.24.44](https://www.npmjs.com/package/@sinclair/typebox/v/0.24.44)
 
 Updates:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## [0.24.49](https://www.npmjs.com/package/@sinclair/typebox/v/0.24.49)
+
+Updates:
+- [264](https://github.com/sinclairzx81/typebox/pull/264) TypeBox now provides preliminary support for non-boolean `additionalProperties`. This allows existing `TObject` schemas to be augmented with additional properties of a known type.
+
 ## [0.24.44](https://www.npmjs.com/package/@sinclair/typebox/v/0.24.44)
 
 Updates:

--- a/codegen/jsonschema.ts
+++ b/codegen/jsonschema.ts
@@ -209,11 +209,7 @@ export namespace JsonSchemaCodeGen {
   }
 
   function* ConditionalTypeNode(node: ts.ConditionalTypeNode): IterableIterator<string> {
-    const checkType = Collect(node.checkType)
-    const extendsType = Collect(node.extendsType)
-    const trueType = Collect(node.trueType)
-    const falseType = Collect(node.falseType)
-    yield `${checkType} ${extendsType}, ${trueType}, ${falseType})`
+    throw new NonExpressable('ConditionalTypeNode')
   }
 
   function* TypeReferenceNode(node: ts.TypeReferenceNode): IterableIterator<string> {
@@ -348,7 +344,7 @@ export namespace JsonSchemaCodeGen {
     } else if (ts.isConditionalTypeNode(node)) {
       return yield* ConditionalTypeNode(node)
     } else if (node.kind === ts.SyntaxKind.KeyOfKeyword) {
-      throw Error('JsonSchemaCodeGen: keyof cannot be expressed as json schema')
+      throw new NonExpressable('KeyOfKeyword')
     } else if (node.kind === ts.SyntaxKind.NumberKeyword) {
       return yield `{ 
         type: 'number' 
@@ -362,7 +358,7 @@ export namespace JsonSchemaCodeGen {
         type: 'boolean' 
       }`
     } else if (node.kind === ts.SyntaxKind.UndefinedKeyword) {
-      throw Error('JsonSchemaCodeGen: undefined cannot be expressed as json schema')
+      throw new NonExpressable('UndefinedKeyword')
     } else if (node.kind === ts.SyntaxKind.UnknownKeyword) {
       return yield `{
 
@@ -389,7 +385,7 @@ export namespace JsonSchemaCodeGen {
         type: 'null' 
       }`
     } else if (node.kind === ts.SyntaxKind.VoidKeyword) {
-      throw Error('JsonSchemaCodeGen: void cannot be expressed as json schema')
+      throw new NonExpressable('KeyOfKeyword')
     } else if (node.kind === ts.SyntaxKind.EndOfFileToken) {
       return
     } else if (node.kind === ts.SyntaxKind.SyntaxList) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.24.48",
+  "version": "0.24.49",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/readme.md
+++ b/readme.md
@@ -1062,29 +1062,29 @@ This benchmark measures compilation performance for varying types. You can revie
 ┌──────────────────┬────────────┬──────────────┬──────────────┬──────────────┐
 │     (index)      │ Iterations │     Ajv      │ TypeCompiler │ Performance  │
 ├──────────────────┼────────────┼──────────────┼──────────────┼──────────────┤
-│           Number │    2000    │ '    384 ms' │ '      9 ms' │ '   42.67 x' │
-│           String │    2000    │ '    322 ms' │ '      8 ms' │ '   40.25 x' │
-│          Boolean │    2000    │ '    310 ms' │ '      6 ms' │ '   51.67 x' │
-│             Null │    2000    │ '    271 ms' │ '      6 ms' │ '   45.17 x' │
-│            RegEx │    2000    │ '    491 ms' │ '     12 ms' │ '   40.92 x' │
-│          ObjectA │    2000    │ '   2935 ms' │ '     44 ms' │ '   66.70 x' │
-│          ObjectB │    2000    │ '   3076 ms' │ '     30 ms' │ '  102.53 x' │
-│            Tuple │    2000    │ '   1274 ms' │ '     22 ms' │ '   57.91 x' │
-│            Union │    2000    │ '   1281 ms' │ '     22 ms' │ '   58.23 x' │
-│          Vector4 │    2000    │ '   1602 ms' │ '     17 ms' │ '   94.24 x' │
-│          Matrix4 │    2000    │ '    959 ms' │ '     10 ms' │ '   95.90 x' │
-│   Literal_String │    2000    │ '    337 ms' │ '      6 ms' │ '   56.17 x' │
-│   Literal_Number │    2000    │ '    376 ms' │ '      5 ms' │ '   75.20 x' │
-│  Literal_Boolean │    2000    │ '    370 ms' │ '      5 ms' │ '   74.00 x' │
-│     Array_Number │    2000    │ '    733 ms' │ '      9 ms' │ '   81.44 x' │
-│     Array_String │    2000    │ '    764 ms' │ '     10 ms' │ '   76.40 x' │
-│    Array_Boolean │    2000    │ '    818 ms' │ '      6 ms' │ '  136.33 x' │
-│    Array_ObjectA │    2000    │ '   3744 ms' │ '     35 ms' │ '  106.97 x' │
-│    Array_ObjectB │    2000    │ '   3893 ms' │ '     34 ms' │ '  114.50 x' │
-│      Array_Tuple │    2000    │ '   2229 ms' │ '     16 ms' │ '  139.31 x' │
-│      Array_Union │    2000    │ '   1705 ms' │ '     18 ms' │ '   94.72 x' │
-│    Array_Vector4 │    2000    │ '   2261 ms' │ '     17 ms' │ '  133.00 x' │
-│    Array_Matrix4 │    2000    │ '   1574 ms' │ '     14 ms' │ '  112.43 x' │
+│           Number │    2000    │ '    428 ms' │ '     12 ms' │ '   35.67 x' │
+│           String │    2000    │ '    337 ms' │ '     12 ms' │ '   28.08 x' │
+│          Boolean │    2000    │ '    317 ms' │ '     11 ms' │ '   28.82 x' │
+│             Null │    2000    │ '    274 ms' │ '     10 ms' │ '   27.40 x' │
+│            RegEx │    2000    │ '    500 ms' │ '     18 ms' │ '   27.78 x' │
+│          ObjectA │    2000    │ '   2717 ms' │ '     49 ms' │ '   55.45 x' │
+│          ObjectB │    2000    │ '   2854 ms' │ '     37 ms' │ '   77.14 x' │
+│            Tuple │    2000    │ '   1224 ms' │ '     21 ms' │ '   58.29 x' │
+│            Union │    2000    │ '   1266 ms' │ '     23 ms' │ '   55.04 x' │
+│          Vector4 │    2000    │ '   1513 ms' │ '     19 ms' │ '   79.63 x' │
+│          Matrix4 │    2000    │ '    841 ms' │ '     12 ms' │ '   70.08 x' │
+│   Literal_String │    2000    │ '    327 ms' │ '      8 ms' │ '   40.88 x' │
+│   Literal_Number │    2000    │ '    358 ms' │ '      6 ms' │ '   59.67 x' │
+│  Literal_Boolean │    2000    │ '    355 ms' │ '      5 ms' │ '   71.00 x' │
+│     Array_Number │    2000    │ '    685 ms' │ '      7 ms' │ '   97.86 x' │
+│     Array_String │    2000    │ '    716 ms' │ '     11 ms' │ '   65.09 x' │
+│    Array_Boolean │    2000    │ '    732 ms' │ '      6 ms' │ '  122.00 x' │
+│    Array_ObjectA │    2000    │ '   3503 ms' │ '     34 ms' │ '  103.03 x' │
+│    Array_ObjectB │    2000    │ '   3626 ms' │ '     38 ms' │ '   95.42 x' │
+│      Array_Tuple │    2000    │ '   2095 ms' │ '     21 ms' │ '   99.76 x' │
+│      Array_Union │    2000    │ '   1577 ms' │ '     22 ms' │ '   71.68 x' │
+│    Array_Vector4 │    2000    │ '   2172 ms' │ '     17 ms' │ '  127.76 x' │
+│    Array_Matrix4 │    2000    │ '   1468 ms' │ '     19 ms' │ '   77.26 x' │
 └──────────────────┴────────────┴──────────────┴──────────────┴──────────────┘
 ```
 
@@ -1098,31 +1098,31 @@ This benchmark measures validation performance for varying types. You can review
 ┌──────────────────┬────────────┬──────────────┬──────────────┬──────────────┬──────────────┐
 │     (index)      │ Iterations │  ValueCheck  │     Ajv      │ TypeCompiler │ Performance  │
 ├──────────────────┼────────────┼──────────────┼──────────────┼──────────────┼──────────────┤
-│           Number │  1000000   │ '     37 ms' │ '      5 ms' │ '      5 ms' │ '    1.00 x' │
-│           String │  1000000   │ '     31 ms' │ '     24 ms' │ '     13 ms' │ '    1.85 x' │
-│          Boolean │  1000000   │ '     25 ms' │ '     25 ms' │ '     11 ms' │ '    2.27 x' │
-│             Null │  1000000   │ '     32 ms' │ '     26 ms' │ '     10 ms' │ '    2.60 x' │
-│            RegEx │  1000000   │ '    170 ms' │ '     48 ms' │ '     35 ms' │ '    1.37 x' │
-│          ObjectA │  1000000   │ '    564 ms' │ '     36 ms' │ '     23 ms' │ '    1.57 x' │
-│          ObjectB │  1000000   │ '   1000 ms' │ '     56 ms' │ '     40 ms' │ '    1.40 x' │
-│            Tuple │  1000000   │ '    125 ms' │ '     27 ms' │ '     13 ms' │ '    2.08 x' │
-│            Union │  1000000   │ '    316 ms' │ '     27 ms' │ '     14 ms' │ '    1.93 x' │
-│        Recursive │  1000000   │ '   3308 ms' │ '    415 ms' │ '    183 ms' │ '    2.27 x' │
-│          Vector4 │  1000000   │ '    135 ms' │ '     27 ms' │ '     12 ms' │ '    2.25 x' │
-│          Matrix4 │  1000000   │ '    658 ms' │ '     44 ms' │ '     30 ms' │ '    1.47 x' │
-│   Literal_String │  1000000   │ '     48 ms' │ '     26 ms' │ '     10 ms' │ '    2.60 x' │
-│   Literal_Number │  1000000   │ '     49 ms' │ '     31 ms' │ '      9 ms' │ '    3.44 x' │
-│  Literal_Boolean │  1000000   │ '     47 ms' │ '     28 ms' │ '     10 ms' │ '    2.80 x' │
-│     Array_Number │  1000000   │ '    418 ms' │ '     38 ms' │ '     17 ms' │ '    2.24 x' │
-│     Array_String │  1000000   │ '    466 ms' │ '     35 ms' │ '     22 ms' │ '    1.59 x' │
-│    Array_Boolean │  1000000   │ '    403 ms' │ '     41 ms' │ '     24 ms' │ '    1.71 x' │
-│    Array_ObjectA │  1000000   │ '  13596 ms' │ '   2861 ms' │ '   1759 ms' │ '    1.63 x' │
-│    Array_ObjectB │  1000000   │ '  15767 ms' │ '   2798 ms' │ '   1991 ms' │ '    1.41 x' │
-│      Array_Tuple │  1000000   │ '   1666 ms' │ '    103 ms' │ '     73 ms' │ '    1.41 x' │
-│      Array_Union │  1000000   │ '   4738 ms' │ '    229 ms' │ '     87 ms' │ '    2.63 x' │
-│  Array_Recursive │  1000000   │ '  56371 ms' │ '   7315 ms' │ '   2813 ms' │ '    2.60 x' │
-│    Array_Vector4 │  1000000   │ '   2180 ms' │ '    106 ms' │ '     53 ms' │ '    2.00 x' │
-│    Array_Matrix4 │  1000000   │ '  11795 ms' │ '    384 ms' │ '    313 ms' │ '    1.23 x' │
+│           Number │  1000000   │ '     24 ms' │ '      9 ms' │ '      6 ms' │ '    1.50 x' │
+│           String │  1000000   │ '     23 ms' │ '     19 ms' │ '     12 ms' │ '    1.58 x' │
+│          Boolean │  1000000   │ '     24 ms' │ '     19 ms' │ '     10 ms' │ '    1.90 x' │
+│             Null │  1000000   │ '     23 ms' │ '     18 ms' │ '      9 ms' │ '    2.00 x' │
+│            RegEx │  1000000   │ '    164 ms' │ '     46 ms' │ '     38 ms' │ '    1.21 x' │
+│          ObjectA │  1000000   │ '    548 ms' │ '     36 ms' │ '     22 ms' │ '    1.64 x' │
+│          ObjectB │  1000000   │ '   1118 ms' │ '     51 ms' │ '     38 ms' │ '    1.34 x' │
+│            Tuple │  1000000   │ '    136 ms' │ '     25 ms' │ '     14 ms' │ '    1.79 x' │
+│            Union │  1000000   │ '    338 ms' │ '     27 ms' │ '     16 ms' │ '    1.69 x' │
+│        Recursive │  1000000   │ '   3251 ms' │ '    416 ms' │ '     98 ms' │ '    4.24 x' │
+│          Vector4 │  1000000   │ '    146 ms' │ '     23 ms' │ '     12 ms' │ '    1.92 x' │
+│          Matrix4 │  1000000   │ '    584 ms' │ '     40 ms' │ '     25 ms' │ '    1.60 x' │
+│   Literal_String │  1000000   │ '     46 ms' │ '     19 ms' │ '     10 ms' │ '    1.90 x' │
+│   Literal_Number │  1000000   │ '     46 ms' │ '     20 ms' │ '     10 ms' │ '    2.00 x' │
+│  Literal_Boolean │  1000000   │ '     47 ms' │ '     21 ms' │ '     10 ms' │ '    2.10 x' │
+│     Array_Number │  1000000   │ '    456 ms' │ '     31 ms' │ '     19 ms' │ '    1.63 x' │
+│     Array_String │  1000000   │ '    489 ms' │ '     40 ms' │ '     25 ms' │ '    1.60 x' │
+│    Array_Boolean │  1000000   │ '    458 ms' │ '     35 ms' │ '     27 ms' │ '    1.30 x' │
+│    Array_ObjectA │  1000000   │ '  13559 ms' │ '   2568 ms' │ '   1564 ms' │ '    1.64 x' │
+│    Array_ObjectB │  1000000   │ '  15863 ms' │ '   2744 ms' │ '   2060 ms' │ '    1.33 x' │
+│      Array_Tuple │  1000000   │ '   1694 ms' │ '     96 ms' │ '     63 ms' │ '    1.52 x' │
+│      Array_Union │  1000000   │ '   4736 ms' │ '    229 ms' │ '     86 ms' │ '    2.66 x' │
+│  Array_Recursive │  1000000   │ '  53804 ms' │ '   6744 ms' │ '   1167 ms' │ '    5.78 x' │
+│    Array_Vector4 │  1000000   │ '   2244 ms' │ '     99 ms' │ '     46 ms' │ '    2.15 x' │
+│    Array_Matrix4 │  1000000   │ '  11966 ms' │ '    378 ms' │ '    229 ms' │ '    1.65 x' │
 └──────────────────┴────────────┴──────────────┴──────────────┴──────────────┴──────────────┘
 ```
 
@@ -1136,11 +1136,11 @@ The following table lists esbuild compiled and minified sizes for each TypeBox m
 ┌──────────────────────┬────────────┬────────────┬─────────────┐
 │       (index)        │  Compiled  │  Minified  │ Compression │
 ├──────────────────────┼────────────┼────────────┼─────────────┤
-│ typebox/compiler     │ '   49 kb' │ '   24 kb' │  '2.00 x'   │
+│ typebox/compiler     │ '   51 kb' │ '   25 kb' │  '2.00 x'   │
 │ typebox/conditional  │ '   42 kb' │ '   17 kb' │  '2.46 x'   │
 │ typebox/format       │ '    0 kb' │ '    0 kb' │  '2.66 x'   │
-│ typebox/guard        │ '   21 kb' │ '   10 kb' │  '2.07 x'   │
-│ typebox/value        │ '   72 kb' │ '   33 kb' │  '2.16 x'   │
+│ typebox/guard        │ '   21 kb' │ '   10 kb' │  '2.08 x'   │
+│ typebox/value        │ '   74 kb' │ '   34 kb' │  '2.16 x'   │
 │ typebox              │ '   11 kb' │ '    6 kb' │  '1.91 x'   │
 └──────────────────────┴────────────┴────────────┴─────────────┘
 ```

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -189,8 +189,8 @@ export namespace TypeCompiler {
     }
     if (TypeGuard.TSchema(schema.additionalProperties)) {
       const expression = CreateExpression(schema.additionalProperties, 'value[key]')
-      const keys = `${propertyKeys.map((key) => `'${key}'`).join(', ')}`
-      yield `(Object.keys(${value}).every(key => [${keys}].includes(key) || ${expression}))`
+      const keys = `[${propertyKeys.map((key) => `'${key}'`).join(', ')}]`
+      yield `(Object.keys(${value}).every(key => ${keys}.includes(key) || ${expression}))`
     }
     for (const propertyKey of propertyKeys) {
       const memberExpression = Property.Check(propertyKey) ? `${value}.${propertyKey}` : `${value}['${propertyKey}']`

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -187,6 +187,11 @@ export namespace TypeCompiler {
         yield `(Object.keys(${value}).every(key => ${keys}.includes(key)))`
       }
     }
+    if (TypeGuard.TSchema(schema.additionalProperties)) {
+      const expression = CreateExpression(schema.additionalProperties, 'value[key]')
+      const keys = `${propertyKeys.map((key) => `'${key}'`).join(', ')}`
+      yield `(Object.keys(${value}).every(key => [${keys}].includes(key) || ${expression}))`
+    }
     for (const propertyKey of propertyKeys) {
       const memberExpression = Property.Check(propertyKey) ? `${value}.${propertyKey}` : `${value}['${propertyKey}']`
       const propertySchema = schema.properties[propertyKey]

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -226,7 +226,12 @@ export namespace ValueErrors {
         yield { type: ValueErrorType.ObjectRequiredProperties, schema: schema.properties[requiredKey], path: `${path}/${requiredKey}`, value: undefined, message: `Expected required property` }
       }
     }
-
+    if (typeof schema.additionalProperties === 'object') {
+      for (const objectKey of globalThis.Object.keys(value)) {
+        if (propertyKeys.includes(objectKey)) continue
+        yield* Visit(schema.additionalProperties as Types.TSchema, references, `${path}/${objectKey}`, value[objectKey])
+      }
+    }
     for (const propertyKey of propertyKeys) {
       const propertySchema = schema.properties[propertyKey]
       if (schema.required && schema.required.includes(propertyKey)) {

--- a/src/guard/guard.ts
+++ b/src/guard/guard.ts
@@ -83,16 +83,17 @@ export namespace TypeGuard {
   function IsOptionalBoolean(value: unknown): value is boolean | undefined {
     return value === undefined || (value !== undefined && IsBoolean(value))
   }
-
   function IsOptionalString(value: unknown): value is string | undefined {
     return value === undefined || (value !== undefined && IsString(value))
   }
-
   function IsOptionalPattern(value: unknown): value is string | undefined {
     return value === undefined || (value !== undefined && IsString(value) && IsControlCharacterFree(value) && IsPattern(value))
   }
   function IsOptionalFormat(value: unknown): value is string | undefined {
     return value === undefined || (value !== undefined && IsString(value) && IsControlCharacterFree(value))
+  }
+  function IsOptionalSchema(value: unknown): value is boolean | undefined {
+    return value === undefined || TSchema(value)
   }
   /** Returns true if the given schema is TAny */
   export function TAny(schema: unknown): schema is Types.TAny {
@@ -207,7 +208,7 @@ export namespace TypeGuard {
         schema.type === 'object' &&
         IsOptionalString(schema.$id) &&
         IsObject(schema.properties) &&
-        IsOptionalBoolean(schema.additionalProperties) &&
+        (IsOptionalBoolean(schema.additionalProperties) || IsOptionalSchema(schema.additionalProperties)) &&
         IsOptionalNumber(schema.minProperties) &&
         IsOptionalNumber(schema.maxProperties)
       )

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -310,15 +310,18 @@ export type ObjectProperties<T> = T extends TObject<infer U> ? U : never
 
 export type ObjectPropertyKeys<T> = T extends TObject<infer U> ? keyof U : never
 
-export interface ObjectOptions extends SchemaOptions {
-  additionalProperties?: boolean
+export type TAdditionalProperties = undefined | TSchema | boolean
+
+export interface ObjectOptions<A extends TAdditionalProperties = undefined> extends SchemaOptions {
+  additionalProperties?: A
   minProperties?: number
   maxProperties?: number
 }
 
-export interface TObject<T extends TProperties = TProperties> extends TSchema, ObjectOptions {
+export interface TObject<T extends TProperties = TProperties, A extends TAdditionalProperties = undefined> extends TSchema, ObjectOptions<A> {
   [Kind]: 'Object'
-  static: PropertiesReduce<T, this['params']>
+  static: A extends TSchema ? PropertiesReduce<T, this['params']> & Record<string, Static<A, ['params']>> : PropertiesReduce<T, this['params']>
+  additionalProperties?: A
   type: 'object'
   properties: T
   required?: string[]
@@ -726,7 +729,7 @@ export class TypeBuilder {
   }
 
   /** Creates an object type with the given properties */
-  public Object<T extends TProperties>(properties: T, options: ObjectOptions = {}): TObject<T> {
+  public Object<T extends TProperties, A extends TAdditionalProperties = undefined>(properties: T, options: ObjectOptions<A> = {}): TObject<T, A> {
     const property_names = Object.keys(properties)
     const optional = property_names.filter((name) => {
       const property = properties[name] as TModifier

--- a/src/value/cast.ts
+++ b/src/value/cast.ts
@@ -240,6 +240,14 @@ export namespace ValueCast {
       if (!required.has(key) && value[key] === undefined) continue
       result[key] = Visit(property, references, value[key])
     }
+    // additional schema properties
+    if (typeof schema.additionalProperties === 'object') {
+      const propertyKeys = globalThis.Object.keys(schema.properties)
+      for (const objectKey of globalThis.Object.keys(value)) {
+        if (propertyKeys.includes(objectKey)) continue
+        result[objectKey] = Visit(schema.additionalProperties, references, value[objectKey])
+      }
+    }
     return result
   }
 

--- a/src/value/check.ts
+++ b/src/value/check.ts
@@ -150,6 +150,14 @@ export namespace ValueCheck {
         }
       }
     }
+    if (typeof schema.additionalProperties === 'object') {
+      for (const objectKey of globalThis.Object.keys(value)) {
+        if (propertyKeys.includes(objectKey)) continue
+        if (!Visit(schema.additionalProperties as Types.TSchema, references, value[objectKey])) {
+          return false
+        }
+      }
+    }
     for (const propertyKey of propertyKeys) {
       const propertySchema = schema.properties[propertyKey]
       if (schema.required && schema.required.includes(propertyKey)) {

--- a/test/runtime/compiler/object.ts
+++ b/test/runtime/compiler/object.ts
@@ -139,4 +139,70 @@ describe('type/compiler/Object', () => {
       '!@#$%^&*(': 4,
     })
   })
+
+  it('Should validate schema additional properties of string', () => {
+    const T = Type.Object(
+      {
+        x: Type.Number(),
+        y: Type.Number(),
+      },
+      {
+        additionalProperties: Type.String(),
+      },
+    )
+    ok(T, {
+      x: 1,
+      y: 2,
+      z: 'hello',
+    })
+    fail(T, {
+      x: 1,
+      y: 2,
+      z: 3,
+    })
+  })
+  it('Should validate schema additional properties of array', () => {
+    const T = Type.Object(
+      {
+        x: Type.Number(),
+        y: Type.Number(),
+      },
+      {
+        additionalProperties: Type.Array(Type.Number()),
+      },
+    )
+    ok(T, {
+      x: 1,
+      y: 2,
+      z: [0, 1, 2],
+    })
+    fail(T, {
+      x: 1,
+      y: 2,
+      z: 3,
+    })
+  })
+  it('Should validate schema additional properties of object', () => {
+    const T = Type.Object(
+      {
+        x: Type.Number(),
+        y: Type.Number(),
+      },
+      {
+        additionalProperties: Type.Object({
+          z: Type.Number(),
+        }),
+      },
+    )
+    ok(T, {
+      x: 1,
+      y: 2,
+      z: { z: 1 },
+    })
+    fail(T, {
+      x: 1,
+      y: 2,
+      z: 3,
+    })
+  })
 })

--- a/test/runtime/guard/object.ts
+++ b/test/runtime/guard/object.ts
@@ -96,4 +96,35 @@ describe('type/guard/TObject', () => {
     )
     Assert.equal(R, false)
   })
+
+  it('should guard for TObject with invalid additional properties', () => {
+    const R = TypeGuard.TObject(
+      Type.Object(
+        {
+          x: Type.Number(),
+          y: Type.Number(),
+        },
+        {
+          // @ts-ignore
+          additionalProperties: 1,
+        },
+      ),
+    )
+    Assert.equal(R, false)
+  })
+
+  it('should not guard for TObject with valid additional properties schema', () => {
+    const R = TypeGuard.TObject(
+      Type.Object(
+        {
+          x: Type.Number(),
+          y: Type.Number(),
+        },
+        {
+          additionalProperties: Type.String(),
+        },
+      ),
+    )
+    Assert.equal(R, true)
+  })
 })

--- a/test/runtime/schema/object.ts
+++ b/test/runtime/schema/object.ts
@@ -139,4 +139,72 @@ describe('type/schema/Object', () => {
       '!@#$%^&*(': 4,
     })
   })
+
+  it('Should validate schema additional properties of string', () => {
+    const T = Type.Object(
+      {
+        x: Type.Number(),
+        y: Type.Number(),
+      },
+      {
+        additionalProperties: Type.String(),
+      },
+    )
+    ok(T, {
+      x: 1,
+      y: 2,
+      z: 'hello',
+    })
+    fail(T, {
+      x: 1,
+      y: 2,
+      z: 3,
+    })
+  })
+
+  it('Should validate schema additional properties of array', () => {
+    const T = Type.Object(
+      {
+        x: Type.Number(),
+        y: Type.Number(),
+      },
+      {
+        additionalProperties: Type.Array(Type.Number()),
+      },
+    )
+    ok(T, {
+      x: 1,
+      y: 2,
+      z: [0, 1, 2],
+    })
+    fail(T, {
+      x: 1,
+      y: 2,
+      z: 3,
+    })
+  })
+
+  it('Should validate schema additional properties of object', () => {
+    const T = Type.Object(
+      {
+        x: Type.Number(),
+        y: Type.Number(),
+      },
+      {
+        additionalProperties: Type.Object({
+          z: Type.Number(),
+        }),
+      },
+    )
+    ok(T, {
+      x: 1,
+      y: 2,
+      z: { z: 1 },
+    })
+    fail(T, {
+      x: 1,
+      y: 2,
+      z: 3,
+    })
+  })
 })

--- a/test/runtime/value/cast/object.ts
+++ b/test/runtime/value/cast/object.ts
@@ -109,4 +109,58 @@ describe('value/cast/Object', () => {
       c: 'c',
     })
   })
+
+  it('Should upcast and create invalid additional properties', () => {
+    const result = Value.Cast(
+      Type.Object(
+        {
+          x: Type.Number(),
+          y: Type.Number(),
+        },
+        {
+          additionalProperties: Type.Object({
+            a: Type.Number(),
+            b: Type.Number(),
+          }),
+        },
+      ),
+      {
+        x: 1,
+        y: 2,
+        z: true,
+      },
+    )
+    Assert.deepEqual(result, {
+      x: 1,
+      y: 2,
+      z: { a: 0, b: 0 },
+    })
+  })
+
+  it('Should upcast and preserve additional properties', () => {
+    const result = Value.Cast(
+      Type.Object(
+        {
+          x: Type.Number(),
+          y: Type.Number(),
+        },
+        {
+          additionalProperties: Type.Object({
+            a: Type.Number(),
+            b: Type.Number(),
+          }),
+        },
+      ),
+      {
+        x: 1,
+        y: 2,
+        z: { b: 1 },
+      },
+    )
+    Assert.deepEqual(result, {
+      x: 1,
+      y: 2,
+      z: { a: 0, b: 1 },
+    })
+  })
 })

--- a/test/runtime/value/check/object.ts
+++ b/test/runtime/value/check/object.ts
@@ -98,4 +98,96 @@ describe('value/check/Object', () => {
     const result = Value.Check(T, value)
     Assert.equal(result, false)
   })
+
+  it('Should validate schema additional properties of string', () => {
+    const T = Type.Object(
+      {
+        x: Type.Number(),
+        y: Type.Number(),
+      },
+      {
+        additionalProperties: Type.String(),
+      },
+    )
+
+    Assert.equal(
+      Value.Check(T, {
+        x: 1,
+        y: 2,
+        z: 'hello',
+      }),
+      true,
+    )
+
+    Assert.equal(
+      Value.Check(T, {
+        x: 1,
+        y: 2,
+        z: 3,
+      }),
+      false,
+    )
+  })
+
+  it('Should validate schema additional properties of array', () => {
+    const T = Type.Object(
+      {
+        x: Type.Number(),
+        y: Type.Number(),
+      },
+      {
+        additionalProperties: Type.Array(Type.Number()),
+      },
+    )
+
+    Assert.equal(
+      Value.Check(T, {
+        x: 1,
+        y: 2,
+        z: [0, 1, 2],
+      }),
+      true,
+    )
+
+    Assert.equal(
+      Value.Check(T, {
+        x: 1,
+        y: 2,
+        z: 3,
+      }),
+      false,
+    )
+  })
+
+  it('Should validate schema additional properties of object', () => {
+    const T = Type.Object(
+      {
+        x: Type.Number(),
+        y: Type.Number(),
+      },
+      {
+        additionalProperties: Type.Object({
+          z: Type.Number(),
+        }),
+      },
+    )
+
+    Assert.equal(
+      Value.Check(T, {
+        x: 1,
+        y: 2,
+        z: { z: 1 },
+      }),
+      true,
+    )
+
+    Assert.equal(
+      Value.Check(T, {
+        x: 1,
+        y: 2,
+        z: 3,
+      }),
+      false,
+    )
+  })
 })

--- a/test/static/object.ts
+++ b/test/static/object.ts
@@ -51,13 +51,16 @@ import { Type, Static } from '@sinclair/typebox'
   }>()
 }
 {
-  const T = Type.Object({
-    A: Type.Number(),
-    B: Type.Number(),
-    C: Type.Number(),
-  }, {
-    additionalProperties: Type.Boolean()
-  })
+  const T = Type.Object(
+    {
+      A: Type.Number(),
+      B: Type.Number(),
+      C: Type.Number(),
+    },
+    {
+      additionalProperties: Type.Boolean(),
+    },
+  )
   // note: the inferenced additionalProperty type does break usual structural
   // equivelence and assignment checks, but does allow for the following usage.
   function test(value: Static<typeof T>) {

--- a/test/static/object.ts
+++ b/test/static/object.ts
@@ -1,5 +1,5 @@
 import { Expect } from './assert'
-import { Type } from '@sinclair/typebox'
+import { Type, Static } from '@sinclair/typebox'
 
 {
   const T = Type.Object({
@@ -49,4 +49,21 @@ import { Type } from '@sinclair/typebox'
       C: string
     }
   }>()
+}
+{
+  const T = Type.Object({
+    A: Type.Number(),
+    B: Type.Number(),
+    C: Type.Number(),
+  }, {
+    additionalProperties: Type.Boolean()
+  })
+  // note: the inferenced additionalProperty type does break usual structural
+  // equivelence and assignment checks, but does allow for the following usage.
+  function test(value: Static<typeof T>) {
+    value.A = 10
+    value.B = 20
+    value.C = 30
+    value.D = true // ok
+  }
 }


### PR DESCRIPTION
This PR implements support for `additionalProperties: TSchema` on Value and TypeCompiler API's to allow for additional properties of a known type. This functionality aligns TypeBox validators with `non-boolean` additional properties constraints which are outlined at http://json-schema.org/understanding-json-schema/reference/object.html#additional-properties 

> You can use non-boolean schemas to put more complex constraints on the additional properties of an instance. For example, one can allow additional properties, but only if their values are each a string:

This PR also includes a new generic argument of `TAdditionalProperties` on  `TObject`. This generic argument is used to infer a intersection of the normal `TObject` inference type with a `Record<string, TAdditionalProperties>` type. Intersection is only mapped when passing a `non-boolean` additionalProperties value. The `TAdditionalProperties` argument itself is static and reflectable.

Testing has been completed on TS 4.1.5 and should be fine; however the inference for `TAdditionalProperties` can be considered provisional as the output type produced results in a non-assignable type whose usage is somewhat limited. Future updates may default the inference to `unknown`.

```typescript
const T = Type.Object({
  x: Type.Number(),
  y: Type.Number(),
}, {
  additionalProperties: Type.String()
})

function test(value: Static<typeof T>) {
  value.x = 1
  value.y = 1
  value.z = 'hello world' // ok
}
```