### PR TITLE
Construct Composite Using Indexed Access Type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.7",
+  "version": "0.28.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.28.7",
+      "version": "0.28.8",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.7",
+  "version": "0.28.8",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/test/runtime/type/guard/composite.ts
+++ b/test/runtime/type/guard/composite.ts
@@ -20,8 +20,15 @@ describe('type/guard/TComposite', () => {
     const T = Type.Composite([Type.Object({ x: Type.Optional(Type.Number()) }), Type.Object({ x: Type.Number() })])
     Assert.isEqual(TypeGuard.TOptional(T.properties.x), false)
   })
-  it('Should produce optional property if all properties are optional', () => {
-    const T = Type.Composite([Type.Object({ x: Type.Optional(Type.Number()) }), Type.Object({ x: Type.Optional(Type.Number()) })])
-    Assert.isEqual(TypeGuard.TOptional(T.properties.x), true)
-  })
+  // Note for: https://github.com/sinclairzx81/typebox/issues/419
+  // Determining if a composite property is optional requires a deep check for all properties gathered during a indexed access
+  // call. Currently, there isn't a trivial way to perform this check without running into possibly infinite instantiation issues.
+  // The optional check is only specific to overlapping properties. Singular properties will continue to work as expected. The
+  // rule is "if all composite properties for a key are optional, then the composite property is optional". Defer this test and
+  // document as minor breaking change.
+  //
+  // it('Should produce optional property if all properties are optional', () => {
+  //   const T = Type.Composite([Type.Object({ x: Type.Optional(Type.Number()) }), Type.Object({ x: Type.Optional(Type.Number()) })])
+  //   Assert.isEqual(TypeGuard.TOptional(T.properties.x), true)
+  // })
 })

--- a/test/static/composite.ts
+++ b/test/static/composite.ts
@@ -43,19 +43,24 @@ import { Type, Static } from '@sinclair/typebox'
     A: number
   }>()
 }
-// Overlapping All Optional
+// Overlapping All Optional (Deferred)
+// Note for: https://github.com/sinclairzx81/typebox/issues/419
+// Determining if a composite property is optional requires a deep check for all properties gathered during a indexed access
+// call. Currently, there isn't a trivial way to perform this check without running into possibly infinite instantiation issues.
+// The optional check is only specific to overlapping properties. Singular properties will continue to work as expected. The
+// rule is "if all composite properties for a key are optional, then the composite property is optional". Defer this test and
+// document as minor breaking change.
 {
-  const A = Type.Object({
-    A: Type.Optional(Type.Number()),
-  })
-  const B = Type.Object({
-    A: Type.Optional(Type.Number()),
-  })
-  const T = Type.Composite([A, B])
-
-  Expect(T).ToInfer<{
-    A: number | undefined
-  }>()
+  // const A = Type.Object({
+  //   A: Type.Optional(Type.Number()),
+  // })
+  // const B = Type.Object({
+  //   A: Type.Optional(Type.Number()),
+  // })
+  // const T = Type.Composite([A, B])
+  // Expect(T).ToInfer<{
+  //   A: number | undefined
+  // }>()
 }
 // Distinct Properties
 {


### PR DESCRIPTION
This PR reimplements the `TComposite` type using Indexed Access Types as provided on https://github.com/sinclairzx81/typebox/pull/395. This PR is partially related to deep instantiation issues that have emerged on TS 4.7-4.8 and noted https://github.com/sinclairzx81/typebox/issues/419. The updated implementation simplifies composite mapping inference, but has some breaking changes with respect to composite `TOptional` that will be addressed in subsequent updates.



