### PR TITLE
Inverse Assert for Compiler and Value Check Alignment

### DIFF
--- a/test/runtime/compiler/validate.ts
+++ b/test/runtime/compiler/validate.ts
@@ -96,6 +96,9 @@ export function Ok<T extends TSchema>(schema: T, data: unknown, references: any[
 export function Fail<T extends TSchema>(schema: T, data: unknown, references: any[] = []) {
   const C = TypeCompiler.Compile(schema, references)
   const result = C.Check(data)
+  if (result !== Value.Check(schema, references, data)) {
+    throw Error('Compiler and Value Check disparity')
+  }
   if (result === false) {
     const errors = [...Value.Errors(schema, references, data)]
     if (errors.length === 0) throw Error('expected at least 1 error')


### PR DESCRIPTION
This PR is a small unit update to check that the Value assertion failure cases are aligned with the TypeCompiler failure cases.