### PR TITLE
Fix PropertiesReduce typing

### DIFF
--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -319,7 +319,7 @@ export type PropertiesReduce<T extends TProperties, P extends unknown[]> =
   Readonly<Partial<Pick<{ [K in keyof T]: Static<T[K], P> }, ReadonlyOptionalPropertyKeys<T>>>> &
   Readonly<Pick<{ [K in keyof T]: Static<T[K], P> }, ReadonlyPropertyKeys<T>>> &
   Partial<Pick<{ [K in keyof T]: Static<T[K], P> }, OptionalPropertyKeys<T>>> &
-  Required<Pick<{ [K in keyof T]: Static<T[K], P> }, RequiredPropertyKeys<T>>> extends infer R ? { [K in keyof R]: R[K] } : never;
+  Required<Pick<{ [K in keyof T]: Static<T[K], P> }, RequiredPropertyKeys<T>>> extends infer R ? { [K in keyof R]: R[K] } : never
 
 export type TRecordProperties<K extends TUnion<TLiteral[]>, T extends TSchema> = Static<K> extends string ? { [X in Static<K>]: T } : never
 

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -316,10 +316,10 @@ export type RequiredPropertyKeys<T extends TProperties> = keyof Omit<T, Readonly
 
 // prettier-ignore
 export type PropertiesReduce<T extends TProperties, P extends unknown[]> = 
-  { readonly [K in ReadonlyOptionalPropertyKeys<T>]?: Static<T[K], P> } & 
-  { readonly [K in ReadonlyPropertyKeys<T>]:          Static<T[K], P> } & 
-  {          [K in OptionalPropertyKeys<T>]?:         Static<T[K], P> } & 
-  {          [K in RequiredPropertyKeys<T>]:          Static<T[K], P> } extends infer R ? { [K in keyof R]: R[K] } : never
+  Readonly<Partial<Pick<{ [K in keyof T]: Static<T[K], P> }, ReadonlyOptionalPropertyKeys<T>>>> &
+  Readonly<Pick<{ [K in keyof T]: Static<T[K], P> }, ReadonlyPropertyKeys<T>>> &
+  Partial<Pick<{ [K in keyof T]: Static<T[K], P> }, OptionalPropertyKeys<T>>> &
+  Required<Pick<{ [K in keyof T]: Static<T[K], P> }, RequiredPropertyKeys<T>>> extends infer R ? { [K in keyof R]: R[K] } : never;
 
 export type TRecordProperties<K extends TUnion<TLiteral[]>, T extends TSchema> = Static<K> extends string ? { [X in Static<K>]: T } : never
 


### PR DESCRIPTION
Dug into these issues a bit since I was running into it.
https://github.com/sinclairzx81/typebox/issues/260
https://github.com/sinclairzx81/typebox/issues/150#issuecomment-1030143472

The main issue is the `PropertiesReduce` type. With the change below, IntelliSense comments for objects can now be linked back to their original schema declaration.

These are the fixed types here:
```typescript
export type PropertiesReduce<T extends TProperties, P extends unknown[]> = 
  Readonly<Partial<Pick<{ [K in keyof T]: Static<T[K], P> }, ReadonlyOptionalPropertyKeys<T>>>> &
  Readonly<Pick<{ [K in keyof T]: Static<T[K], P> }, ReadonlyPropertyKeys<T>>> &
  Partial<Pick<{ [K in keyof T]: Static<T[K], P> }, OptionalPropertyKeys<T>>> &
  Required<Pick<{ [K in keyof T]: Static<T[K], P> }, RequiredPropertyKeys<T>>> extends infer R ? { [K in keyof R]: R[K] } : never
```

Please verify that this works and still maintains the existing requirements for types.

Also not sure if you had this type of structure anywhere else in the library, I only verified this for `Type.Object()`.

Feel free to clean up the types if you want it implemented differently and thanks for the great library!

# Reasoning

I haven't verified this in depth, but my intuition on why this fixes the issue is because `Pick` is implemented in the following way:
```typescript
type Pick<T, K extends keyof T> = {
    [P in K]: T[P];
}
```
Because `Pick` has `K extends keyof T`, TypeScript is able to maintain the link between the original keys because it knows that `K` is a key of `T`.

To use required properties as an example:
```typescript
{ [K in RequiredPropertyKeys<T>]: Static<T[K], P> }
```
`RequiredPropertyKeys<T>` can't be verified to `extend keyof T` here because you could easily implement `RequiredPropertyKeys<T>` as any arbitrary type such as `type RequiredPropertyKeys<T> = 'randomKey'`.

You have to instead use something similar to `Pick` that guarantees that the keys in the mapped type are actually keys of `T`.
```typescript
Required<Pick<{ [K in keyof T]: Static<T[K], P> }, RequiredPropertyKeys<T>>>
```