### PR TITLE
Record and Union Conversion Logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/test/runtime/value/convert/record.ts
+++ b/test/runtime/value/convert/record.ts
@@ -3,5 +3,9 @@ import { Type } from '@sinclair/typebox'
 import { Assert } from '../../assert/index'
 
 describe('value/convert/Record', () => {
-  it('Should convert', () => {})
+  it('Should convert record value to numeric', () => {
+    const T = Type.Record(Type.String(), Type.Number())
+    const V = Value.Convert(T, { x: '42', y: '24', z: 'hello' })
+    Assert.deepEqual(V, { x: 42, y: '24', z: 'hello' })
+  })
 })

--- a/test/runtime/value/convert/union.ts
+++ b/test/runtime/value/convert/union.ts
@@ -3,5 +3,22 @@ import { Type } from '@sinclair/typebox'
 import { Assert } from '../../assert/index'
 
 describe('value/convert/Union', () => {
-  it('Should convert', () => {})
+  it('Should convert union variant', () => {
+    const T = Type.Object({
+      x: Type.Union([Type.Number(), Type.Null()]),
+    })
+    const V1 = Value.Convert(T, { x: '42' })
+    const V2 = Value.Convert(T, { x: 'null' })
+    const V3 = Value.Convert(T, { x: 'hello' })
+    Assert.deepEqual(V1, { x: 42 })
+    Assert.deepEqual(V2, { x: null })
+    Assert.deepEqual(V3, { x: 'hello' })
+  })
+  it('Should convert first variant in ambigous conversion', () => {
+    const T = Type.Object({
+      x: Type.Union([Type.Boolean(), Type.Number()]),
+    })
+    const V1 = Value.Convert(T, { x: '1' })
+    Assert.deepEqual(V1, { x: true })
+  })
 })

--- a/test/runtime/value/convert/union.ts
+++ b/test/runtime/value/convert/union.ts
@@ -14,7 +14,7 @@ describe('value/convert/Union', () => {
     Assert.deepEqual(V2, { x: null })
     Assert.deepEqual(V3, { x: 'hello' })
   })
-  it('Should convert first variant in ambigous conversion', () => {
+  it('Should convert first variant in ambiguous conversion', () => {
     const T = Type.Object({
       x: Type.Union([Type.Boolean(), Type.Number()]),
     })


### PR DESCRIPTION
This PR includes additional conversion logic for unions and records. These conversions were omitted during the work to extract conversion logic from cast. As reported on https://github.com/sinclairzx81/typebox/issues/360