### PR TITLE
Numeric Indexed Keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.6",
+  "version": "0.28.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.28.6",
+      "version": "0.28.7",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.6",
+  "version": "0.28.7",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -369,7 +369,7 @@ export interface TIntersect<T extends TSchema[] = TSchema[]> extends TSchema, In
 // --------------------------------------------------------------------------
 // prettier-ignore
 export type TKeyOfProperties<T extends TSchema> = Static<T> extends infer S
-  ? UnionToTuple<{[K in keyof S]: TLiteral<`${Assert<K, TLiteralValue>}`>}[keyof S]>
+  ? UnionToTuple<{[K in keyof S]: TLiteral<Assert<K, TLiteralValue>>}[keyof S]>
   : []
 // prettier-ignore
 export type TKeyOfIndicesArray<T extends TSchema[]> = UnionToTuple<keyof T & `${number}`>

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -1943,7 +1943,8 @@ export namespace IndexedAccessor {
     return Type.Never()
   }
   export function Resolve(schema: TSchema, keys: Key[], options: SchemaOptions = {}): TSchema {
-    return Type.Union(keys.map((key) => Visit(schema, key.toString())))
+    // prettier-ignore
+    return Type.Union(keys.map((key) => Visit(schema, key.toString())), options)
   }
 }
 // --------------------------------------------------------------------------

--- a/test/runtime/type/guard/indexed.ts
+++ b/test/runtime/type/guard/indexed.ts
@@ -233,4 +233,48 @@ describe('type/guard/TIndex', () => {
     Assert.isTrue(TypeGuard.TNumber(I.anyOf[1]))
     Assert.isTrue(TypeGuard.TThis(I.anyOf[2]))
   })
+  it('Should Index 27', () => {
+    const T = Type.Object({
+      0: Type.String(),
+      1: Type.Number(),
+    })
+    const I = Type.Index(T, [0, 1])
+    Assert.isTrue(TypeGuard.TUnion(I))
+    Assert.isTrue(TypeGuard.TString(I.anyOf[0]))
+    Assert.isTrue(TypeGuard.TNumber(I.anyOf[1]))
+  })
+  it('Should Index 28', () => {
+    const T = Type.Object({
+      0: Type.String(),
+      '1': Type.Number(),
+    })
+    const I = Type.Index(T, [0, '1'])
+    Assert.isTrue(TypeGuard.TUnion(I))
+    Assert.isTrue(TypeGuard.TString(I.anyOf[0]))
+    Assert.isTrue(TypeGuard.TNumber(I.anyOf[1]))
+  })
+  it('Should Index 29', () => {
+    const T = Type.Object({
+      0: Type.String(),
+      '1': Type.Number(),
+    })
+    const I = Type.Index(T, Type.Union([Type.Literal(0), Type.Literal('1')]))
+    Assert.isTrue(TypeGuard.TUnion(I))
+    Assert.isTrue(TypeGuard.TString(I.anyOf[0]))
+    Assert.isTrue(TypeGuard.TNumber(I.anyOf[1]))
+  })
+  it('Should Index 30', () => {
+    const T = Type.Object({
+      0: Type.String(),
+      '1': Type.Number(),
+    })
+    const I = Type.Index(T, Type.Union([Type.Literal(0), Type.Literal(1)]))
+    Assert.isTrue(TypeGuard.TUnion(I))
+    Assert.isTrue(TypeGuard.TString(I.anyOf[0]))
+    Assert.isTrue(TypeGuard.TNumber(I.anyOf[1]))
+    // Note: Expect TNever for anyOf[1] but permit for TNumber due to IndexedAccess
+    // Resolve() which currently cannot differentiate between string and numeric keys
+    // on the object. This may be resolvable in later revisions, but test for this
+    // fall-through to ensure case is documented. For review.
+  })
 })

--- a/test/static/indexed.ts
+++ b/test/static/indexed.ts
@@ -6,60 +6,60 @@ import { Type, Static } from '@sinclair/typebox'
     x: Type.Number(),
     y: Type.String(),
   })
