### PR TITLE
DefaultAdditionalProperties policy

### DIFF
--- a/src/system/system.ts
+++ b/src/system/system.ts
@@ -52,6 +52,8 @@ export namespace TypeSystem {
   export let AllowNaN: boolean = false
   /** Sets whether `null` should validate for void types. The default is `false` */
   export let AllowVoidNull: boolean = false
+  /** Default value for `additionalProperties` on Object types */
+  export let DefaultAdditionalProperties: Types.TAdditionalProperties = undefined
   // ------------------------------------------------------------------------
   // String Formats and Types
   // ------------------------------------------------------------------------

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -29,6 +29,8 @@ THE SOFTWARE.
 // --------------------------------------------------------------------------
 // Symbols
 // --------------------------------------------------------------------------
+import { TypeSystem } from '@sinclair/typebox/system';
+
 export const Modifier = Symbol.for('TypeBox.Modifier')
 export const Hint = Symbol.for('TypeBox.Hint')
 export const Kind = Symbol.for('TypeBox.Kind')
@@ -2517,12 +2519,15 @@ export class StandardTypeBuilder extends TypeBuilder {
     const propertyKeys = globalThis.Object.getOwnPropertyNames(properties)
     const optionalKeys = propertyKeys.filter((key) => TypeGuard.TOptional(properties[key]) || TypeGuard.TReadonlyOptional(properties[key]))
     const requiredKeys = propertyKeys.filter((name) => !optionalKeys.includes(name))
-    const clonedAdditionalProperties = TypeGuard.TSchema(options.additionalProperties) ? { additionalProperties: TypeClone.Clone(options.additionalProperties, {}) } : {}
+
+    const additionalProperties = options.additionalProperties ?? TypeSystem.DefaultAdditionalProperties;
+
+    const clonedAdditionalProperties = TypeGuard.TSchema(options) ? { additionalProperties: TypeClone.Clone(options, {}) } : {}
     const clonedProperties = propertyKeys.reduce((acc, key) => ({ ...acc, [key]: TypeClone.Clone(properties[key], {}) }), {} as TProperties)
     if (requiredKeys.length > 0) {
-      return this.Create({ ...options, ...clonedAdditionalProperties, [Kind]: 'Object', type: 'object', properties: clonedProperties, required: requiredKeys })
+      return this.Create({ ...options, additionalProperties, ...clonedAdditionalProperties, [Kind]: 'Object', type: 'object', properties: clonedProperties, required: requiredKeys })
     } else {
-      return this.Create({ ...options, ...clonedAdditionalProperties, [Kind]: 'Object', type: 'object', properties: clonedProperties })
+      return this.Create({ ...options, additionalProperties, ...clonedAdditionalProperties, [Kind]: 'Object', type: 'object', properties: clonedProperties })
     }
   }
   /** `[Standard]` Creates a mapped type whose keys are omitted from the given type */

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -2520,14 +2520,17 @@ export class StandardTypeBuilder extends TypeBuilder {
     const optionalKeys = propertyKeys.filter((key) => TypeGuard.TOptional(properties[key]) || TypeGuard.TReadonlyOptional(properties[key]))
     const requiredKeys = propertyKeys.filter((name) => !optionalKeys.includes(name))
 
-    const additionalProperties = options.additionalProperties ?? TypeSystem.DefaultAdditionalProperties
+    let additionalProperties = options.additionalProperties ?? TypeSystem.DefaultAdditionalProperties
 
-    const clonedAdditionalProperties = TypeGuard.TSchema(additionalProperties) ? { additionalProperties: TypeClone.Clone(additionalProperties, {}) } : {}
+    if (TypeGuard.TSchema(additionalProperties)) {
+      additionalProperties = TypeClone.Clone(additionalProperties, {})
+    }
+
     const clonedProperties = propertyKeys.reduce((acc, key) => ({ ...acc, [key]: TypeClone.Clone(properties[key], {}) }), {} as TProperties)
     if (requiredKeys.length > 0) {
-      return this.Create({ ...options, additionalProperties, ...clonedAdditionalProperties, [Kind]: 'Object', type: 'object', properties: clonedProperties, required: requiredKeys })
+      return this.Create({ ...options, additionalProperties, [Kind]: 'Object', type: 'object', properties: clonedProperties, required: requiredKeys })
     } else {
-      return this.Create({ ...options, additionalProperties, ...clonedAdditionalProperties, [Kind]: 'Object', type: 'object', properties: clonedProperties })
+      return this.Create({ ...options, additionalProperties, [Kind]: 'Object', type: 'object', properties: clonedProperties })
     }
   }
   /** `[Standard]` Creates a mapped type whose keys are omitted from the given type */

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -25,11 +25,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
+import { TypeSystem } from '@sinclair/typebox/system'
 
 // --------------------------------------------------------------------------
 // Symbols
 // --------------------------------------------------------------------------
-import { TypeSystem } from '@sinclair/typebox/system'
 
 export const Modifier = Symbol.for('TypeBox.Modifier')
 export const Hint = Symbol.for('TypeBox.Hint')
@@ -2522,7 +2522,7 @@ export class StandardTypeBuilder extends TypeBuilder {
 
     const additionalProperties = options.additionalProperties ?? TypeSystem.DefaultAdditionalProperties
 
-    const clonedAdditionalProperties = TypeGuard.TSchema(options) ? { additionalProperties: TypeClone.Clone(options, {}) } : {}
+    const clonedAdditionalProperties = TypeGuard.TSchema(additionalProperties) ? { additionalProperties: TypeClone.Clone(additionalProperties, {}) } : {}
     const clonedProperties = propertyKeys.reduce((acc, key) => ({ ...acc, [key]: TypeClone.Clone(properties[key], {}) }), {} as TProperties)
     if (requiredKeys.length > 0) {
       return this.Create({ ...options, additionalProperties, ...clonedAdditionalProperties, [Kind]: 'Object', type: 'object', properties: clonedProperties, required: requiredKeys })

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -29,7 +29,7 @@ THE SOFTWARE.
 // --------------------------------------------------------------------------
 // Symbols
 // --------------------------------------------------------------------------
-import { TypeSystem } from '@sinclair/typebox/system';
+import { TypeSystem } from '@sinclair/typebox/system'
 
 export const Modifier = Symbol.for('TypeBox.Modifier')
 export const Hint = Symbol.for('TypeBox.Hint')
@@ -2520,7 +2520,7 @@ export class StandardTypeBuilder extends TypeBuilder {
     const optionalKeys = propertyKeys.filter((key) => TypeGuard.TOptional(properties[key]) || TypeGuard.TReadonlyOptional(properties[key]))
     const requiredKeys = propertyKeys.filter((name) => !optionalKeys.includes(name))
 
-    const additionalProperties = options.additionalProperties ?? TypeSystem.DefaultAdditionalProperties;
+    const additionalProperties = options.additionalProperties ?? TypeSystem.DefaultAdditionalProperties
 
     const clonedAdditionalProperties = TypeGuard.TSchema(options) ? { additionalProperties: TypeClone.Clone(options, {}) } : {}
     const clonedProperties = propertyKeys.reduce((acc, key) => ({ ...acc, [key]: TypeClone.Clone(properties[key], {}) }), {} as TProperties)


### PR DESCRIPTION
Changing the default behavior of setting "additionalProperties" to false makes it quite verbose if you want to strip additional properties everywhere (or add a new property that you want include on every schema)

Let me know what kind of coverage you need to get this merged
