### PR TITLE
Template Literal Finite Checks

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -3,14 +3,38 @@ import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
 import { Type, TypeGuard, Kind, Static, TSchema } from '@sinclair/typebox'
 
-const L = Type.TemplateLiteral([Type.String(), Type.Literal('_foo')])
-const R = Type.Record(L, Type.String())
-type L = Static<typeof L>
-type R = Static<typeof R>
-console.log(R)
+// -----------------------------------------------------------
+// Create: Type
+// -----------------------------------------------------------
 
-// const L = Type.TemplateLiteral([Type.Literal('.*')])
-// const R = Type.Record(L, Type.String());
-// type L = Static<typeof L>
-// type R = Static<typeof R>
-// console.log(R);
+const T = Type.Object({
+  x: Type.Number(),
+  y: Type.Number(),
+  z: Type.Number(),
+})
+
+type T = Static<typeof T>
+
+console.log(T)
+
+// -----------------------------------------------------------
+// Create: Value
+// -----------------------------------------------------------
+
+const V = Value.Create(T)
+
+console.log(V)
+
+// -----------------------------------------------------------
+// Compile: Type
+// -----------------------------------------------------------
+
+const C = TypeCompiler.Compile(T)
+
+console.log(C.Code())
+
+// -----------------------------------------------------------
+// Check: Value
+// -----------------------------------------------------------
+
+console.log(C.Check(V))

--- a/example/index.ts
+++ b/example/index.ts
@@ -3,38 +3,14 @@ import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
 import { Type, TypeGuard, Kind, Static, TSchema } from '@sinclair/typebox'
 
-// -----------------------------------------------------------
-// Create: Type
-// -----------------------------------------------------------
+const L = Type.TemplateLiteral([Type.String(), Type.Literal('_foo')])
+const R = Type.Record(L, Type.String())
+type L = Static<typeof L>
+type R = Static<typeof R>
+console.log(R)
 
-const T = Type.Object({
-  x: Type.Number(),
-  y: Type.Number(),
-  z: Type.Number(),
-})
-
-type T = Static<typeof T>
-
-console.log(T)
-
-// -----------------------------------------------------------
-// Create: Value
-// -----------------------------------------------------------
-
-const V = Value.Create(T)
-
-console.log(V)
-
-// -----------------------------------------------------------
-// Compile: Type
-// -----------------------------------------------------------
-
-const C = TypeCompiler.Compile(T)
-
-console.log(C.Code())
-
-// -----------------------------------------------------------
-// Check: Value
-// -----------------------------------------------------------
-
-console.log(C.Check(V))
+// const L = Type.TemplateLiteral([Type.Literal('.*')])
+// const R = Type.Record(L, Type.String());
+// type L = Static<typeof L>
+// type R = Static<typeof R>
+// console.log(R);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.27.4",
+  "version": "0.27.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.27.4",
+      "version": "0.27.5",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.27.4",
+  "version": "0.27.5",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/test/runtime/type/guard/record.ts
+++ b/test/runtime/type/guard/record.ts
@@ -1,4 +1,4 @@
-import { TypeGuard, PatternNumberExact, PatternStringExact, PatternNumber } from '@sinclair/typebox'
+import { TypeGuard, PatternNumberExact, PatternStringExact, PatternString, PatternNumber } from '@sinclair/typebox'
 import { Type } from '@sinclair/typebox'
 import { Assert } from '../../assert/index'
 
@@ -55,6 +55,13 @@ describe('type/guard/TRecord', () => {
     Assert.equal(TypeGuard.TString(T.patternProperties[PatternStringExact]), true)
     Assert.equal(T.extra, 1)
   })
+  it('Should guard overload 9', () => {
+    const L = Type.TemplateLiteral([Type.String(), Type.Literal('_foo')])
+    const T = Type.Record(L, Type.String(), { extra: 1 })
+    Assert.equal(TypeGuard.TRecord(T), true)
+    Assert.equal(TypeGuard.TString(T.patternProperties[`^${PatternString}_foo$`]), true)
+    Assert.equal(T.extra, 1)
+  })
   // -------------------------------------------------------------
   // Variants
   // -------------------------------------------------------------
@@ -62,7 +69,6 @@ describe('type/guard/TRecord', () => {
     const R = TypeGuard.TRecord(Type.Record(Type.String(), Type.Number()))
     Assert.equal(R, true)
   })
