### PR TITLE
Revision 0.28.5

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -3,10 +3,38 @@ import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
 import { Type, TypeGuard, Kind, Static, TSchema } from '@sinclair/typebox'
 
+// -----------------------------------------------------------
+// Create: Type
+// -----------------------------------------------------------
+
 const T = Type.Object({
-  0: Type.Number(),
-  1: Type.String()
+  x: Type.Number(),
+  y: Type.Number(),
+  z: Type.Number(),
 })
 
-const A = Type.Index(T, Type.Literal(1))
+type T = Static<typeof T>
 
+console.log(T)
+
+// -----------------------------------------------------------
+// Create: Value
+// -----------------------------------------------------------
+
+const V = Value.Create(T)
+
+console.log(V)
+
+// -----------------------------------------------------------
+// Compile: Type
+// -----------------------------------------------------------
+
+const C = TypeCompiler.Compile(T)
+
+console.log(C.Code())
+
+// -----------------------------------------------------------
+// Check: Value
+// -----------------------------------------------------------
+
+console.log(C.Check(V))

--- a/example/index.ts
+++ b/example/index.ts
@@ -3,38 +3,10 @@ import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
 import { Type, TypeGuard, Kind, Static, TSchema } from '@sinclair/typebox'
 
-// -----------------------------------------------------------
-// Create: Type
-// -----------------------------------------------------------
-
 const T = Type.Object({
-  x: Type.Number(),
-  y: Type.Number(),
-  z: Type.Number(),
+  0: Type.Number(),
+  1: Type.String()
 })
 
-type T = Static<typeof T>
+const A = Type.Index(T, Type.Literal(1))
 
-console.log(T)
-
-// -----------------------------------------------------------
-// Create: Value
-// -----------------------------------------------------------
-
-const V = Value.Create(T)
-
-console.log(V)
-
-// -----------------------------------------------------------
-// Compile: Type
-// -----------------------------------------------------------
-
-const C = TypeCompiler.Compile(T)
-
-console.log(C.Code())
-
-// -----------------------------------------------------------
-// Check: Value
-// -----------------------------------------------------------
-
-console.log(C.Check(V))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -348,7 +348,9 @@ export type TIndexFromKeyTuple<T extends TSchema, K extends Key[]> =
     TNever : 
   TNever
 // prettier-ignore
-export type TIndex<T extends TSchema, K extends TSchema> = 
+export type TIndex<T extends TSchema, K extends TSchema> =
+  [T, K] extends [TTuple, TNumber]  ? UnionType<Assert<T['items'], TSchema[]>> :  
+  [T, K] extends [TArray, TNumber]  ? AssertType<T['items']> :
   K extends TTemplateLiteral        ? TIndexFromKeyTuple<T, TTemplateLiteralKeyTuple<K>> :
   K extends TUnion<TLiteral<Key>[]> ? TIndexFromKeyTuple<T, TUnionLiteral<K>> :
   K extends TLiteral<Key>           ? TIndexFromKeyTuple<T, [K['const']]> :
@@ -2418,10 +2420,6 @@ export class StandardTypeBuilder extends TypeBuilder {
   }
   /** `[Standard]` Returns indexed property types for the given keys */
   public Index<T extends TSchema, K extends (keyof Static<T>)[]>(schema: T, keys: [...K], options?: SchemaOptions): TIndexFromKeyTuple<T, Assert<K, Key[]>>
-  /** `[Standard]` Returns indexed property types for the given keys */
-  public Index<T extends TTuple, K extends TNumber>(schema: T, key: K, options?: SchemaOptions): UnionType<Assert<T['items'], TSchema[]>>
-  /** `[Standard]` Returns indexed property types for the given keys */
-  public Index<T extends TArray, K extends TNumber>(schema: T, key: K, options?: SchemaOptions): AssertType<T['items']>
   /** `[Standard]` Returns indexed property types for the given keys */
   public Index<T extends TSchema, K extends TSchema>(schema: T, key: K, options?: SchemaOptions): TIndex<T, K>
   /** `[Standard]` Returns indexed property types for the given keys */

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -697,13 +697,11 @@ export interface TTemplateLiteral<T extends TTemplateLiteralKind[] = TTemplateLi
 // --------------------------------------------------------------------------
 export type TTupleIntoArray<T extends TTuple<TSchema[]>> = T extends TTuple<infer R> ? AssertRest<R> : never
 
