### PR TITLE
Revision 0.28.4

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,15 +1,9 @@
 import { TypeSystem } from '@sinclair/typebox/system'
 import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
-import { Type, TypeGuard, Kind, Static, TSchema } from '@sinclair/typebox'
+import { Type, UnionResolver, TypeGuard, Kind, Static, TNever, TSchema, TUnion } from '@sinclair/typebox'
 
-type S = { 0: number }
-type M = S['0']
+const U = Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])
+const X = Type.Record(U, Type.Number())
 
-const S = Type.Object({
-  0: Type.Number(),
-})
-
-type T = Static<typeof T>
-const T = Type.Index(S, Type.Literal('0'))
-console.log(T)
+console.log(X)

--- a/example/index.ts
+++ b/example/index.ts
@@ -3,38 +3,13 @@ import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
 import { Type, TypeGuard, Kind, Static, TSchema } from '@sinclair/typebox'
 
-// -----------------------------------------------------------
-// Create: Type
-// -----------------------------------------------------------
+type S = { 0: number }
+type M = S['0']
 
-const T = Type.Object({
-  x: Type.Number(),
-  y: Type.Number(),
-  z: Type.Number(),
+const S = Type.Object({
+  0: Type.Number(),
 })
 
 type T = Static<typeof T>
-
+const T = Type.Index(S, Type.Literal('0'))
 console.log(T)
-
-// -----------------------------------------------------------
-// Create: Value
-// -----------------------------------------------------------
-
-const V = Value.Create(T)
-
-console.log(V)
-
-// -----------------------------------------------------------
-// Compile: Type
-// -----------------------------------------------------------
-
-const C = TypeCompiler.Compile(T)
-
-console.log(C.Code())
-
-// -----------------------------------------------------------
-// Check: Value
-// -----------------------------------------------------------
-
-console.log(C.Check(V))

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,9 +1,40 @@
 import { TypeSystem } from '@sinclair/typebox/system'
 import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
-import { Type, UnionResolver, TypeGuard, Kind, Static, TNever, TSchema, TUnion } from '@sinclair/typebox'
+import { Type, TypeGuard, Kind, Static, TSchema } from '@sinclair/typebox'
 
-const U = Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])
-const X = Type.Record(U, Type.Number())
+// -----------------------------------------------------------
+// Create: Type
+// -----------------------------------------------------------
 
-console.log(X)
+const T = Type.Object({
+  x: Type.Number(),
+  y: Type.Number(),
+  z: Type.Number(),
+})
+
+type T = Static<typeof T>
+
+console.log(T)
+
+// -----------------------------------------------------------
+// Create: Value
+// -----------------------------------------------------------
+
+const V = Value.Create(T)
+
+console.log(V)
+
+// -----------------------------------------------------------
+// Compile: Type
+// -----------------------------------------------------------
+
+const C = TypeCompiler.Compile(T)
+
+console.log(C.Code())
+
+// -----------------------------------------------------------
+// Check: Value
+// -----------------------------------------------------------
+
+console.log(C.Check(V))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/readme.md
+++ b/readme.md
@@ -1476,11 +1476,11 @@ The following table lists esbuild compiled and minified sizes for each TypeBox m
 ┌──────────────────────┬────────────┬────────────┬─────────────┐
 │       (index)        │  Compiled  │  Minified  │ Compression │
 ├──────────────────────┼────────────┼────────────┼─────────────┤
