### PR TITLE
Enhanced Member Expression Check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -147,7 +147,7 @@ export namespace TypeCompiler {
   // Polices
   // -------------------------------------------------------------------
   function IsExactOptionalProperty(value: string, key: string, expression: string) {
-    return TypeSystem.ExactOptionalPropertyTypes ? `('${key}' in ${value} ? ${expression} : true)` : `(${value}.${key} !== undefined ? ${expression} : true)`
+    return TypeSystem.ExactOptionalPropertyTypes ? `('${key}' in ${value} ? ${expression} : true)` : `(${MemberExpression.Encode(value, key)} !== undefined ? ${expression} : true)`
   }
   function IsObjectCheck(value: string): string {
     return !TypeSystem.AllowArrayObjects ? `(typeof ${value} === 'object' && ${value} !== null && !Array.isArray(${value}))` : `(typeof ${value} === 'object' && ${value} !== null)`

--- a/test/runtime/compiler/object.ts
+++ b/test/runtime/compiler/object.ts
@@ -132,16 +132,20 @@ describe('type/compiler/Object', () => {
       '0-leading': Type.Literal(2),
       '$-leading': Type.Literal(3),
       '!@#$%^&*(': Type.Literal(4),
-      'node-mirror:release': Type.Literal(5), // issue: 353
-      "a'a": Type.Literal(6),
+      'node-mirror:release:0': Type.Literal(5), // issue: 353
+      'node-mirror:release:1': Type.Optional(Type.Literal(6)), // issue: 356
+      'node-mirror:release:2': Type.Union([Type.Literal(7), Type.Undefined()]), // key known
+      "a'a": Type.Literal(8),
     })
     Ok(T, {
       'with-hyphen': 1,
       '0-leading': 2,
       '$-leading': 3,
       '!@#$%^&*(': 4,
-      'node-mirror:release': 5,
-      "a'a": 6,
+      'node-mirror:release:0': 5,
+      'node-mirror:release:1': 6,
+      'node-mirror:release:2': 7,
+      "a'a": 8,
     })
   })
   it('Should validate schema additional properties of string', () => {


### PR DESCRIPTION
This PR is a follow on from #354 which missed the member expression encode for optional properties. 