### PR TITLE
Structural Object Check

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -10,7 +10,7 @@ import { Type, Kind, Static, TSchema } from '@sinclair/typebox'
 const T = Type.Object({
   x: Type.Number(),
   y: Type.Number(),
-  z: Type.Number()
+  z: Type.Number(),
 })
 
 type T = Static<typeof T>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.25.13",
+  "version": "0.25.14",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -187,7 +187,7 @@ export namespace TypeCompiler {
   function* Object(schema: Types.TObject, value: string): IterableIterator<string> {
     // Optimization: We can optimize here by only running the array check if the
     // schema is fully partial. This has implication for arrays as passing the
-    // type { length: number } will allow this check to succeed. For consideration.
+    // type { length: number } will allow this check to succeed.
     if (schema.required === undefined || schema.required.length === 0) {
       yield `(typeof ${value} === 'object' && ${value} !== null && !Array.isArray(${value}))`
     } else {

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -233,8 +233,14 @@ export namespace ValueErrors {
   }
 
   function* Object(schema: Types.TObject, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
-    if (!(typeof value === 'object' && value !== null && !globalThis.Array.isArray(value))) {
-      return yield { type: ValueErrorType.Object, schema, path, value, message: `Expected object` }
+    if (schema.required === undefined || schema.required.length === 0) {
+      if (!(typeof value === 'object' && value !== null && !globalThis.Array.isArray(value))) {
+        return yield { type: ValueErrorType.Object, schema, path, value, message: `Expected object` }
+      }
+    } else {
+      if (!(typeof value === 'object' && value !== null)) {
+        return yield { type: ValueErrorType.Object, schema, path, value, message: `Expected object` }
+      }
     }
     if (IsNumber(schema.minProperties) && !(globalThis.Object.keys(value).length >= schema.minProperties)) {
       yield { type: ValueErrorType.ObjectMinProperties, schema, path, value, message: `Expected object to have at least ${schema.minProperties} properties` }

--- a/src/value/check.ts
+++ b/src/value/check.ts
@@ -153,8 +153,17 @@ export namespace ValueCheck {
   }
 
   function Object(schema: Types.TObject, references: Types.TSchema[], value: any): boolean {
-    if (!(typeof value === 'object' && value !== null && !globalThis.Array.isArray(value))) {
-      return false
+    // Optimization: We can optimize here by only running the array check if the
+    // schema is fully partial. This has implication for arrays as passing the
+    // type { length: number } will allow this check to succeed.
+    if (schema.required === undefined || schema.required.length === 0) {
+      if (!(typeof value === 'object' && value !== null && !globalThis.Array.isArray(value))) {
+        return false
+      }
+    } else {
+      if (!(typeof value === 'object' && value !== null)) {
+        return false
+      }
     }
     if (IsNumber(schema.minProperties) && !(globalThis.Object.keys(value).length >= schema.minProperties)) {
       return false

--- a/test/runtime/compiler/object.ts
+++ b/test/runtime/compiler/object.ts
@@ -205,4 +205,18 @@ describe('type/compiler/Object', () => {
       z: 3,
     })
   })
+
+  // ----------------------------------------------------------------
+  // TypeComplier Variance
+  // ----------------------------------------------------------------
+
+  it('Should validate an Array if it only contains a length property', () => {
+    const T = Type.Object({ length: Type.Number() })
+    ok(T, [1, 2])
+  })
+
+  it('Should not validate an Array if it only has a length property with additionalProperties: false', () => {
+    const T = Type.Object({ length: Type.Number() }, { additionalProperties: false })
+    fail(T, [1, 2])
+  })
 })


### PR DESCRIPTION
This PR implements a compiler optimization and structural check for `isArray()` when testing object schematics. This optimization only applies to object checks when testing partial objects, but has the following implication when testing array values against object schematics. This PR opts for the structural interpretation of a JavaScript value, not the nominal interpretation (as is the case for Ajv)

### Cases

```typescript
import { TypeCompiler } from '@sinclair/typebox/compiler'
import { Type } from '@sinclair/typebox'

// Case A
{
  const T = Type.Object({ length: Type.Number() })
  const C = TypeCompiler.Compile(T)
  
  C.Check([0, 1, 2]) //  true: because array.length is numeric
}

// Case B
{
  const T = Type.Object({ length: Type.Number() }, { additionalProperties: false })
  const C = TypeCompiler.Compile(T)
  
  C.Check([0, 1, 2]) // false because the keys ['0', '1', '2'] are additional properties.
}
```