-│ typebox/compiler     │ '126.7 kb' │ ' 56.6 kb' │  '2.24 x'   │
-│ typebox/errors       │ '110.4 kb' │ ' 48.8 kb' │  '2.26 x'   │
-│ typebox/system       │ ' 75.9 kb' │ ' 31.1 kb' │  '2.44 x'   │
-│ typebox/value        │ '176.4 kb' │ ' 76.4 kb' │  '2.31 x'   │
-│ typebox              │ ' 74.8 kb' │ ' 30.7 kb' │  '2.44 x'   │
+│ typebox/compiler     │ '127.1 kb' │ ' 56.7 kb' │  '2.24 x'   │
+│ typebox/errors       │ '110.9 kb' │ ' 48.9 kb' │  '2.27 x'   │
+│ typebox/system       │ ' 76.3 kb' │ ' 31.2 kb' │  '2.44 x'   │
+│ typebox/value        │ '176.8 kb' │ ' 76.5 kb' │  '2.31 x'   │
+│ typebox              │ ' 75.2 kb' │ ' 30.8 kb' │  '2.44 x'   │
 └──────────────────────┴────────────┴────────────┴─────────────┘
 ```
 

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -540,7 +540,7 @@ export interface TPromise<T extends TSchema = TSchema> extends TSchema {
 // --------------------------------------------------------------------------
 export type RecordTemplateLiteralObjectType<K extends TTemplateLiteral, T extends TSchema> = Ensure<TObject<Evaluate<{ [_ in Static<K>]: T }>>>
 export type RecordTemplateLiteralType<K extends TTemplateLiteral, T extends TSchema> = IsTemplateLiteralFinite<K> extends true ? RecordTemplateLiteralObjectType<K, T> : TRecord<K, T>
-export type RecordUnionLiteralType<K extends TUnion<TLiteral<string | number>[]>, T extends TSchema> = Static<K> extends string ? Ensure<TObject<{ [X in Static<K>]: T }>> : never
+export type RecordUnionLiteralType<K extends TUnion, T extends TSchema> = Static<K> extends string ? Ensure<TObject<{ [X in Static<K>]: T }>> : never
 export type RecordLiteralType<K extends TLiteral<string | number>, T extends TSchema> = Ensure<TObject<{ [K2 in K['const']]: T }>>
 export type RecordNumberType<K extends TInteger | TNumber, T extends TSchema> = Ensure<TRecord<K, T>>
 export type RecordStringType<K extends TString, T extends TSchema> = Ensure<TRecord<K, T>>
@@ -1045,9 +1045,9 @@ export namespace TypeGuard {
   export function TLiteralBoolean(schema: unknown): schema is TLiteral<boolean> {
     return TKind(schema) && schema[Kind] === 'Literal' && IsOptionalString(schema.$id) && typeof schema.const === 'boolean'
   }
-  /** Returns true if the given schema is TUnion<Literal<string>[]> */
-  export function TLiteralUnion(schema: unknown): schema is TUnion<TLiteral<string>[]> {
-    return TUnion(schema) && schema.anyOf.every((schema) => TLiteral(schema))
+  /** Returns true if the given schema is TUnion<Literal<string | number>[]> */
+  export function TLiteralUnion(schema: unknown): schema is TUnion<TLiteral[]> {
+    return TUnion(schema) && schema.anyOf.every((schema) => TLiteralString(schema) || TLiteralNumber(schema))
   }
   /** Returns true if the given schema is TLiteral */
   export function TLiteral(schema: unknown): schema is TLiteral {
@@ -2019,7 +2019,7 @@ export namespace KeyArrayResolver {
   /** Resolves an array of string[] keys from the given schema or array type. */
   export function Resolve(schema: TSchema | string[]): string[] {
     if (globalThis.Array.isArray(schema)) return schema
-    if (TypeGuard.TLiteralUnion(schema)) return schema.anyOf.map((schema) => schema.const)
+    if (TypeGuard.TLiteralUnion(schema)) return schema.anyOf.map((schema) => schema.const.toString())
     if (TypeGuard.TLiteral(schema)) return [schema.const as string]
     if (TypeGuard.TTemplateLiteral(schema)) {
       const expression = TemplateLiteralParser.ParseExact(schema.pattern)
@@ -2027,6 +2027,24 @@ export namespace KeyArrayResolver {
       return [...TemplateLiteralGenerator.Generate(expression)]
     }
     return []
+  }
+}
+// --------------------------------------------------------------------------
+// UnionResolver
+// --------------------------------------------------------------------------
+export namespace UnionResolver {
+  function* Union(union: TUnion): IterableIterator<TSchema> {
+    for (const schema of union.anyOf) {
+      if (schema[Kind] === 'Union') {
+        yield* Union(schema as TUnion)
+      } else {
+        yield schema
+      }
+    }
+  }
+  /** Returns a resolved union with interior unions flattened */
+  export function Resolve(union: TUnion): TUnion {
+    return Type.Union([...Union(union)], { ...union })
   }
 }
 // --------------------------------------------------------------------------
@@ -2559,7 +2577,7 @@ export class StandardTypeBuilder extends TypeBuilder {
     }, options)
   }
   /** `[Standard]` Creates a Record type */
-  public Record<K extends TUnion<TLiteral<string | number>[]>, T extends TSchema>(key: K, schema: T, options?: ObjectOptions): RecordUnionLiteralType<K, T>
+  public Record<K extends TUnion, T extends TSchema>(key: K, schema: T, options?: ObjectOptions): RecordUnionLiteralType<K, T>
   /** `[Standard]` Creates a Record type */
   public Record<K extends TLiteral<string | number>, T extends TSchema>(key: K, schema: T, options?: ObjectOptions): RecordLiteralType<K, T>
   /** `[Standard]` Creates a Record type */
@@ -2576,15 +2594,16 @@ export class StandardTypeBuilder extends TypeBuilder {
       return TemplateLiteralFinite.Check(expression)
         ? (this.Object([...TemplateLiteralGenerator.Generate(expression)].reduce((acc, key) => ({ ...acc, [key]: TypeClone.Clone(schema, {}) }), {} as TProperties), options))
         : this.Create<any>({ ...options, [Kind]: 'Record', type: 'object', patternProperties: { [key.pattern]: TypeClone.Clone(schema, {}) }})
-    } else if (TypeGuard.TLiteralUnion(key)) {
-      if (key.anyOf.every((schema) => TypeGuard.TLiteral(schema) && (typeof schema.const === 'string' || typeof schema.const === 'number'))) {
-        const properties = key.anyOf.reduce((acc: any, literal: any) => ({ ...acc, [literal.const]: TypeClone.Clone(schema, {}) }), {} as TProperties)
+    } else if (TypeGuard.TUnion(key)) {
+      const union = UnionResolver.Resolve(key)
+      if (TypeGuard.TLiteralUnion(union)) {
+        const properties = union.anyOf.reduce((acc: any, literal: any) => ({ ...acc, [literal.const]: TypeClone.Clone(schema, {}) }), {} as TProperties)
         return this.Object(properties, { ...options, [Hint]: 'Record' })
-      } else throw Error('TypeBuilder: Record key can only be derived from union literal of number or string')
+      } else throw Error('TypeBuilder: Record key of type union contains non-literal types')
     } else if (TypeGuard.TLiteral(key)) {
       if (typeof key.const === 'string' || typeof key.const === 'number') {
         return this.Object({ [key.const]: TypeClone.Clone(schema, {}) }, options)
-      } else throw Error('TypeBuilder: Record key can only be derived from literals of number or string')
+      } else throw Error('TypeBuilder: Record key of type literal is not of type string or number')
     } else if (TypeGuard.TInteger(key) || TypeGuard.TNumber(key)) {
       const pattern = PatternNumberExact
       return this.Create<any>({ ...options, [Kind]: 'Record', type: 'object', patternProperties: { [pattern]: TypeClone.Clone(schema, {}) } })
@@ -2592,7 +2611,7 @@ export class StandardTypeBuilder extends TypeBuilder {
       const pattern = key.pattern === undefined ? PatternStringExact : key.pattern
       return this.Create<any>({ ...options, [Kind]: 'Record', type: 'object', patternProperties: { [pattern]: TypeClone.Clone(schema, {}) } })
     } else {
-      throw Error(`StandardTypeBuilder: Invalid Record Key`)
+      throw Error(`StandardTypeBuilder: Record key is an invalid type`)
     }
   }
   /** `[Standard]` Creates a Recursive type */

--- a/test/runtime/type/guard/indexed.ts
+++ b/test/runtime/type/guard/indexed.ts
@@ -9,7 +9,7 @@ describe('type/guard/TIndex', () => {
       y: Type.String(),
     })
     const I = Type.Index(T, ['x'])
-    Assert.isEqual(TypeGuard.TNumber(I), true)
+    Assert.isTrue(TypeGuard.TNumber(I))
   })
   it('Should Index 2', () => {
     const T = Type.Object({
@@ -17,9 +17,9 @@ describe('type/guard/TIndex', () => {
       y: Type.String(),
     })
     const I = Type.Index(T, ['x', 'y'])
-    Assert.isEqual(TypeGuard.TUnion(I), true)
-    Assert.isEqual(TypeGuard.TNumber(I.anyOf[0]), true)
-    Assert.isEqual(TypeGuard.TString(I.anyOf[1]), true)
+    Assert.isTrue(TypeGuard.TUnion(I))
+    Assert.isTrue(TypeGuard.TNumber(I.anyOf[0]))
+    Assert.isTrue(TypeGuard.TString(I.anyOf[1]))
   })
   it('Should Index 3', () => {
     const T = Type.Object({
@@ -27,9 +27,9 @@ describe('type/guard/TIndex', () => {
       y: Type.String(),
     })
     const I = Type.Index(T, Type.KeyOf(T))
-    Assert.isEqual(TypeGuard.TUnion(I), true)
-    Assert.isEqual(TypeGuard.TNumber(I.anyOf[0]), true)
-    Assert.isEqual(TypeGuard.TString(I.anyOf[1]), true)
+    Assert.isTrue(TypeGuard.TUnion(I))
+    Assert.isTrue(TypeGuard.TNumber(I.anyOf[0]))
+    Assert.isTrue(TypeGuard.TString(I.anyOf[1]))
   })
   it('Should Index 4', () => {
     const T = Type.Object({
@@ -37,59 +37,59 @@ describe('type/guard/TIndex', () => {
       ac: Type.String(),
     })
     const I = Type.Index(T, Type.TemplateLiteral([Type.Literal('a'), Type.Union([Type.Literal('b'), Type.Literal('c')])]))
-    Assert.isEqual(TypeGuard.TUnion(I), true)
-    Assert.isEqual(TypeGuard.TNumber(I.anyOf[0]), true)
-    Assert.isEqual(TypeGuard.TString(I.anyOf[1]), true)
+    Assert.isTrue(TypeGuard.TUnion(I))
+    Assert.isTrue(TypeGuard.TNumber(I.anyOf[0]))
+    Assert.isTrue(TypeGuard.TString(I.anyOf[1]))
   })
   it('Should Index 5', () => {
     const T = Type.Intersect([Type.Object({ x: Type.Number() }), Type.Object({ y: Type.String() })])
     const I = Type.Index(T, ['x', 'y'])
-    Assert.isEqual(TypeGuard.TUnion(I), true)
-    Assert.isEqual(TypeGuard.TNumber(I.anyOf[0]), true)
-    Assert.isEqual(TypeGuard.TString(I.anyOf[1]), true)
+    Assert.isTrue(TypeGuard.TUnion(I))
+    Assert.isTrue(TypeGuard.TNumber(I.anyOf[0]))
+    Assert.isTrue(TypeGuard.TString(I.anyOf[1]))
   })
   it('Should Index 6', () => {
     const T = Type.Union([Type.Object({ x: Type.Number() }), Type.Object({ x: Type.String() })])
     const I = Type.Index(T, ['x'])
-    Assert.isEqual(TypeGuard.TUnion(I), true)
-    Assert.isEqual(TypeGuard.TNumber(I.anyOf[0]), true)
-    Assert.isEqual(TypeGuard.TString(I.anyOf[1]), true)
+    Assert.isTrue(TypeGuard.TUnion(I))
+    Assert.isTrue(TypeGuard.TNumber(I.anyOf[0]))
+    Assert.isTrue(TypeGuard.TString(I.anyOf[1]))
   })
   it('Should Index 7', () => {
     const T = Type.Array(Type.Null())
     const I = Type.Index(T, Type.Number())
-    Assert.isEqual(TypeGuard.TNull(I), true)
+    Assert.isTrue(TypeGuard.TNull(I))
   })
   it('Should Index 6', () => {
     const T = Type.Tuple([Type.Literal('hello'), Type.Literal('world')])
     const I = Type.Index(T, [0])
-    Assert.isEqual(TypeGuard.TLiteralString(I), true)
+    Assert.isTrue(TypeGuard.TLiteralString(I))
     Assert.isEqual(I.const, 'hello')
   })
   it('Should Index 8', () => {
     const T = Type.Tuple([Type.Literal('hello'), Type.Literal('world')])
     const I = Type.Index(T, [1])
-    Assert.isEqual(TypeGuard.TLiteralString(I), true)
+    Assert.isTrue(TypeGuard.TLiteralString(I))
     Assert.isEqual(I.const, 'world')
   })
   it('Should Index 9', () => {
     const T = Type.Tuple([Type.Literal('hello'), Type.Literal('world')])
     const I = Type.Index(T, [0, 1])
-    Assert.isEqual(TypeGuard.TUnion(I), true)
+    Assert.isTrue(TypeGuard.TUnion(I))
     Assert.isEqual(I.anyOf[0].const, 'hello')
     Assert.isEqual(I.anyOf[1].const, 'world')
   })
   it('Should Index 10', () => {
     const T = Type.Tuple([Type.Literal('hello'), Type.Literal('world')])
     const I = Type.Index(T, [1, 0])
-    Assert.isEqual(TypeGuard.TUnion(I), true)
+    Assert.isTrue(TypeGuard.TUnion(I))
     Assert.isEqual(I.anyOf[0].const, 'world')
     Assert.isEqual(I.anyOf[1].const, 'hello')
   })
   it('Should Index 11', () => {
     const T = Type.Tuple([Type.Literal('hello'), Type.Literal('world')])
     const I = Type.Index(T, [0, 0, 0, 1])
-    Assert.isEqual(TypeGuard.TUnion(I), true)
+    Assert.isTrue(TypeGuard.TUnion(I))
     Assert.isEqual(I.anyOf[0].const, 'hello')
     Assert.isEqual(I.anyOf[1].const, 'hello')
     Assert.isEqual(I.anyOf[2].const, 'hello')
@@ -98,18 +98,57 @@ describe('type/guard/TIndex', () => {
   it('Should Index 12', () => {
     const T = Type.Tuple([Type.String(), Type.Boolean()])
     const I = Type.Index(T, Type.Number())
-    Assert.isEqual(TypeGuard.TUnion(I), true)
-    Assert.isEqual(TypeGuard.TString(I.anyOf[0]), true)
-    Assert.isEqual(TypeGuard.TBoolean(I.anyOf[1]), true)
+    Assert.isTrue(TypeGuard.TUnion(I))
+    Assert.isTrue(TypeGuard.TString(I.anyOf[0]))
+    Assert.isTrue(TypeGuard.TBoolean(I.anyOf[1]))
   })
   it('Should Index 13', () => {
     const T = Type.Tuple([Type.String()])
     const I = Type.Index(T, Type.Number())
-    Assert.isEqual(TypeGuard.TString(I), true)
+    Assert.isTrue(TypeGuard.TString(I))
   })
   it('Should Index 14', () => {
     const T = Type.Tuple([])
     const I = Type.Index(T, Type.Number())
-    Assert.isEqual(TypeGuard.TNever(I), true)
+    Assert.isTrue(TypeGuard.TNever(I))
+  })
+  it('Should Index 15', () => {
+    const T = Type.Object({
+      0: Type.Number(),
+    })
+    const I = Type.Index(T, Type.Literal(0))
+    Assert.isTrue(TypeGuard.TNumber(I))
+  })
+  it('Should Index 16', () => {
+    const T = Type.Object({
+      0: Type.Number(),
+    })
+    const I = Type.Index(T, Type.Literal('0'))
+    Assert.isTrue(TypeGuard.TNumber(I))
+  })
+  it('Should Index 17', () => {
+    const T = Type.Object({
+      '0': Type.Number(),
+    })
+    const I = Type.Index(T, Type.Literal(0))
+    Assert.isTrue(TypeGuard.TNumber(I))
+  })
+  it('Should Index 18', () => {
+    const T = Type.Object({
+      '0': Type.Number(),
+    })
+    const I = Type.Index(T, Type.Literal('0'))
+    Assert.isTrue(TypeGuard.TNumber(I))
+  })
+  it('Should Index 19', () => {
+    const T = Type.Object({
+      0: Type.Number(),
+      1: Type.String(),
+      2: Type.Boolean(),
+    })
+    const I = Type.Index(T, Type.Union([Type.Literal(0), Type.Literal(2)]))
+    Assert.isTrue(TypeGuard.TUnion(I))
+    Assert.isTrue(TypeGuard.TNumber(I.anyOf[0]))
+    Assert.isTrue(TypeGuard.TBoolean(I.anyOf[1]))
   })
 })

--- a/test/runtime/type/guard/record.ts
+++ b/test/runtime/type/guard/record.ts
@@ -8,15 +8,15 @@ describe('type/guard/TRecord', () => {
   // -------------------------------------------------------------
   it('Should guard overload 1', () => {
     const T = Type.Record(Type.Union([Type.Literal('A'), Type.Literal('B')]), Type.String(), { extra: 1 })
-    Assert.isEqual(TypeGuard.TObject(T), true)
-    Assert.isEqual(TypeGuard.TString(T.properties.A), true)
-    Assert.isEqual(TypeGuard.TString(T.properties.B), true)
+    Assert.isTrue(TypeGuard.TObject(T))
+    Assert.isTrue(TypeGuard.TString(T.properties.A))
+    Assert.isTrue(TypeGuard.TString(T.properties.B))
     Assert.isEqual(T.extra, 1)
   })
   it('Should guard overload 2', () => {
     const T = Type.Record(Type.Union([Type.Literal('A')]), Type.String(), { extra: 1 }) // unwrap as literal
-    Assert.isEqual(TypeGuard.TObject(T), true)
-    Assert.isEqual(TypeGuard.TString(T.properties.A), true)
+    Assert.isTrue(TypeGuard.TObject(T))
+    Assert.isTrue(TypeGuard.TString(T.properties.A))
     Assert.isEqual(T.extra, 1)
   })
   it('Should guard overload 3', () => {
@@ -25,49 +25,57 @@ describe('type/guard/TRecord', () => {
   })
   it('Should guard overload 4', () => {
     const T = Type.Record(Type.Literal('A'), Type.String(), { extra: 1 })
-    Assert.isEqual(TypeGuard.TObject(T), true)
-    Assert.isEqual(TypeGuard.TString(T.properties.A), true)
+    Assert.isTrue(TypeGuard.TObject(T))
+    Assert.isTrue(TypeGuard.TString(T.properties.A))
     Assert.isEqual(T.extra, 1)
   })
   it('Should guard overload 5', () => {
     const L = Type.TemplateLiteral([Type.Literal('hello'), Type.Union([Type.Literal('A'), Type.Literal('B')])])
     const T = Type.Record(L, Type.String(), { extra: 1 })
-    Assert.isEqual(TypeGuard.TObject(T), true)
-    Assert.isEqual(TypeGuard.TString(T.properties.helloA), true)
-    Assert.isEqual(TypeGuard.TString(T.properties.helloB), true)
+    Assert.isTrue(TypeGuard.TObject(T))
+    Assert.isTrue(TypeGuard.TString(T.properties.helloA))
+    Assert.isTrue(TypeGuard.TString(T.properties.helloB))
     Assert.isEqual(T.extra, 1)
   })
   it('Should guard overload 6', () => {
     const T = Type.Record(Type.Number(), Type.String(), { extra: 1 })
-    Assert.isEqual(TypeGuard.TRecord(T), true)
-    Assert.isEqual(TypeGuard.TString(T.patternProperties[PatternNumberExact]), true)
+    Assert.isTrue(TypeGuard.TRecord(T))
+    Assert.isTrue(TypeGuard.TString(T.patternProperties[PatternNumberExact]))
     Assert.isEqual(T.extra, 1)
   })
   it('Should guard overload 7', () => {
     const T = Type.Record(Type.Integer(), Type.String(), { extra: 1 })
-    Assert.isEqual(TypeGuard.TRecord(T), true)
-    Assert.isEqual(TypeGuard.TString(T.patternProperties[PatternNumberExact]), true)
+    Assert.isTrue(TypeGuard.TRecord(T))
+    Assert.isTrue(TypeGuard.TString(T.patternProperties[PatternNumberExact]))
     Assert.isEqual(T.extra, 1)
   })
   it('Should guard overload 8', () => {
     const T = Type.Record(Type.String(), Type.String(), { extra: 1 })
-    Assert.isEqual(TypeGuard.TRecord(T), true)
-    Assert.isEqual(TypeGuard.TString(T.patternProperties[PatternStringExact]), true)
+    Assert.isTrue(TypeGuard.TRecord(T))
+    Assert.isTrue(TypeGuard.TString(T.patternProperties[PatternStringExact]))
     Assert.isEqual(T.extra, 1)
   })
   it('Should guard overload 9', () => {
     const L = Type.TemplateLiteral([Type.String(), Type.Literal('_foo')])
     const T = Type.Record(L, Type.String(), { extra: 1 })
-    Assert.isEqual(TypeGuard.TRecord(T), true)
-    Assert.isEqual(TypeGuard.TString(T.patternProperties[`^${PatternString}_foo$`]), true)
+    Assert.isTrue(TypeGuard.TRecord(T))
+    Assert.isTrue(TypeGuard.TString(T.patternProperties[`^${PatternString}_foo$`]))
     Assert.isEqual(T.extra, 1)
+  })
+  it('Should guard overload 10', () => {
+    const L = Type.Union([Type.Literal('A'), Type.Union([Type.Literal('B'), Type.Literal('C')])])
+    const T = Type.Record(L, Type.String())
+    Assert.isTrue(TypeGuard.TObject(T))
+    Assert.isTrue(TypeGuard.TString(T.properties.A))
+    Assert.isTrue(TypeGuard.TString(T.properties.B))
+    Assert.isTrue(TypeGuard.TString(T.properties.C))
   })
   // -------------------------------------------------------------
   // Variants
   // -------------------------------------------------------------
   it('Should guard for TRecord', () => {
     const R = TypeGuard.TRecord(Type.Record(Type.String(), Type.Number()))
-    Assert.isEqual(R, true)
+    Assert.isTrue(R)
   })
   it('Should guard for TRecord with TObject value', () => {
     const R = TypeGuard.TRecord(
@@ -79,16 +87,16 @@ describe('type/guard/TRecord', () => {
         }),
       ),
     )
-    Assert.isEqual(R, true)
+    Assert.isTrue(R)
   })
   it('Should not guard for TRecord', () => {
     const R = TypeGuard.TRecord(null)
-    Assert.isEqual(R, false)
+    Assert.isFalse(R)
   })
   it('Should not guard for TRecord with invalid $id', () => {
     // @ts-ignore
     const R = TypeGuard.TRecord(Type.Record(Type.String(), Type.Number(), { $id: 1 }))
-    Assert.isEqual(R, false)
+    Assert.isFalse(R)
   })
   it('Should not guard for TRecord with TObject value with invalid Property', () => {
     const R = TypeGuard.TRecord(
@@ -100,16 +108,16 @@ describe('type/guard/TRecord', () => {
         }),
       ),
     )
-    Assert.isEqual(R, false)
+    Assert.isFalse(R)
   })
   it('Transform: Should should transform to TObject for single literal union value', () => {
     const K = Type.Union([Type.Literal('ok')])
     const R = TypeGuard.TObject(Type.Record(K, Type.Number()))
-    Assert.isEqual(R, true)
+    Assert.isTrue(R)
   })
   it('Transform: Should should transform to TObject for multi literal union value', () => {
     const K = Type.Union([Type.Literal('A'), Type.Literal('B')])
     const R = TypeGuard.TObject(Type.Record(K, Type.Number()))
-    Assert.isEqual(R, true)
+    Assert.isTrue(R)
   })
 })


### PR DESCRIPTION
This PR includes minor enhancements for Record Keys of type literal union, and refined support for numeric Indexed Access Types.

### Record Union Literal Keys

This update includes union normalization for nested union structures. Previously record keys could only be derived from a linear union. This update includes union flattening to support the following implementation.

```typescript
const K = Type.Union([
  Type.Literal('A'),
  Type.Union([                          // <--- nested union
    Type.Literal('B'),
    Type.Literal('C'),
  ])
])

const R = Type.Record(K, Type.String()) // {
                                        //   type: 'object',
                                        //   properties: {
                                        //     A: { type: 'string', [Symbol(TypeBox.Kind)]: 'String' },
                                        //     B: { type: 'string', [Symbol(TypeBox.Kind)]: 'String' },
                                        //     C: { type: 'string', [Symbol(TypeBox.Kind)]: 'String' }
                                        //   },
                                        //   required: [ 'A', 'B', 'C' ],
                                        //   [Symbol(TypeBox.Hint)]: 'Record',
                                        //   [Symbol(TypeBox.Kind)]: 'Object'
                                        // }
```
### Numeric Indexing

This update fixes the inference behavior for numeric indexed keys and makes some refinements to key resolution to support both numeric and string indexing. These fixes are applied for TypeScript alignment and only relate to TLiteral key values only.

```typescript
// TypeScript

type T = { 0: string }

type I1 = T[0]                                // string                         

type I2 = T['0']                              // string

// TypeBox

const T = Type.Object({ 0: Type.String() })

const I1 = Type.Index(T, Type.Literal(0))     // TString - Fixed

const I2 = Type.Index(T, Type.Literal('0'))   // TString - Fixed
```