-
   it('Should guard for TRecord with TObject value', () => {
     const R = TypeGuard.TRecord(
       Type.Record(
@@ -75,18 +81,15 @@ describe('type/guard/TRecord', () => {
     )
     Assert.equal(R, true)
   })
-
   it('Should not guard for TRecord', () => {
     const R = TypeGuard.TRecord(null)
     Assert.equal(R, false)
   })
-
   it('Should not guard for TRecord with invalid $id', () => {
     // @ts-ignore
     const R = TypeGuard.TRecord(Type.Record(Type.String(), Type.Number(), { $id: 1 }))
     Assert.equal(R, false)
   })
-
   it('Should not guard for TRecord with TObject value with invalid Property', () => {
     const R = TypeGuard.TRecord(
       Type.Record(
@@ -99,7 +102,6 @@ describe('type/guard/TRecord', () => {
     )
     Assert.equal(R, false)
   })
-
   it('Transform: Should should transform to TObject for single literal union value', () => {
     const K = Type.Union([Type.Literal('ok')])
     const R = TypeGuard.TObject(Type.Record(K, Type.Number()))

--- a/test/runtime/type/template/finite.ts
+++ b/test/runtime/type/template/finite.ts
@@ -25,6 +25,11 @@ describe('type/TemplateLiteralFinite', () => {
     const R = TemplateLiteralFinite.Check(E)
     Assert.deepEqual(R, true)
   })
+  it('Finite 5', () => {
+    const E = TemplateLiteralParser.Parse(`\\.\\*`)
+    const R = TemplateLiteralFinite.Check(E)
+    Assert.deepEqual(R, true)
+  })
   // ---------------------------------------------------------------
   // Infinite
   // ---------------------------------------------------------------
@@ -55,6 +60,11 @@ describe('type/TemplateLiteralFinite', () => {
   })
   it('Infinite 6', () => {
     const E = TemplateLiteralParser.Parse(`A(${PatternNumber})`)
+    const R = TemplateLiteralFinite.Check(E)
+    Assert.deepEqual(R, false)
+  })
+  it('Infinite 7', () => {
+    const E = TemplateLiteralParser.Parse(`${PatternString}_foo`)
     const R = TemplateLiteralFinite.Check(E)
     Assert.deepEqual(R, false)
   })

--- a/test/runtime/type/template/generate.ts
+++ b/test/runtime/type/template/generate.ts
@@ -44,12 +44,12 @@ describe('type/TemplateLiteralGenerator', () => {
   it('Expression 2', () => {
     const E = TemplateLiteralParser.Parse('\\)')
     const R = [...TemplateLiteralGenerator.Generate(E)]
-    Assert.deepEqual(R, [')'])
+    Assert.deepEqual(R, ['\\)'])
   })
   it('Expression 3', () => {
     const E = TemplateLiteralParser.Parse('\\(')
     const R = [...TemplateLiteralGenerator.Generate(E)]
-    Assert.deepEqual(R, ['('])
+    Assert.deepEqual(R, ['\\('])
   })
   it('Expression 4', () => {
     const E = TemplateLiteralParser.Parse('')
@@ -59,7 +59,7 @@ describe('type/TemplateLiteralGenerator', () => {
   it('Expression 5', () => {
     const E = TemplateLiteralParser.Parse('\\')
     const R = [...TemplateLiteralGenerator.Generate(E)]
-    Assert.deepEqual(R, [''])
+    Assert.deepEqual(R, ['\\'])
   })
   it('Expression 6', () => {
     const E = TemplateLiteralParser.Parse('()')

--- a/test/runtime/type/template/parser.ts
+++ b/test/runtime/type/template/parser.ts
@@ -84,14 +84,14 @@ describe('type/TemplateLiteralParser', () => {
     const E = TemplateLiteralParser.Parse('\\)')
     Assert.deepEqual(E, {
       type: 'const',
-      const: ')',
+      const: '\\)',
     })
   })
   it('Expression 3', () => {
     const E = TemplateLiteralParser.Parse('\\(')
     Assert.deepEqual(E, {
       type: 'const',
-      const: '(',
+      const: '\\(',
     })
   })
   it('Expression 4', () => {
@@ -105,7 +105,7 @@ describe('type/TemplateLiteralParser', () => {
     const E = TemplateLiteralParser.Parse('\\')
     Assert.deepEqual(E, {
       type: 'const',
-      const: '',
+      const: '\\',
     })
   })
   it('Expression 6', () => {

--- a/test/runtime/type/template/pattern.ts
+++ b/test/runtime/type/template/pattern.ts
@@ -7,6 +7,25 @@ describe('type/TemplateLiteralPattern', () => {
     Assert.equal(pattern, expect)
   }
   // ---------------------------------------------------------------
+  // Escape
+  // ---------------------------------------------------------------
+  it('Escape 1', () => {
+    const T = Type.TemplateLiteral([Type.Literal('.*')])
+    Assert.equal(T.pattern, '^\\.\\*$')
+  })
+  it('Escape 2', () => {
+    const T = Type.TemplateLiteral([Type.Literal('(')])
+    Assert.equal(T.pattern, '^\\($')
+  })
+  it('Escape 3', () => {
+    const T = Type.TemplateLiteral([Type.Literal(')')])
+    Assert.equal(T.pattern, '^\\)$')
+  })
+  it('Escape 4', () => {
+    const T = Type.TemplateLiteral([Type.Literal('|')])
+    Assert.equal(T.pattern, '^\\|$')
+  })
+  // ---------------------------------------------------------------
   // Pattern
   // ---------------------------------------------------------------
   it('Pattern 1', () => {


### PR DESCRIPTION
This PR implements more robust finite checks for pattern expressions. It also removes automatic pattern unescape during parsing. This is required to enable finite checks to distinguish between `.*` patterns passed for literals. 

This PR also adds type inference for record keys.