-export type TTupleInfer<T extends TSchema[], P extends unknown[]> = 
-  T extends [infer L, ...infer R] ? [Static<AssertType<L>, P>, ...TTupleInfer<AssertRest<R>, P>] 
-  : []
+export type TTupleInfer<T extends TSchema[], P extends unknown[]> = T extends [infer L, ...infer R] ? [Static<AssertType<L>, P>, ...TTupleInfer<AssertRest<R>, P>] : []
 
 export interface TTuple<T extends TSchema[] = TSchema[]> extends TSchema {
   [Kind]: 'Tuple'
-  static: TTupleInfer<T, this['params']>// { [K in keyof T]: T[K] extends TSchema ? Static<T[K], this['params']> : T[K] }
+  static: TTupleInfer<T, this['params']> // { [K in keyof T]: T[K] extends TSchema ? Static<T[K], this['params']> : T[K] }
   type: 'array'
   items?: T
   additionalItems?: false
@@ -2419,13 +2417,13 @@ export class StandardTypeBuilder extends TypeBuilder {
     }
   }
   /** `[Standard]` Returns indexed property types for the given keys */
+  public Index<T extends TSchema, K extends (keyof Static<T>)[]>(schema: T, keys: [...K], options?: SchemaOptions): TIndexFromKeyTuple<T, Assert<K, Key[]>>
+  /** `[Standard]` Returns indexed property types for the given keys */
   public Index<T extends TTuple, K extends TNumber>(schema: T, key: K, options?: SchemaOptions): UnionType<Assert<T['items'], TSchema[]>>
   /** `[Standard]` Returns indexed property types for the given keys */
   public Index<T extends TArray, K extends TNumber>(schema: T, key: K, options?: SchemaOptions): AssertType<T['items']>
   /** `[Standard]` Returns indexed property types for the given keys */
   public Index<T extends TSchema, K extends TSchema>(schema: T, key: K, options?: SchemaOptions): TIndex<T, K>
-  /** `[Standard]` Returns indexed property types for the given keys */
-  public Index<T extends TSchema, K extends (keyof Static<T>)[]>(schema: T, keys: [...K], options?: SchemaOptions): TIndexFromKeyTuple<T, Assert<K, Key[]>>
   /** `[Standard]` Returns indexed property types for the given keys */
   public Index(schema: TSchema, unresolved: any, options: SchemaOptions = {}): any {
     const keys = KeyArrayResolver.Resolve(unresolved)

--- a/test/runtime/type/guard/indexed.ts
+++ b/test/runtime/type/guard/indexed.ts
@@ -151,4 +151,22 @@ describe('type/guard/TIndex', () => {
     Assert.isTrue(TypeGuard.TNumber(I.anyOf[0]))
     Assert.isTrue(TypeGuard.TBoolean(I.anyOf[1]))
   })
+  it('Should Index 20', () => {
+    const T = Type.Object({
+      0: Type.Number(),
+      1: Type.String(),
+      2: Type.Boolean(),
+    })
+    const I = Type.Index(T, Type.BigInt())
+    Assert.isTrue(TypeGuard.TNever(I))
+  })
+  it('Should Index 21', () => {
+    const T = Type.Object({
+      0: Type.Number(),
+      1: Type.String(),
+      2: Type.Boolean(),
+    })
+    const I = Type.Index(T, Type.Object({}))
+    Assert.isTrue(TypeGuard.TNever(I))
+  })
 })

--- a/test/static/indexed.ts
+++ b/test/static/indexed.ts
@@ -48,3 +48,17 @@ import { Type, Static } from '@sinclair/typebox'
 
   Expect(R).ToInfer<never>()
 }
+{
+  const A = Type.Object({})
+
+  const R = Type.Index(A, Type.BigInt()) // Support Overload
+
+  Expect(R).ToInfer<never>()
+}
+{
+  const A = Type.Array(Type.Number())
+
+  const R = Type.Index(A, Type.BigInt()) // Support Overload
+
+  Expect(R).ToInfer<never>()
+}


### PR DESCRIPTION
This is a minor revision to support generalized Indexed Access keys of type TSchema

```typescript
const T = Type.Tuple([Type.Number(), Type.String()])

const I0 = Type.Index(T, Type.Literal(0)) // TNumber

const I1 = Type.Index(T, Type.Literal(1)) // TString

const I2 = Type.Index(T, Type.Number())   // TUnion<[TString | TNumber]>

const I3 = Type.Index(T, Type.BigInt())   // TNever (Overload for TSchema fallthrough)

const I4 = Type.Index(T, Type.Object({})) // TNever (Overload for TSchema fallthrough)
```
Cases `T3` and `T4` are accepted as they extend `TSchema`. 

### Generic Types

This enables key indexing when used in generic types.

```typescript
export const ExteriorIndex = <T extends TSchema, K extends TSchema>(t: T, k: K) => Type.Index(t, k)  

const T = Type.Tuple([Type.Number(), Type.String()])

const I0 = ExteriorIndex(T, Type.Literal(0)) // TNumber

const I1 = ExteriorIndex(T, Type.Literal(1)) // TString

const I2 = ExteriorIndex(T, Type.Number())   // TUnion<[TString | TNumber]>
```