### PR TITLE
Remove Unused Object Array Check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -253,7 +253,6 @@ export namespace TypeCompiler {
 
   function* Object(schema: Types.TObject, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield IsObjectCheck(value)
-    if (!TypeSystem.AllowArrayObjects) yield `!Array.isArray(${value})`
     if (IsNumber(schema.minProperties)) yield `Object.getOwnPropertyNames(${value}).length >= ${schema.minProperties}`
     if (IsNumber(schema.maxProperties)) yield `Object.getOwnPropertyNames(${value}).length <= ${schema.maxProperties}`
     const schemaKeys = globalThis.Object.getOwnPropertyNames(schema.properties)

--- a/src/value/check.ts
+++ b/src/value/check.ts
@@ -220,10 +220,10 @@ export namespace ValueCheck {
     if (!IsObject(value)) {
       return false
     }
-    if (IsNumber(schema.minProperties) && !(globalThis.Object.getOwnPropertyNames(value).length >= schema.minProperties)) {
+    if (IsDefined<number>(schema.minProperties) && !(globalThis.Object.getOwnPropertyNames(value).length >= schema.minProperties)) {
       return false
     }
-    if (IsNumber(schema.maxProperties) && !(globalThis.Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
+    if (IsDefined<number>(schema.maxProperties) && !(globalThis.Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
       return false
     }
     const knownKeys = globalThis.Object.getOwnPropertyNames(schema.properties)


### PR DESCRIPTION
Post 0.26.0 fixes. Removed unused object array check from TypeCompiler. Small constraint check optimization on ValueCheck.