### PR TITLE
Recursive Utility Types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.27.6",
+  "version": "0.27.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.27.6",
+      "version": "0.27.7",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.27.6",
+  "version": "0.27.7",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/test/static/recursive.ts
+++ b/test/static/recursive.ts
@@ -2,14 +2,79 @@ import { Expect } from './assert'
 import { Type, Static } from '@sinclair/typebox'
 
 {
-  const T = Type.Recursive((Node) =>
+  // identity
+  const R = Type.Recursive((Node) =>
     Type.Object({
       id: Type.String(),
       nodes: Type.Array(Node),
     }),
   )
-
-  type T = Static<typeof T>
-
-  Expect(T).ToInfer<T>() // ? how to test....
+  type T = Static<typeof R>
+  Expect(R).ToInfer<{ id: string; nodes: T[] }>()
+}
+{
+  // keyof
+  const R = Type.Recursive((Node) =>
+    Type.Object({
+      id: Type.String(),
+      nodes: Type.Array(Node),
+    }),
+  )
+  const T = Type.KeyOf(R)
+  Expect(T).ToInfer<'id' | 'nodes'>()
+}
+{
+  // partial
+  const R = Type.Recursive((Node) =>
+    Type.Object({
+      id: Type.String(),
+      nodes: Type.Array(Node),
+    }),
+  )
+  const T = Type.Partial(R)
+  Expect(T).ToInfer<{
+    id: string | undefined
+    nodes: Static<typeof T>[] | undefined
+  }>()
+}
+{
+  // required
+  const R = Type.Recursive((Node) =>
+    Type.Object({
+      id: Type.String(),
+      nodes: Type.Array(Node),
+    }),
+  )
+  const P = Type.Partial(R)
+  const T = Type.Required(P)
+  Expect(T).ToInfer<{
+    id: string
+    nodes: Static<typeof T>[]
+  }>()
+}
+{
+  // pick
+  const R = Type.Recursive((Node) =>
+    Type.Object({
+      id: Type.String(),
+      nodes: Type.Array(Node),
+    }),
+  )
+  const T = Type.Pick(R, ['id'])
+  Expect(T).ToInfer<{
+    id: string
+  }>()
+}
+{
+  // omit
+  const R = Type.Recursive((Node) =>
+    Type.Object({
+      id: Type.String(),
+      nodes: Type.Array(Node),
+    }),
+  )
+  const T = Type.Omit(R, ['id'])
+  Expect(T).ToInfer<{
+    nodes: Static<typeof T>[]
+  }>()
 }


### PR DESCRIPTION
This PR implements type mapping support for Recursive Pick, Omit, Required, Partial. These mappings were missed on 0.26.0. This update required an additional `[Hint]: 'Recursive` field on the recursive type. This helps the inference correctly narrow and extract the inner type during mapping.