### PR TITLE
Expression Variable Fix for Compiled Records

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -248,7 +248,6 @@ export namespace TypeCompiler {
     if (IsNumber(schema.minimum)) yield `${value} >= ${schema.minimum}`
     if (IsNumber(schema.maximum)) yield `${value} <= ${schema.maximum}`
   }
-
   function* Object(schema: Types.TObject, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield IsObjectCheck(value)
     if (IsNumber(schema.minProperties)) yield `Object.getOwnPropertyNames(${value}).length >= ${schema.minProperties}`
@@ -288,7 +287,7 @@ export namespace TypeCompiler {
     if (IsNumber(schema.maxProperties)) yield `Object.getOwnPropertyNames(${value}).length <= ${schema.maxProperties}`
     const [patternKey, patternSchema] = globalThis.Object.entries(schema.patternProperties)[0]
     const local = PushLocal(`new RegExp(/${patternKey}/)`)
-    const check1 = CreateExpression(patternSchema, references, value)
+    const check1 = CreateExpression(patternSchema, references, 'value')
     const check2 = Types.TypeGuard.TSchema(schema.additionalProperties) ? CreateExpression(schema.additionalProperties, references, value) : schema.additionalProperties === false ? 'false' : 'true'
     const expression = `(${local}.test(key) ? ${check1} : ${check2})`
     yield `(Object.entries(${value}).every(([key, value]) => ${expression}))`

--- a/test/runtime/compiler/record.ts
+++ b/test/runtime/compiler/record.ts
@@ -3,6 +3,23 @@ import { Ok, Fail } from './validate'
 
 describe('type/compiler/Record', () => {
   // -------------------------------------------------------------
+  // Issues
+  // -------------------------------------------------------------
+  it('Issue: https://github.com/sinclairzx81/typebox/issues/402', () => {
+    const T = Type.Object({
+      foo: Type.Object({
+        bar: Type.Record(Type.String(), Type.Number()),
+      }),
+    })
+    Ok(T, { foo: { bar: { x: 42 } } })
+    Ok(T, { foo: { bar: {} } })
+    Fail(T, { foo: { bar: { x: '42' } } })
+    Fail(T, { foo: { bar: [] } })
+    Fail(T, { foo: {} })
+    Fail(T, { foo: [] })
+    Fail(T, {})
+  })
+  // -------------------------------------------------------------
   // TypeBox Only: Date and Record
   // -------------------------------------------------------------
   it('Should fail record with Date', () => {


### PR DESCRIPTION
This PR applies a fix for sub pathed records. This was incorrectly using the top level variable, not the expression variable used to assert sub properties. 

Related: https://github.com/sinclairzx81/typebox/issues/402

