### PR TITLE
Use BigInt Initializer Functions

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -7,6 +7,9 @@ import { Custom } from '@sinclair/typebox/custom'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
 import { Type, Kind, Static, TSchema } from '@sinclair/typebox'
 
+console.log(Value.Hash(1))
+console.log(Value.Hash(2))
+
 const T = Type.Object({
   x: Type.Number(),
   y: Type.Number(),
@@ -15,4 +18,3 @@ const T = Type.Object({
 
 type T = Static<typeof T>
 
-console.log(T)

--- a/src/hash/hash.ts
+++ b/src/hash/hash.ts
@@ -49,8 +49,8 @@ export namespace ValueHash {
   // State
   // ----------------------------------------------------
 
-  let Hash = 14695981039346656037n
-  const [Prime, Size] = [1099511628211n, 2n ** 64n]
+  let Hash = BigInt('14695981039346656037')
+  const [Prime, Size] = [BigInt(1099511628211), BigInt(2) ** BigInt(64)]
   const Bytes = globalThis.Array.from({ length: 256 }).map((_, i) => globalThis.BigInt(i))
   const F64 = new globalThis.Float64Array(1)
   const F64In = new globalThis.DataView(F64.buffer)
@@ -186,7 +186,7 @@ export namespace ValueHash {
 
   /** Creates a FNV1A-64 non cryptographic hash of the given value */
   export function Create(value: unknown) {
-    Hash = 14695981039346656037n
+    Hash = BigInt('14695981039346656037')
     Visit(value)
     return Hash
   }

--- a/src/value/cast.ts
+++ b/src/value/cast.ts
@@ -146,11 +146,11 @@ export namespace ValueCast {
   }
 
   function IsValueTrue(value: unknown): value is true {
-    return value === true || (IsNumber(value) && value === 1) || (IsBigInt(value) && value === 1n) || (IsString(value) && (value.toLowerCase() === 'true' || value === '1'))
+    return value === true || (IsNumber(value) && value === 1) || (IsBigInt(value) && value === BigInt(1)) || (IsString(value) && (value.toLowerCase() === 'true' || value === '1'))
   }
 
   function IsValueFalse(value: unknown): value is true {
-    return value === false || (IsNumber(value) && value === 0) || (IsBigInt(value) && value === 0n) || (IsString(value) && (value.toLowerCase() === 'false' || value === '0'))
+    return value === false || (IsNumber(value) && value === 0) || (IsBigInt(value) && value === BigInt(0)) || (IsString(value) && (value.toLowerCase() === 'false' || value === '0'))
   }
 
   // ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR updates all occurrences of `bigint` literals to use BigInt initializer functions. This is to help support compatibility on legacy JS runtime targets. 