### PR TITLE
Fix: '@' character is not alpha

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -64,7 +64,7 @@ namespace Character {
     return code === 95
   }
   export function IsAlpha(code: number) {
-    return (code >= 64 && code <= 90) || (code >= 97 && code <= 122)
+    return (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
   }
   export function IsNumeric(code: number) {
     return code >= 48 && code <= 57

--- a/test/runtime/compiler/object.ts
+++ b/test/runtime/compiler/object.ts
@@ -136,6 +136,7 @@ describe('type/compiler/Object', () => {
       'node-mirror:release:1': Type.Optional(Type.Literal(6)), // issue: 356
       'node-mirror:release:2': Type.Union([Type.Literal(7), Type.Undefined()]), // key known
       "a'a": Type.Literal(8),
+      "@onlyAtSymbol": Type.Literal(9)
     })
     Ok(T, {
       'with-hyphen': 1,
@@ -146,6 +147,7 @@ describe('type/compiler/Object', () => {
       'node-mirror:release:1': 6,
       'node-mirror:release:2': 7,
       "a'a": 8,
+      "@onlyAtSymbol": 9
     })
   })
   it('Should validate schema additional properties of string', () => {


### PR DESCRIPTION
currently this fails:
```
TypeCompiler.Compile(Type.Object({ "@foo": Type.String() }))
```
because the `@` character (ascii code: 64) is mistakenly included in the `Character.IsAlpha` check