### PR TITLE
Allow Integer keys in Record types

### DIFF
--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -380,7 +380,7 @@ export interface TPromise<T extends TSchema = TSchema> extends TSchema {
 // Record
 // --------------------------------------------------------------------------
 
-export type TRecordKey = TString | TNumber | TUnion<TLiteral<any>[]>
+export type TRecordKey = TString | TInteger | TNumber | TUnion<TLiteral<any>[]>
 
 export interface TRecord<K extends TRecordKey = TRecordKey, T extends TSchema = TSchema> extends TSchema {
   [Kind]: 'Record'
@@ -823,7 +823,7 @@ export class TypeBuilder {
   public Record<K extends TUnion<TLiteral[]>, T extends TSchema>(key: K, schema: T, options?: ObjectOptions): TObject<TRecordProperties<K, T>>
 
   /** Creates a record type */
-  public Record<K extends TString | TNumber, T extends TSchema>(key: K, schema: T, options?: ObjectOptions): TRecord<K, T>
+  public Record<K extends TString | TInteger | TNumber, T extends TSchema>(key: K, schema: T, options?: ObjectOptions): TRecord<K, T>
 
   /** Creates a record type */
   public Record(key: any, value: any, options: ObjectOptions = {}) {
@@ -837,7 +837,7 @@ export class TypeBuilder {
       )
     }
     // otherwise return TRecord with patternProperties
-    const pattern = key[Kind] === 'Number' ? '^(0|[1-9][0-9]*)$' : key[Kind] === 'String' && key.pattern ? key.pattern : '^.*$'
+    const pattern = ['Integer', 'Number'].includes(key[Kind]) ? '^(0|[1-9][0-9]*)$' : key[Kind] === 'String' && key.pattern ? key.pattern : '^.*$'
     return this.Create({
       ...options,
       [Kind]: 'Record',


### PR DESCRIPTION
Hello! I recognize the contribution guidelines ask to open an issue first, but I think a PR might help better explain what I'm hoping to accomplish with the following suggestion.

Currently, if you attempt to define a record with an integer key you'll get a type error:

```ts
t = Type.Record(Type.Integer(), ApiUser);
```

```
Argument of type 'TInteger' is not assignable to parameter of type 'TString<string> | TNumber'
```

Considering numbers are allowed as `Record` keys, it seems reasonable to also allow integers.

With that said, I might be missing something, so feel free to close this if this doesn't align.

Thanks for your consideration!
