### PR TITLE
Annual License Update

### DIFF
--- a/codegen/codegen.ts
+++ b/codegen/codegen.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/codegen/formatter.ts
+++ b/codegen/formatter.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/codegen/index.ts
+++ b/codegen/index.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/codegen/jsonschema.ts
+++ b/codegen/jsonschema.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/codegen/typebox.ts
+++ b/codegen/typebox.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/codegen/typescript.ts
+++ b/codegen/typescript.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/codegen/zod.ts
+++ b/codegen/zod.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example/collections/array.ts
+++ b/example/collections/array.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example/collections/index.ts
+++ b/example/collections/index.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example/collections/map.ts
+++ b/example/collections/map.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example/collections/set.ts
+++ b/example/collections/set.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example/extensions/index.ts
+++ b/example/extensions/index.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example/extensions/intersect-allof.ts
+++ b/example/extensions/intersect-allof.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example/extensions/union-enum.ts
+++ b/example/extensions/union-enum.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example/extensions/union-oneof.ts
+++ b/example/extensions/union-oneof.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/license
+++ b/license
@@ -2,7 +2,7 @@ TypeBox: JSON Schema Type Builder with Static Type Resolution for TypeScript
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.25.10",
+  "version": "0.25.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.25.10",
+      "version": "0.25.20",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.25.20",
+  "version": "0.25.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.25.20",
+      "version": "0.25.21",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.25.20",
+  "version": "0.25.21",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/conditional/conditional.ts
+++ b/src/conditional/conditional.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/conditional/index.ts
+++ b/src/conditional/index.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/conditional/structural.ts
+++ b/src/conditional/structural.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/custom/custom.ts
+++ b/src/custom/custom.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/custom/index.ts
+++ b/src/custom/index.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/guard/guard.ts
+++ b/src/guard/guard.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/guard/index.ts
+++ b/src/guard/index.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/hash/hash.ts
+++ b/src/hash/hash.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/hash/index.ts
+++ b/src/hash/index.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/system/system.ts
+++ b/src/system/system.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/value/cast.ts
+++ b/src/value/cast.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/value/check.ts
+++ b/src/value/check.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/value/clone.ts
+++ b/src/value/clone.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/value/create.ts
+++ b/src/value/create.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/value/delta.ts
+++ b/src/value/delta.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/value/equal.ts
+++ b/src/value/equal.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/value/index.ts
+++ b/src/value/index.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/value/is.ts
+++ b/src/value/is.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/value/pointer.ts
+++ b/src/value/pointer.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/value/value.ts
+++ b/src/value/value.ts
@@ -4,7 +4,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR updates the license source header to reflect the current year. Now spans 2017 (since first publish) to 2023.