### PR TITLE
Exact Optional Property Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -146,7 +146,7 @@ export namespace TypeCompiler {
   // -------------------------------------------------------------------
   // Polices
   // -------------------------------------------------------------------
-  function IsExactOptionalProperty(key: string, value: string, expression: string) {
+  function IsExactOptionalProperty(value: string, key: string, expression: string) {
     return TypeSystem.ExactOptionalPropertyTypes ? `('${key}' in ${value} ? ${expression} : true)` : `(${value}.${key} !== undefined ? ${expression} : true)`
   }
   function IsObjectCheck(value: string): string {
@@ -267,7 +267,7 @@ export namespace TypeCompiler {
         if (Types.ExtendsUndefined.Check(property)) yield `('${knownKey}' in ${value})`
       } else {
         const expression = CreateExpression(property, references, memberExpression)
-        yield IsExactOptionalProperty(knownKey, value, expression)
+        yield IsExactOptionalProperty(value, knownKey, expression)
       }
     }
     if (schema.additionalProperties === false) {

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -150,7 +150,7 @@ export namespace ValueErrors {
   // ----------------------------------------------------------------------
   // Policies
   // ----------------------------------------------------------------------
-  function IsExactOptionalProperty(key: string, value: Record<keyof any, unknown>) {
+  function IsExactOptionalProperty(value: Record<keyof any, unknown>, key: string) {
     return TypeSystem.ExactOptionalPropertyTypes ? key in value : value[key] !== undefined
   }
   function IsObject(value: unknown): value is Record<keyof any, unknown> {
@@ -358,7 +358,7 @@ export namespace ValueErrors {
           yield { type: ValueErrorType.ObjectRequiredProperties, schema: property, path: `${path}/${knownKey}`, value: undefined, message: `Expected required property` }
         }
       } else {
-        if (IsExactOptionalProperty(knownKey, value)) {
+        if (IsExactOptionalProperty(value, knownKey)) {
           yield* Visit(property, references, `${path}/${knownKey}`, value[knownKey])
         }
       }

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -351,7 +351,8 @@ export namespace ValueErrors {
           yield { type: ValueErrorType.ObjectRequiredProperties, schema: property, path: `${path}/${knownKey}`, value: undefined, message: `Expected required property` }
         }
       } else {
-        if (knownKey in value) {
+        const exactOptionalCheck = TypeSystem.ExactOptionalPropertyTypes ? knownKey in value : value[knownKey] !== undefined
+        if (exactOptionalCheck) {
           yield* Visit(property, references, `${path}/${knownKey}`, value[knownKey])
         }
       }

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -135,19 +135,8 @@ export namespace ValueErrors {
   // ----------------------------------------------------------------------
   // Guards
   // ----------------------------------------------------------------------
-  function IsObject(value: unknown): value is Record<keyof any, unknown> {
-    const result = typeof value === 'object' && value !== null
-    return TypeSystem.AllowArrayObjects ? result : result && !globalThis.Array.isArray(value)
-  }
-  function IsRecordObject(value: unknown): value is Record<keyof any, unknown> {
-    return IsObject(value) && !(value instanceof globalThis.Date) && !(value instanceof globalThis.Uint8Array)
-  }
   function IsBigInt(value: unknown): value is bigint {
     return typeof value === 'bigint'
-  }
-  function IsNumber(value: unknown): value is number {
-    const result = typeof value === 'number'
-    return TypeSystem.AllowNaN ? result : result && globalThis.Number.isFinite(value)
   }
   function IsInteger(value: unknown): value is number {
     return globalThis.Number.isInteger(value)
@@ -155,13 +144,31 @@ export namespace ValueErrors {
   function IsString(value: unknown): value is string {
     return typeof value === 'string'
   }
+  function IsDefined<T>(value: unknown): value is T {
+    return value !== undefined
+  }
+  // ----------------------------------------------------------------------
+  // Policies
+  // ----------------------------------------------------------------------
+  function IsExactOptionalProperty(key: string, value: Record<keyof any, unknown>) {
+    return TypeSystem.ExactOptionalPropertyTypes ? key in value : value[key] !== undefined
+  }
+  function IsObject(value: unknown): value is Record<keyof any, unknown> {
+    const result = typeof value === 'object' && value !== null
+    return TypeSystem.AllowArrayObjects ? result : result && !globalThis.Array.isArray(value)
+  }
+  function IsRecordObject(value: unknown): value is Record<keyof any, unknown> {
+    return IsObject(value) && !(value instanceof globalThis.Date) && !(value instanceof globalThis.Uint8Array)
+  }
+  function IsNumber(value: unknown): value is number {
+    const result = typeof value === 'number'
+    return TypeSystem.AllowNaN ? result : result && globalThis.Number.isFinite(value)
+  }
   function IsVoid(value: unknown): value is void {
     const result = value === undefined
     return TypeSystem.AllowVoidNull ? result || value === null : result
   }
-  function IsDefined<T>(value: unknown): value is T {
-    return value !== undefined
-  }
+
   // ----------------------------------------------------------------------
   // Types
   // ----------------------------------------------------------------------
@@ -351,8 +358,7 @@ export namespace ValueErrors {
           yield { type: ValueErrorType.ObjectRequiredProperties, schema: property, path: `${path}/${knownKey}`, value: undefined, message: `Expected required property` }
         }
       } else {
-        const exactOptionalCheck = TypeSystem.ExactOptionalPropertyTypes ? knownKey in value : value[knownKey] !== undefined
-        if (exactOptionalCheck) {
+        if (IsExactOptionalProperty(knownKey, value)) {
           yield* Visit(property, references, `${path}/${knownKey}`, value[knownKey])
         }
       }

--- a/src/system/system.ts
+++ b/src/system/system.ts
@@ -38,14 +38,24 @@ export class TypeSystemDuplicateFormat extends Error {
     super(`Duplicate string format '${kind}' detected`)
   }
 }
+
 /** Creates user defined types and formats and provides overrides for value checking behaviours */
 export namespace TypeSystem {
+  // ------------------------------------------------------------------------
+  // Assertion Policies
+  // ------------------------------------------------------------------------
+  /** Sets whether assertions should allow strict `undefined` optional properties. The default is `false` */
+  export let ExactOptionalPropertyTypes: boolean = false
   /** Sets whether arrays should be treated as a kind of objects. The default is `false` */
   export let AllowArrayObjects: boolean = false
   /** Sets whether `NaN` or `Infinity` should be treated as valid numeric values. The default is `false` */
   export let AllowNaN: boolean = false
   /** Sets whether `null` should validate for void types. The default is `false` */
   export let AllowVoidNull: boolean = false
+
+  // ------------------------------------------------------------------------
+  // String Formats and Types
+  // ------------------------------------------------------------------------
   /** Creates a new type */
   export function Type<Type, Options = object>(kind: string, check: (options: Options, value: unknown) => boolean) {
     if (Types.TypeRegistry.Has(kind)) throw new TypeSystemDuplicateTypeKind(kind)
@@ -58,6 +68,7 @@ export namespace TypeSystem {
     Types.FormatRegistry.Set(format, check)
     return format
   }
+
   // ------------------------------------------------------------------------
   // Deprecated
   // ------------------------------------------------------------------------

--- a/src/system/system.ts
+++ b/src/system/system.ts
@@ -44,7 +44,7 @@ export namespace TypeSystem {
   // ------------------------------------------------------------------------
   // Assertion Policies
   // ------------------------------------------------------------------------
-  /** Sets whether assertions should allow strict `undefined` optional properties. The default is `false` */
+  /** Sets whether TypeBox should assert optional properties using the TypeScript `exactOptionalPropertyTypes` assertion policy. The default is `false` */
   export let ExactOptionalPropertyTypes: boolean = false
   /** Sets whether arrays should be treated as a kind of objects. The default is `false` */
   export let AllowArrayObjects: boolean = false

--- a/src/value/check.ts
+++ b/src/value/check.ts
@@ -62,7 +62,7 @@ export namespace ValueCheck {
   // ----------------------------------------------------------------------
   // Policies
   // ----------------------------------------------------------------------
-  function IsExactOptionalProperty(key: string, value: Record<keyof any, unknown>) {
+  function IsExactOptionalProperty(value: Record<keyof any, unknown>, key: string) {
     return TypeSystem.ExactOptionalPropertyTypes ? key in value : value[key] !== undefined
   }
   function IsObject(value: unknown): value is Record<keyof any, unknown> {
@@ -243,7 +243,7 @@ export namespace ValueCheck {
           return knownKey in value
         }
       } else {
-        if (IsExactOptionalProperty(knownKey, value) && !Visit(property, references, value[knownKey])) {
+        if (IsExactOptionalProperty(value, knownKey) && !Visit(property, references, value[knownKey])) {
           return false
         }
       }

--- a/src/value/check.ts
+++ b/src/value/check.ts
@@ -60,15 +60,10 @@ export namespace ValueCheck {
     return value !== undefined
   }
   // ----------------------------------------------------------------------
-  // Overrides
+  // Policies
   // ----------------------------------------------------------------------
-  function IsExactOptionalPropertyType(schema: Types.TSchema, references: Types.TSchema[], key: string, value: Record<keyof any, unknown>) {
-    if (TypeSystem.ExactOptionalPropertyTypes && key in value && !Visit(schema, references, value[key])) {
-      return false
-    }
-    if (value[key] !== undefined && !Visit(schema, references, value[key])) {
-      return false
-    }
+  function IsExactOptionalProperty(key: string, value: Record<keyof any, unknown>) {
+    return TypeSystem.ExactOptionalPropertyTypes ? key in value : value[key] !== undefined
   }
   function IsObject(value: unknown): value is Record<keyof any, unknown> {
     const result = typeof value === 'object' && value !== null
@@ -85,7 +80,6 @@ export namespace ValueCheck {
     const result = value === undefined
     return TypeSystem.AllowVoidNull ? result || value === null : result
   }
-
   // ----------------------------------------------------------------------
   // Types
   // ----------------------------------------------------------------------
@@ -249,8 +243,7 @@ export namespace ValueCheck {
           return knownKey in value
         }
       } else {
-        const exactOptionalCheck = TypeSystem.ExactOptionalPropertyTypes ? knownKey in value : value[knownKey] !== undefined
-        if (exactOptionalCheck && !Visit(property, references, value[knownKey])) {
+        if (IsExactOptionalProperty(knownKey, value) && !Visit(property, references, value[knownKey])) {
           return false
         }
       }

--- a/test/runtime/compiler/object.ts
+++ b/test/runtime/compiler/object.ts
@@ -227,16 +227,16 @@ describe('type/compiler/Object', () => {
     Ok(T, { x: undefined })
     Ok(T, {})
   })
-  it('Should not check undefined for optional property of number', () => {
+  it('Should check undefined for optional property of number', () => {
     const T = Type.Object({ x: Type.Optional(Type.Number()) })
     Ok(T, { x: 1 })
+    Ok(T, { x: undefined }) // allowed by default
     Ok(T, {})
-    Fail(T, { x: undefined })
   })
   it('Should check undefined for optional property of undefined', () => {
     const T = Type.Object({ x: Type.Optional(Type.Undefined()) })
     Fail(T, { x: 1 })
-    Ok(T, {})
     Ok(T, { x: undefined })
+    Ok(T, {})
   })
 })

--- a/test/runtime/system/system.ts
+++ b/test/runtime/system/system.ts
@@ -3,6 +3,42 @@ import { Assert } from '../assert/index'
 import { TypeSystem } from '@sinclair/typebox/system'
 import { Type } from '@sinclair/typebox'
 
+describe('system/TypeSystem/ExactOptionalPropertyTypes', () => {
+  before(() => {
+    TypeSystem.ExactOptionalPropertyTypes = true
+  })
+  after(() => {
+    TypeSystem.ExactOptionalPropertyTypes = false
+  })
+  // ---------------------------------------------------------------
+  // Number
+  // ---------------------------------------------------------------
+  it('Should not validate optional number', () => {
+    const T = Type.Object({
+      x: Type.Optional(Type.Number()),
+    })
+    Ok(T, {})
+    Ok(T, { x: 1 })
+    Fail(T, { x: undefined })
+  })
+  it('Should not validate undefined', () => {
+    const T = Type.Object({
+      x: Type.Optional(Type.Undefined()),
+    })
+    Ok(T, {})
+    Fail(T, { x: 1 })
+    Ok(T, { x: undefined })
+  })
+  it('Should validate optional number | undefined', () => {
+    const T = Type.Object({
+      x: Type.Optional(Type.Union([Type.Number(), Type.Undefined()])),
+    })
+    Ok(T, {})
+    Ok(T, { x: 1 })
+    Ok(T, { x: undefined })
+  })
+})
+
 describe('system/TypeSystem/AllowNaN', () => {
   before(() => {
     TypeSystem.AllowNaN = true

--- a/test/runtime/value/check/object.ts
+++ b/test/runtime/value/check/object.ts
@@ -212,11 +212,11 @@ describe('value/check/Object', () => {
     Assert.equal(Value.Check(T, { x: undefined }), true)
     Assert.equal(Value.Check(T, {}), true)
   })
-  it('Should not check undefined for optional property of number', () => {
+  it('Should check undefined for optional property of number', () => {
     const T = Type.Object({ x: Type.Optional(Type.Number()) })
     Assert.equal(Value.Check(T, { x: 1 }), true)
+    Assert.equal(Value.Check(T, { x: undefined }), true) // allowed by default
     Assert.equal(Value.Check(T, {}), true)
-    Assert.equal(Value.Check(T, { x: undefined }), false)
   })
   it('Should check undefined for optional property of undefined', () => {
     const T = Type.Object({ x: Type.Optional(Type.Undefined()) })


### PR DESCRIPTION
This PR implements the TypeScript compiler option `exactOptionalPropertyTypes` which will perform a `key` assertion for optional properties (as opposed to a less strict `obj.value === undefined`).  The `exactOptionalPropertyTypes` assertion was implemented by default on 0.26.0 but has caused some problems for those upgrading to 0.26.0, this PR makes this assertion "opt-in" via `TypeSystem.ExactOptionalPropertyTypes`.

```typescript
import { TypeSystem } from '@sinclair/typebox/system'

TypeSystem.ExactOptionalPropertyTypes = true // default is false

const T = Type.Object({
  x: Type.Optional(Type.Number())
})

Value.Check(T, {}) // ok
Value.Check(T, { x: 1 }) // ok
Value.Check(T, { x: undefined }) // fail: ExactOptionalPropertyTypes is true
```
This change is inline with the default TypeScript compiler settings.

Documentation on this compiler setting can be found at the link below.

https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes