### PR TITLE
Date Cast

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 Updates:
 
-- [307](https://github.com/sinclairzx81/typebox/pull/307) implements date conversion when casting values with `Value.Cast(Type.Date(), ...)`. Castable values include numbers (interpretted as timestamps) and iso8601 string values. Uncastable values will result in dates with values of `1970-01-01T00:00:00.000Z`.
+- [307](https://github.com/sinclairzx81/typebox/pull/307) implements date conversion when casting values with `Value.Cast(Type.Date(), ...)`. Castable values include numbers (interpretted as timestamps) and iso8601 string values. Uncastable values will result in dates with values of `1970-01-01T00:00:00.000Z`. This version also includes more robust checks for Dates initialized with invalid values.
 
 ## [0.25.11](https://www.npmjs.com/package/@sinclair/typebox/v/0.25.11)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## [0.25.18](https://www.npmjs.com/package/@sinclair/typebox/v/0.25.18)
+
+Updates:
+
+- [307](https://github.com/sinclairzx81/typebox/pull/307) implements date conversion when casting values with `Value.Cast(Type.Date(), ...)`. Castable values include numbers (interpretted as timestamps) and iso8601 string values. Uncastable values will result in dates with values of `1970-01-01T00:00:00.000Z`.
+
 ## [0.25.11](https://www.npmjs.com/package/@sinclair/typebox/v/0.25.11)
 
 Updates:

--- a/example/index.ts
+++ b/example/index.ts
@@ -12,8 +12,8 @@ const T = Type.Object({
   x: Type.Number(),
   y: Type.Number(),
   z: Type.Number(),
-  w: Type.Date(),
 })
-const V = Value.Cast(T, { x: 1, y: 2, z: 3, w: '2020-01-01' })
 
-console.log(V)
+type T = Static<typeof T>
+
+console.log(T)

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,4 +1,4 @@
-import { CodeGen } from '@sinclair/typebox/codegen'
+import { Codegen } from '@sinclair/typebox/codegen'
 import { TypeSystem } from '@sinclair/typebox/system'
 import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { TypeGuard } from '@sinclair/typebox/guard'
@@ -8,12 +8,6 @@ import { Custom } from '@sinclair/typebox/custom'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
 import { Type, Kind, Static, TSchema } from '@sinclair/typebox'
 
-const T = Type.Object({
-  x: Type.Number(),
-  y: Type.Number(),
-  z: Type.Number(),
-})
-
-type T = Static<typeof T>
-
-console.log(T)
+const C = Type.Date()
+console.log(Value.Cast(C, '00:01:33'))
+console.log(Value.Cast(C, '00:00:01').getTime())

--- a/example/index.ts
+++ b/example/index.ts
@@ -12,8 +12,8 @@ const T = Type.Object({
   x: Type.Number(),
   y: Type.Number(),
   z: Type.Number(),
+  w: Type.Date(),
 })
+const V = Value.Cast(T, { x: 1, y: 2, z: 3, w: '2020-01-01' })
 
-type T = Static<typeof T>
-
-console.log(T)
+console.log(V)

--- a/example/index.ts
+++ b/example/index.ts
@@ -8,6 +8,12 @@ import { Custom } from '@sinclair/typebox/custom'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
 import { Type, Kind, Static, TSchema } from '@sinclair/typebox'
 
-const C = Type.Date()
-console.log(Value.Cast(C, '00:01:33'))
-console.log(Value.Cast(C, '00:00:01').getTime())
+const T = Type.Object({
+  x: Type.Number(),
+  y: Type.Number(),
+  z: Type.Number(),
+})
+
+type T = Static<typeof T>
+
+console.log(T)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.25.17",
+  "version": "0.25.18",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -140,7 +140,7 @@ export namespace TypeCompiler {
   }
 
   function* Date(schema: Types.TDate, value: string): IterableIterator<string> {
-    yield `(${value} instanceof Date)`
+    yield `(${value} instanceof Date) && !isNaN(${value}.getTime())`
     if (IsNumber(schema.exclusiveMinimumTimestamp)) yield `(${value}.getTime() > ${schema.exclusiveMinimumTimestamp})`
     if (IsNumber(schema.exclusiveMaximumTimestamp)) yield `(${value}.getTime() < ${schema.exclusiveMaximumTimestamp})`
     if (IsNumber(schema.minimumTimestamp)) yield `(${value}.getTime() >= ${schema.minimumTimestamp})`

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -151,6 +151,9 @@ export namespace ValueErrors {
     if (!(value instanceof globalThis.Date)) {
       return yield { type: ValueErrorType.Date, schema, path, value, message: `Expected Date object` }
     }
+    if (isNaN(value.getTime())) {
+      return yield { type: ValueErrorType.Date, schema, path, value, message: `Invalid Date` }
+    }
     if (IsNumber(schema.exclusiveMinimumTimestamp) && !(value.getTime() > schema.exclusiveMinimumTimestamp)) {
       yield { type: ValueErrorType.DateExclusiveMinimumTimestamp, schema, path, value, message: `Expected Date timestamp to be greater than ${schema.exclusiveMinimum}` }
     }

--- a/src/value/cast.ts
+++ b/src/value/cast.ts
@@ -171,6 +171,10 @@ export namespace ValueCast {
     return IsValueTrue(value) ? true : IsValueFalse(value) ? false : value
   }
   function TryConvertDate(value: unknown) {
+    // note: this function may return an invalid dates for the regex tests
+    // above. Invalid dates will however be checked during the casting
+    // function and will return a epoch date if invalid. Consider better
+    // string parsing for the iso dates in future revisions.
     return IsDate(value)
       ? value
       : IsNumber(value)

--- a/src/value/cast.ts
+++ b/src/value/cast.ts
@@ -143,13 +143,13 @@ export namespace ValueCast {
     return IsString(value) && /^(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)$/i.test(value)
   }
   function IsTimeStringWithoutTimeZone(value: unknown): value is string {
-    return IsString(value) && /^(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?$/i.test(value)
+    return IsString(value) && /^(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)?$/i.test(value)
   }
   function IsDateTimeStringWithTimeZone(value: unknown): value is string {
     return IsString(value) && /^\d\d\d\d-[0-1]\d-[0-3]\dt(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)$/i.test(value)
   }
   function IsDateTimeStringWithoutTimeZone(value: unknown): value is string {
-    return IsString(value) && /^\d\d\d\d-[0-1]\d-[0-3]\dt(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?$/i.test(value)
+    return IsString(value) && /^\d\d\d\d-[0-1]\d-[0-3]\dt(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)?$/i.test(value)
   }
   function IsDateString(value: unknown): value is string {
     return IsString(value) && /^\d\d\d\d-[0-1]\d-[0-3]\d$/i.test(value)

--- a/src/value/cast.ts
+++ b/src/value/cast.ts
@@ -35,25 +35,21 @@ import { Custom } from '../custom/index'
 // ----------------------------------------------------------------------------------------------
 // Errors
 // ----------------------------------------------------------------------------------------------
-
 export class ValueCastReferenceTypeError extends Error {
   constructor(public readonly schema: Types.TRef | Types.TSelf) {
     super(`ValueCast: Cannot locate referenced schema with $id '${schema.$ref}'`)
   }
 }
-
 export class ValueCastArrayUniqueItemsTypeError extends Error {
   constructor(public readonly schema: Types.TSchema, public readonly value: unknown) {
     super('ValueCast: Array cast produced invalid data due to uniqueItems constraint')
   }
 }
-
 export class ValueCastNeverTypeError extends Error {
   constructor(public readonly schema: Types.TSchema) {
     super('ValueCast: Never types cannot be cast')
   }
 }
-
 export class ValueCastRecursiveTypeError extends Error {
   constructor(public readonly schema: Types.TSchema) {
     super('ValueCast.Recursive: Cannot cast recursive schemas')
@@ -71,7 +67,6 @@ export class ValueCastUnknownTypeError extends Error {
 // to prevent large property counts biasing results. Properties that match literal values are
 // maximally awarded as literals are typically used as union discriminator fields.
 // ----------------------------------------------------------------------------------------------
-
 namespace UnionCastCreate {
   function Score(schema: Types.TSchema, references: Types.TSchema[], value: any): number {
     if (schema[Types.Kind] === 'Object' && typeof value === 'object' && value !== null) {
@@ -89,7 +84,6 @@ namespace UnionCastCreate {
       return ValueCheck.Check(schema, references, value) ? 1 : 0
     }
   }
-
   function Select(union: Types.TUnion, references: Types.TSchema[], value: any): Types.TSchema {
     let [select, best] = [union.anyOf[0], 0]
     for (const schema of union.anyOf) {
@@ -101,7 +95,6 @@ namespace UnionCastCreate {
     }
     return select
   }
-
   export function Create(union: Types.TUnion, references: Types.TSchema[], value: any) {
     if (union.default !== undefined) {
       return union.default
@@ -116,71 +109,95 @@ export namespace ValueCast {
   // ----------------------------------------------------------------------------------------------
   // Guards
   // ----------------------------------------------------------------------------------------------
-
   function IsArray(value: unknown): value is unknown[] {
     return typeof value === 'object' && globalThis.Array.isArray(value)
   }
-
+  function IsDate(value: unknown): value is Date {
+    return typeof value === 'object' && value instanceof globalThis.Date
+  }
   function IsString(value: unknown): value is string {
     return typeof value === 'string'
   }
-
   function IsBoolean(value: unknown): value is boolean {
     return typeof value === 'boolean'
   }
-
   function IsBigInt(value: unknown): value is bigint {
     return typeof value === 'bigint'
   }
-
   function IsNumber(value: unknown): value is number {
     return typeof value === 'number' && !isNaN(value)
   }
-
   function IsStringNumeric(value: unknown): value is string {
     return IsString(value) && !isNaN(value as any) && !isNaN(parseFloat(value))
   }
-
   function IsValueToString(value: unknown): value is { toString: () => string } {
     return IsBigInt(value) || IsBoolean(value) || IsNumber(value)
   }
-
   function IsValueTrue(value: unknown): value is true {
     return value === true || (IsNumber(value) && value === 1) || (IsBigInt(value) && value === globalThis.BigInt('1')) || (IsString(value) && (value.toLowerCase() === 'true' || value === '1'))
   }
-
   function IsValueFalse(value: unknown): value is true {
     return value === false || (IsNumber(value) && value === 0) || (IsBigInt(value) && value === globalThis.BigInt('0')) || (IsString(value) && (value.toLowerCase() === 'false' || value === '0'))
+  }
+  function IsTimeStringWithTimeZone(value: unknown): value is string {
+    return IsString(value) && /^(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)$/i.test(value)
+  }
+  function IsTimeStringWithoutTimeZone(value: unknown): value is string {
+    return IsString(value) && /^(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?$/i.test(value)
+  }
+  function IsDateTimeStringWithTimeZone(value: unknown): value is string {
+    return IsString(value) && /^\d\d\d\d-[0-1]\d-[0-3]\dt(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)$/i.test(value)
+  }
+  function IsDateTimeStringWithoutTimeZone(value: unknown): value is string {
+    return IsString(value) && /^\d\d\d\d-[0-1]\d-[0-3]\dt(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?$/i.test(value)
+  }
+  function IsDateString(value: unknown): value is string {
+    return IsString(value) && /^\d\d\d\d-[0-1]\d-[0-3]\d$/i.test(value)
   }
 
   // ----------------------------------------------------------------------------------------------
   // Convert
   // ----------------------------------------------------------------------------------------------
-
   function TryConvertString(value: unknown) {
     return IsValueToString(value) ? value.toString() : value
   }
-
   function TryConvertNumber(value: unknown) {
     return IsStringNumeric(value) ? parseFloat(value) : IsValueTrue(value) ? 1 : value
   }
-
   function TryConvertInteger(value: unknown) {
     return IsStringNumeric(value) ? parseInt(value) : IsValueTrue(value) ? 1 : value
   }
-
   function TryConvertBoolean(value: unknown) {
     return IsValueTrue(value) ? true : IsValueFalse(value) ? false : value
+  }
+  function TryConvertDate(value: unknown) {
+    return IsDate(value)
+      ? value
+      : IsNumber(value)
+      ? new globalThis.Date(value)
+      : IsValueTrue(value)
+      ? new globalThis.Date(1)
+      : IsStringNumeric(value)
+      ? new globalThis.Date(parseInt(value))
+      : IsTimeStringWithoutTimeZone(value)
+      ? new globalThis.Date(`1970-01-01T${value}.000Z`)
+      : IsTimeStringWithTimeZone(value)
+      ? new globalThis.Date(`1970-01-01T${value}`)
+      : IsDateTimeStringWithoutTimeZone(value)
+      ? new globalThis.Date(`${value}.000Z`)
+      : IsDateTimeStringWithTimeZone(value)
+      ? new globalThis.Date(value)
+      : IsDateString(value)
+      ? new globalThis.Date(`${value}T00:00:00.000Z`)
+      : value
   }
 
   // ----------------------------------------------------------------------------------------------
   // Cast
   // ----------------------------------------------------------------------------------------------
-
   function Any(schema: Types.TAny, references: Types.TSchema[], value: any): any {
     return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
   }
-
   function Array(schema: Types.TArray, references: Types.TSchema[], value: any): any {
     if (ValueCheck.Check(schema, references, value)) return ValueClone.Clone(value)
     const created = IsArray(value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
@@ -192,12 +209,10 @@ export namespace ValueCast {
     if (!ValueCheck.Check(schema, references, unique)) throw new ValueCastArrayUniqueItemsTypeError(schema, unique)
     return unique
   }
-
   function Boolean(schema: Types.TBoolean, references: Types.TSchema[], value: any): any {
     const conversion = TryConvertBoolean(value)
     return ValueCheck.Check(schema, references, conversion) ? conversion : ValueCreate.Create(schema, references)
   }
-
   function Constructor(schema: Types.TConstructor, references: Types.TSchema[], value: any): any {
     if (ValueCheck.Check(schema, references, value)) return ValueCreate.Create(schema, references)
     const required = new Set(schema.returns.required || [])
@@ -208,37 +223,30 @@ export namespace ValueCast {
     }
     return result
   }
-
   function Date(schema: Types.TDate, references: Types.TSchema[], value: any): any {
-    return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
+    const conversion = TryConvertDate(value)
+    return ValueCheck.Check(schema, references, conversion) ? ValueClone.Clone(conversion) : ValueCreate.Create(schema, references)
   }
-
   function Function(schema: Types.TFunction, references: Types.TSchema[], value: any): any {
     return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
   }
-
   function Integer(schema: Types.TInteger, references: Types.TSchema[], value: any): any {
     const conversion = TryConvertInteger(value)
     return ValueCheck.Check(schema, references, conversion) ? conversion : ValueCreate.Create(schema, references)
   }
-
   function Literal(schema: Types.TLiteral, references: Types.TSchema[], value: any): any {
     return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
   }
-
   function Never(schema: Types.TNever, references: Types.TSchema[], value: any): any {
     throw new ValueCastNeverTypeError(schema)
   }
-
   function Null(schema: Types.TNull, references: Types.TSchema[], value: any): any {
     return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
   }
-
   function Number(schema: Types.TNumber, references: Types.TSchema[], value: any): any {
     const conversion = TryConvertNumber(value)
     return ValueCheck.Check(schema, references, conversion) ? conversion : ValueCreate.Create(schema, references)
   }
-
   function Object(schema: Types.TObject, references: Types.TSchema[], value: any): any {
     if (ValueCheck.Check(schema, references, value)) return ValueClone.Clone(value)
     if (value === null || typeof value !== 'object') return ValueCreate.Create(schema, references)
@@ -258,11 +266,9 @@ export namespace ValueCast {
     }
     return result
   }
-
   function Promise(schema: Types.TSchema, references: Types.TSchema[], value: any): any {
     return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
   }
-
   function Record(schema: Types.TRecord<any, any>, references: Types.TSchema[], value: any): any {
     if (ValueCheck.Check(schema, references, value)) return ValueClone.Clone(value)
     if (value === null || typeof value !== 'object' || globalThis.Array.isArray(value) || value instanceof globalThis.Date) return ValueCreate.Create(schema, references)
@@ -274,59 +280,47 @@ export namespace ValueCast {
     }
     return result
   }
-
   function Recursive(schema: Types.TRecursive<any>, references: Types.TSchema[], value: any): any {
     throw new ValueCastRecursiveTypeError(schema)
   }
-
   function Ref(schema: Types.TRef<any>, references: Types.TSchema[], value: any): any {
     const reference = references.find((reference) => reference.$id === schema.$ref)
     if (reference === undefined) throw new ValueCastReferenceTypeError(schema)
     return Visit(reference, references, value)
   }
-
   function Self(schema: Types.TSelf, references: Types.TSchema[], value: any): any {
     const reference = references.find((reference) => reference.$id === schema.$ref)
     if (reference === undefined) throw new ValueCastReferenceTypeError(schema)
     return Visit(reference, references, value)
   }
-
   function String(schema: Types.TString, references: Types.TSchema[], value: any): any {
     const conversion = TryConvertString(value)
     return ValueCheck.Check(schema, references, conversion) ? conversion : ValueCreate.Create(schema, references)
   }
-
   function Tuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], value: any): any {
     if (ValueCheck.Check(schema, references, value)) return ValueClone.Clone(value)
     if (!globalThis.Array.isArray(value)) return ValueCreate.Create(schema, references)
     if (schema.items === undefined) return []
     return schema.items.map((schema, index) => Visit(schema, references, value[index]))
   }
-
   function Undefined(schema: Types.TUndefined, references: Types.TSchema[], value: any): any {
     return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
   }
-
   function Union(schema: Types.TUnion, references: Types.TSchema[], value: any): any {
     return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : UnionCastCreate.Create(schema, references, value)
   }
-
   function Uint8Array(schema: Types.TUint8Array, references: Types.TSchema[], value: any): any {
     return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
   }
-
   function Unknown(schema: Types.TUnknown, references: Types.TSchema[], value: any): any {
     return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
   }
-
   function Void(schema: Types.TVoid, references: Types.TSchema[], value: any): any {
     return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
   }
-
   function UserDefined(schema: Types.TSchema, references: Types.TSchema[], value: any): any {
     return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
   }
-
   export function Visit(schema: Types.TSchema, references: Types.TSchema[], value: any): any {
     const anyReferences = schema.$id === undefined ? references : [schema, ...references]
     const anySchema = schema as any
@@ -384,7 +378,6 @@ export namespace ValueCast {
         return UserDefined(anySchema, anyReferences, value)
     }
   }
-
   export function Cast<T extends Types.TSchema, R extends Types.TSchema[]>(schema: T, references: [...R], value: any): Types.Static<T> {
     return schema.$id === undefined ? Visit(schema, references, value) : Visit(schema, [schema, ...references], value)
   }

--- a/src/value/check.ts
+++ b/src/value/check.ts
@@ -76,6 +76,9 @@ export namespace ValueCheck {
     if (!(value instanceof globalThis.Date)) {
       return false
     }
+    if (isNaN(value.getTime())) {
+      return false
+    }
     if (IsNumber(schema.exclusiveMinimumTimestamp) && !(value.getTime() > schema.exclusiveMinimumTimestamp)) {
       return false
     }

--- a/src/value/value.ts
+++ b/src/value/value.ts
@@ -38,9 +38,9 @@ import { ValueDelta, Edit } from './delta'
 
 /** Provides functions to perform structural updates to JavaScript values */
 export namespace Value {
-  /** Casts a value into a given type. The return value will retain as much information of the original value as possible. Cast will convert string, number and boolean values if a reasonable conversion is possible. */
+  /** Casts a value into a given type. The return value will retain as much information of the original value as possible. Cast will convert string, number, boolean and date values if a reasonable conversion is possible. */
   export function Cast<T extends Types.TSchema, R extends Types.TSchema[]>(schema: T, references: [...R], value: unknown): Types.Static<T>
-  /** Casts a value into a given type. The return value will retain as much information of the original value as possible. Cast will convert string, number and boolean values if a reasonable conversion is possible. */
+  /** Casts a value into a given type. The return value will retain as much information of the original value as possible. Cast will convert string, number, boolean and date values if a reasonable conversion is possible. */
   export function Cast<T extends Types.TSchema>(schema: T, value: unknown): Types.Static<T>
   export function Cast(...args: any[]) {
     const [schema, references, value] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], [], args[1]]

--- a/test/runtime/compiler/date.ts
+++ b/test/runtime/compiler/date.ts
@@ -34,25 +34,25 @@ describe('type/compiler/Date', () => {
     const T = Type.Date()
     Ok(T, new Date())
   })
-
+  it('Should not validate Date if is invalid', () => {
+    const T = Type.Date()
+    Fail(T, new Date('not-a-valid-date'))
+  })
   it('Should validate Date minimumTimestamp', () => {
     const T = Type.Date({ minimumTimestamp: 10 })
     Fail(T, new Date(9))
     Ok(T, new Date(10))
   })
-
   it('Should validate Date maximumTimestamp', () => {
     const T = Type.Date({ maximumTimestamp: 10 })
     Ok(T, new Date(10))
     Fail(T, new Date(11))
   })
-
   it('Should validate Date exclusiveMinimumTimestamp', () => {
     const T = Type.Date({ exclusiveMinimumTimestamp: 10 })
     Fail(T, new Date(10))
     Ok(T, new Date(11))
   })
-
   it('Should validate Date exclusiveMaximumTimestamp', () => {
     const T = Type.Date({ exclusiveMaximumTimestamp: 10 })
     Ok(T, new Date(9))

--- a/test/runtime/schema/date.ts
+++ b/test/runtime/schema/date.ts
@@ -39,6 +39,10 @@ describe('type/schema/Date', () => {
     const T = Type.Date()
     Ok(T, new Date())
   })
+  it('Should not validate Date if is invalid', () => {
+    const T = Type.Date()
+    Fail(T, new Date('not-a-valid-date'))
+  })
   it('Should validate Date minimumTimestamp', () => {
     const T = Type.Date({ minimumTimestamp: 10 })
     Fail(T, new Date(9))

--- a/test/runtime/value/cast/convert.ts
+++ b/test/runtime/value/cast/convert.ts
@@ -284,4 +284,8 @@ describe('value/convert/Date', () => {
     const result = Value.Cast(Type.Date(), '1980-02-03')
     Assert.deepEqual(result.toISOString(), '1980-02-03T00:00:00.000Z')
   })
+  it('Should convert invalid strings to unix epoch 0', () => {
+    const result = Value.Cast(Type.Date(), 'invalid-date')
+    Assert.deepEqual(result.toISOString(), '1970-01-01T00:00:00.000Z')
+  })
 })

--- a/test/runtime/value/cast/convert.ts
+++ b/test/runtime/value/cast/convert.ts
@@ -2,280 +2,286 @@ import { Value } from '@sinclair/typebox/value'
 import { Type } from '@sinclair/typebox'
 import { Assert } from '../../assert/index'
 
+//---------------------------------------------------------------
+// String Convert
+//---------------------------------------------------------------
 describe('value/convert/String', () => {
   it('Should convert string', () => {
     const value = 'hello'
     const result = Value.Cast(Type.String(), value)
     Assert.deepEqual(result, 'hello')
   })
-
   it('Should convert number #1', () => {
     const value = 42
     const result = Value.Cast(Type.String(), value)
     Assert.deepEqual(result, '42')
   })
-
   it('Should convert number #2', () => {
     const value = 42n
     const result = Value.Cast(Type.String(), value)
     Assert.deepEqual(result, '42')
   })
-
   it('Should convert true', () => {
     const value = true
     const result = Value.Cast(Type.String(), value)
     Assert.deepEqual(result, 'true')
   })
-
   it('Should convert false', () => {
     const value = false
     const result = Value.Cast(Type.String(), value)
     Assert.deepEqual(result, 'false')
   })
-
   it('Should convert object', () => {
     const value = {}
     const result = Value.Cast(Type.String(), value)
     Assert.deepEqual(result, '')
   })
-
   it('Should convert array', () => {
     const value = [] as any[]
     const result = Value.Cast(Type.String(), value)
     Assert.deepEqual(result, '')
   })
 })
-
+//---------------------------------------------------------------
+// Number Convert
+//---------------------------------------------------------------
 describe('value/convert/Number', () => {
   it('Should convert string #1', () => {
     const value = 'hello'
     const result = Value.Cast(Type.Number(), value)
     Assert.deepEqual(result, 0)
   })
-
   it('Should convert string #2', () => {
     const value = '3.14'
     const result = Value.Cast(Type.Number(), value)
     Assert.deepEqual(result, 3.14)
   })
-
   it('Should convert string #3', () => {
     const value = '-0'
     const result = Value.Cast(Type.Number(), value)
     Assert.deepEqual(result, 0)
   })
-
   it('Should convert string #4', () => {
     const value = '-100'
     const result = Value.Cast(Type.Number(), value)
     Assert.deepEqual(result, -100)
   })
-
   it('Should convert number', () => {
     const value = 42
     const result = Value.Cast(Type.Number(), value)
     Assert.deepEqual(result, 42)
   })
-
   it('Should convert true', () => {
     const value = true
     const result = Value.Cast(Type.Number(), value)
     Assert.deepEqual(result, 1)
   })
-
   it('Should convert false', () => {
     const value = false
     const result = Value.Cast(Type.Number(), value)
     Assert.deepEqual(result, 0)
   })
-
   it('Should convert object', () => {
     const value = {}
     const result = Value.Cast(Type.String(), value)
     Assert.deepEqual(result, 0)
   })
-
   it('Should convert array', () => {
     const value = [] as any[]
     const result = Value.Cast(Type.String(), value)
     Assert.deepEqual(result, 0)
   })
 })
-
+//---------------------------------------------------------------
+// Integer Convert
+//---------------------------------------------------------------
 describe('value/convert/Integer', () => {
   it('Should convert string #1', () => {
     const value = 'hello'
     const result = Value.Cast(Type.Integer(), value)
     Assert.deepEqual(result, 0)
   })
-
   it('Should convert string #2', () => {
     const value = '3.14'
     const result = Value.Cast(Type.Integer(), value)
     Assert.deepEqual(result, 3)
   })
-
   it('Should convert string #3', () => {
     const value = '-0'
     const result = Value.Cast(Type.Integer(), value)
     Assert.deepEqual(result, 0)
   })
-
   it('Should convert string #4', () => {
     const value = '-100'
     const result = Value.Cast(Type.Integer(), value)
     Assert.deepEqual(result, -100)
   })
-
   it('Should convert number', () => {
     const value = 42
     const result = Value.Cast(Type.Integer(), value)
     Assert.deepEqual(result, 42)
   })
-
   it('Should convert true', () => {
     const value = true
     const result = Value.Cast(Type.Integer(), value)
     Assert.deepEqual(result, 1)
   })
-
   it('Should convert false', () => {
     const value = false
     const result = Value.Cast(Type.Integer(), value)
     Assert.deepEqual(result, 0)
   })
-
   it('Should convert object', () => {
     const value = {}
     const result = Value.Cast(Type.Integer(), value)
     Assert.deepEqual(result, 0)
   })
-
   it('Should convert array', () => {
     const value = [] as any[]
     const result = Value.Cast(Type.Integer(), value)
     Assert.deepEqual(result, 0)
   })
 })
-
+//---------------------------------------------------------------
+// Boolean Convert
+//---------------------------------------------------------------
 describe('value/convert/Boolean', () => {
   it('Should convert string #1', () => {
     const value = 'hello'
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, false)
   })
-
   it('Should convert string #2', () => {
     const value = 'true'
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, true)
   })
-
   it('Should convert string #3', () => {
     const value = 'TRUE'
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, true)
   })
-
   it('Should convert string #4', () => {
     const value = 'false'
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, false)
   })
-
   it('Should convert string #5', () => {
     const value = '0'
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, false)
   })
-
   it('Should convert string #6', () => {
     const value = '1'
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, true)
   })
-
   it('Should convert string #7', () => {
     const value = '0'
     const result = Value.Cast(Type.Boolean({ default: true }), value)
     Assert.deepEqual(result, false)
   })
-
   it('Should convert string #8', () => {
     const value = '1'
     const result = Value.Cast(Type.Boolean({ default: false }), value)
     Assert.deepEqual(result, true)
   })
-
   it('Should convert string #8', () => {
     const value = '2'
     const result = Value.Cast(Type.Boolean({ default: true }), value)
     Assert.deepEqual(result, true)
   })
-
   it('Should convert number #1', () => {
     const value = 0
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, false)
   })
-
   it('Should convert number #2', () => {
     const value = 1n
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, true)
   })
-
   it('Should convert number #3', () => {
     const value = 1
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, true)
   })
-
   it('Should convert number #4', () => {
     const value = 2
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, false)
   })
-
   it('Should convert number #5', () => {
     const value = 0
     const result = Value.Cast(Type.Boolean({ default: true }), value)
     Assert.deepEqual(result, false)
   })
-
   it('Should convert number #6', () => {
     const value = 1
     const result = Value.Cast(Type.Boolean({ default: false }), value)
     Assert.deepEqual(result, true)
   })
-
   it('Should convert number #7', () => {
     const value = 2
     const result = Value.Cast(Type.Boolean({ default: true }), value)
     Assert.deepEqual(result, true)
   })
-
   it('Should convert true', () => {
     const value = true
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, true)
   })
-
   it('Should convert false', () => {
     const value = false
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, false)
   })
-
   it('Should convert object', () => {
     const value = {}
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, false)
   })
-
   it('Should convert array', () => {
     const value = [] as any[]
     const result = Value.Cast(Type.Boolean(), value)
     Assert.deepEqual(result, false)
+  })
+})
+
+//---------------------------------------------------------------
+// Date Convert
+//---------------------------------------------------------------
+describe('value/convert/Date', () => {
+  it('Should convert from number', () => {
+    const result = Value.Cast(Type.Date(), 123)
+    Assert.deepEqual(result.getTime(), 123)
+  })
+  it('Should convert from numeric string', () => {
+    const result = Value.Cast(Type.Date(), '123')
+    Assert.deepEqual(result.getTime(), 123)
+  })
+  it('Should convert from boolean true (interpretted as numeric 1)', () => {
+    const result = Value.Cast(Type.Date(), true)
+    Assert.deepEqual(result.getTime(), 1)
+  })
+  it('Should convert from datetime string', () => {
+    const result = Value.Cast(Type.Date(), '1980-02-03T01:02:03.000Z')
+    Assert.deepEqual(result.toISOString(), '1980-02-03T01:02:03.000Z')
+  })
+  it('Should convert from datetime string without timezone', () => {
+    const result = Value.Cast(Type.Date(), '1980-02-03T01:02:03')
+    Assert.deepEqual(result.toISOString(), '1980-02-03T01:02:03.000Z')
+  })
+  it('Should convert from time with timezone', () => {
+    const result = Value.Cast(Type.Date(), '01:02:03.000Z')
+    Assert.deepEqual(result.toISOString(), '1970-01-01T01:02:03.000Z')
+  })
+  it('Should convert from time without timezone', () => {
+    const result = Value.Cast(Type.Date(), '01:02:03')
+    Assert.deepEqual(result.toISOString(), '1970-01-01T01:02:03.000Z')
+  })
+  it('Should convert from date string', () => {
+    const result = Value.Cast(Type.Date(), '1980-02-03')
+    Assert.deepEqual(result.toISOString(), '1980-02-03T00:00:00.000Z')
   })
 })

--- a/test/runtime/value/cast/date.ts
+++ b/test/runtime/value/cast/date.ts
@@ -15,13 +15,13 @@ describe('value/cast/Date', () => {
   it('Should upcast from number', () => {
     const value = 1
     const result = Value.Cast(T, value)
-    Assert.deepEqual(result, E)
+    Assert.deepEqual(result.getTime(), 1) // convert
   })
 
   it('Should upcast from boolean', () => {
     const value = true
     const result = Value.Cast(T, value)
-    Assert.deepEqual(result, E)
+    Assert.deepEqual(result.getTime(), 1) // convert
   })
 
   it('Should upcast from object', () => {

--- a/test/runtime/value/check/date.ts
+++ b/test/runtime/value/check/date.ts
@@ -44,4 +44,9 @@ describe('value/check/Date', () => {
     const result = Value.Check(T, value)
     Assert.equal(result, true)
   })
+  it('Should not validate Date if is invalid', () => {
+    const value = new Date('not-a-valid-date')
+    const result = Value.Check(T, value)
+    Assert.equal(result, false)
+  })
 })


### PR DESCRIPTION
This PR implements Date casting for the `Type.Date()` type. It supports both numeric (timestamp) and string (iso8601) variants, as well as supporting `true` interpretations of numeric values for consistency.

```typescript
Value.Cast(Type.Date(), 12345)                      // 1970-01-01T00:00:12.345Z
Value.Cast(Type.Date(), '12345')                    // 1970-01-01T00:00:12.345Z
Value.Cast(Type.Date(), true)                       // 1970-01-01T00:00:00.001Z
Value.Cast(Type.Date(), '2022-04-05')               // 2022-04-05T00:00:00.000Z
Value.Cast(Type.Date(), '2022-04-05T01:02:03.123Z') // 2022-04-05T01:02:03.123Z
Value.Cast(Type.Date(), '2022-04-05T01:02:03')      // 2022-04-05T01:02:03.000Z
Value.Cast(Type.Date(), '01:02:03.345Z')            // 1970-01-01T01:02:03.345Z
Value.Cast(Type.Date(), '01:02:03')                 // 1970-01-01T01:02:03.000Z
Value.Cast(Type.Date(), 'invalid')                  // 1970-01-01T00:00:00.000Z
```
Invalid or non conversion values result in a Date object that defaults to the unix epoch 0 (as given by the last example)