### PR TITLE
Property Inference Optimization

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+## [0.25.23](https://www.npmjs.com/package/@sinclair/typebox/v/0.25.23)
+
+Updates:
+
+- [324](https://github.com/sinclairzx81/typebox/pull/324) TypeScript Language Service now presents JSDoc comments when inferring static object properties. (IntelliSense)
+- [325](https://github.com/sinclairzx81/typebox/pull/325) Additional property inference optimizations.
+
+Additional:
+
+- Huge thank you to Github user [stevezhu](https://github.com/stevezhu) for these excellent contributions.
+
+
 ## [0.25.22](https://www.npmjs.com/package/@sinclair/typebox/v/0.25.22)
 
 Updates:

--- a/example/index.ts
+++ b/example/index.ts
@@ -9,6 +9,7 @@ import { Value, ValuePointer } from '@sinclair/typebox/value'
 import { Type, Kind, Static, TSchema } from '@sinclair/typebox'
 
 const T = Type.Object({
+  /** It's a X */
   x: Type.Number(),
   y: Type.Number(),
   z: Type.Number(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.25.22",
+  "version": "0.25.23",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -315,11 +315,17 @@ export type OptionalPropertyKeys<T extends TProperties> = { [K in keyof T]: T[K]
 export type RequiredPropertyKeys<T extends TProperties> = keyof Omit<T, ReadonlyOptionalPropertyKeys<T> | ReadonlyPropertyKeys<T> | OptionalPropertyKeys<T>>
 
 // prettier-ignore
-export type PropertiesReduce<T extends TProperties, P extends unknown[]> = 
-  Readonly<Partial<Pick<{ [K in keyof T]: Static<T[K], P> }, ReadonlyOptionalPropertyKeys<T>>>> &
-  Readonly<Pick<{ [K in keyof T]: Static<T[K], P> }, ReadonlyPropertyKeys<T>>> &
-  Partial<Pick<{ [K in keyof T]: Static<T[K], P> }, OptionalPropertyKeys<T>>> &
-  Required<Pick<{ [K in keyof T]: Static<T[K], P> }, RequiredPropertyKeys<T>>> extends infer R ? { [K in keyof R]: R[K] } : never
+export type PropertiesReducer<T extends TProperties, R extends Record<keyof any, unknown>> = (
+  Readonly<Partial<Pick<R, ReadonlyOptionalPropertyKeys<T>>>> &
+  Readonly<Pick<R, ReadonlyPropertyKeys<T>>> &
+  Partial<Pick<R, OptionalPropertyKeys<T>>> &
+  Required<Pick<R, RequiredPropertyKeys<T>>>
+) extends infer O ? { [K in keyof O]: O[K] } : never
+
+// prettier-ignore
+export type PropertiesReduce<T extends TProperties, P extends unknown[]> = PropertiesReducer<T, { 
+  [K in keyof T]: Static<T[K], P> 
+}>
 
 export type TRecordProperties<K extends TUnion<TLiteral[]>, T extends TSchema> = Static<K> extends string ? { [X in Static<K>]: T } : never
 


### PR DESCRIPTION
This PR implements the property inference optimization as noted on PR https://github.com/sinclairzx81/typebox/pull/324 by contributor @stevezhu. 

This optimization mitigates repeated static inference for inferred property groups for `readonly`, `optional`, `readonly-optional` and `required` with the rationale to ensure a singular TS inference path for subset property mapping.

Compiler tests have been run against 4.1.5 and up (inline with TypeBox compiler targets)