-  const I = Type.Index(T, ['x', 'y'])
-  Expect(I).ToInfer<number | string>()
+  const R = Type.Index(T, ['x', 'y'])
+  type O = Static<typeof R>
+  Expect(R).ToInfer<number | string>()
 }
 {
   const T = Type.Tuple([Type.Number(), Type.String(), Type.Boolean()])
-  const I = Type.Index(T, Type.Union([Type.Literal('0'), Type.Literal('1')]))
-  Expect(I).ToInfer<number | string>()
+  const R = Type.Index(T, Type.Union([Type.Literal('0'), Type.Literal('1')]))
+  type O = Static<typeof R>
+  Expect(R).ToInfer<number | string>()
 }
 {
   const T = Type.Tuple([Type.Number(), Type.String(), Type.Boolean()])
-  const I = Type.Index(T, Type.Union([Type.Literal(0), Type.Literal(1)]))
-  Expect(I).ToInfer<number | string>()
+  const R = Type.Index(T, Type.Union([Type.Literal(0), Type.Literal(1)]))
+  type O = Static<typeof R>
+  Expect(R).ToInfer<number | string>()
 }
 {
   const T = Type.Object({
     ab: Type.Number(),
     ac: Type.String(),
   })
-  const I = Type.Index(T, Type.TemplateLiteral([Type.Literal('a'), Type.Union([Type.Literal('b'), Type.Literal('c')])]))
-  Expect(I).ToInfer<number | string>()
+
+  const R = Type.Index(T, Type.TemplateLiteral([Type.Literal('a'), Type.Union([Type.Literal('b'), Type.Literal('c')])]))
+  type O = Static<typeof R>
+  Expect(R).ToInfer<number | string>()
 }
 {
   const A = Type.Tuple([Type.String(), Type.Boolean()])
-
   const R = Type.Index(A, Type.Number())
-
+  type O = Static<typeof R>
   Expect(R).ToInfer<string | boolean>()
 }
 {
   const A = Type.Tuple([Type.String()])
-
   const R = Type.Index(A, Type.Number())
-
+  type O = Static<typeof R>
   Expect(R).ToInfer<string>()
 }
 {
   const A = Type.Tuple([])
-
   const R = Type.Index(A, Type.Number())
-
+  type O = Static<typeof R>
   Expect(R).ToInfer<never>()
 }
 {
   const A = Type.Object({})
-
   const R = Type.Index(A, Type.BigInt()) // Support Overload
-
+  type O = Static<typeof R>
   Expect(R).ToInfer<never>()
 }
 {
   const A = Type.Array(Type.Number())
-
   const R = Type.Index(A, Type.BigInt()) // Support Overload
-
+  type O = Static<typeof R>
   Expect(R).ToInfer<never>()
 }
 // ------------------------------------------------------------------
@@ -75,6 +75,7 @@ import { Type, Static } from '@sinclair/typebox'
   const B = Type.Object({ x: Type.String(), y: Type.Number() })
   const C = Type.Intersect([A, B])
   const R = Type.Index(C, ['y'])
+  type O = Static<typeof R>
   Expect(R).ToBe<1>()
 }
 {
@@ -87,6 +88,7 @@ import { Type, Static } from '@sinclair/typebox'
   const B = Type.Object({ x: Type.String(), y: Type.Number() })
   const C = Type.Intersect([A, B])
   const R = Type.Index(C, ['x'])
+  type O = Static<typeof R>
   Expect(R).ToBe<string>()
 }
 {
@@ -99,6 +101,7 @@ import { Type, Static } from '@sinclair/typebox'
   const B = Type.Object({ x: Type.String(), y: Type.Number() })
   const C = Type.Intersect([A, B])
   const R = Type.Index(C, ['x', 'y'])
+  type O = Static<typeof R>
   Expect(R).ToBe<string | 1>()
 }
 {
@@ -111,6 +114,7 @@ import { Type, Static } from '@sinclair/typebox'
   const B = Type.Object({ x: Type.Number(), y: Type.Number() })
   const C = Type.Intersect([A, B])
   const R = Type.Index(C, ['x'])
+  type O = Static<typeof R>
   Expect(R).ToBe<never>()
 }
 {
@@ -123,6 +127,7 @@ import { Type, Static } from '@sinclair/typebox'
   const B = Type.Object({ x: Type.Number(), y: Type.Number() })
   const C = Type.Intersect([A, B])
   const R = Type.Index(C, ['y'])
+  type O = Static<typeof R>
   Expect(R).ToBe<number>()
 }
 {
@@ -135,6 +140,7 @@ import { Type, Static } from '@sinclair/typebox'
   const B = Type.Object({ x: Type.Number(), y: Type.Number() })
   const C = Type.Intersect([A, B])
   const R = Type.Index(C, ['x', 'y'])
+  type O = Static<typeof R>
   Expect(R).ToBe<number>()
 }
 {
@@ -220,6 +226,27 @@ import { Type, Static } from '@sinclair/typebox'
     }),
   )
   const R = Type.Index(I, ['x', 'y', 'z']) // z unresolvable
+  type O = Static<typeof R>
+  Expect(R).ToBe<string | number>()
+}
+// ------------------------------------------------
+// Numeric | String Variants
+// ------------------------------------------------
+{
+  const T = Type.Object({
+    0: Type.Number(),
+    '1': Type.String(),
+  })
+  const R = Type.Index(T, [0, '1'])
+  type O = Static<typeof R>
+  Expect(R).ToBe<string | number>()
+}
+{
+  const T = Type.Object({
+    0: Type.Number(),
+    '1': Type.String(),
+  })
+  const R = Type.Index(T, Type.KeyOf(T))
   type O = Static<typeof R>
   Expect(R).ToBe<string | number>()
 }


### PR DESCRIPTION
This PR implements additional mapping for `Type.Index()` to better align for numeric object keys. 

This to support the following case.

```typescript
const T = Type.Object({
  0: Type.Number(),
  '1': Type.String()
})

const T = Type.Index(T, [0, '1'])
```

Additional

Updated TRPC documentation to show schema references inline with Ajv `RpcType`. These docs where amended during the course of `0.26.0` for the work done to support auto type deref, but as this functionality was removed due to complications, these docs also needed to be reverted. This PR re-adds the reference types.