### PR TITLE
Fix unevaluatedProperties and additionalProperties in nested schemas in TypeCompiler 

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -216,7 +216,7 @@ export namespace TypeCompiler {
       yield `${check1} && ${check2}`
     } else if (Types.TypeGuard.TSchema(schema.unevaluatedProperties)) {
       const keyCheck = PushLocal(`${new RegExp(Types.KeyResolver.ResolvePattern(schema))};`)
-      const check2 = `Object.getOwnPropertyNames(${value}).every(key => ${keyCheck}.test(key) || ${CreateExpression(schema.unevaluatedProperties, references, 'value[key]')})`
+      const check2 = `Object.getOwnPropertyNames(${value}).every(key => ${keyCheck}.test(key) || ${CreateExpression(schema.unevaluatedProperties, references, `${value}[key]`)})`
       yield `${check1} && ${check2}`
     } else {
       yield `${check1}`
@@ -273,7 +273,7 @@ export namespace TypeCompiler {
       }
     }
     if (typeof schema.additionalProperties === 'object') {
-      const expression = CreateExpression(schema.additionalProperties, references, 'value[key]')
+      const expression = CreateExpression(schema.additionalProperties, references, `${value}[key]`)
       const keys = `[${knownKeys.map((key) => `'${key}'`).join(', ')}]`
       yield `(Object.getOwnPropertyNames(${value}).every(key => ${keys}.includes(key) || ${expression}))`
     }

--- a/test/runtime/compiler/intersect.ts
+++ b/test/runtime/compiler/intersect.ts
@@ -54,6 +54,13 @@ describe('type/compiler/Intersect', () => {
     Ok(T, { x: 1, y: 2, z: 3 })
     Fail(T, { x: 1, y: 2, z: '1' })
   })
+  it('Should intersect two nested objects and allow unevaluated properties of number', () => {
+    const A = Type.Object({ x: Type.Number() })
+    const B = Type.Object({ y: Type.Number() })
+    const T = Type.Object({ nested: Type.Intersect([A, B], { unevaluatedProperties: Type.Number() }) })
+    Ok(T, { nested: { x: 1, y: 2, z: 3 } })
+    Fail(T, { nested: { x: 1, y: 2, z: '1' } })
+  })
   it('Should intersect two union objects with overlapping properties of the same type', () => {
     const A = Type.Union([Type.Object({ x: Type.Number() })])
     const B = Type.Union([Type.Object({ x: Type.Number() })])

--- a/test/runtime/compiler/object.ts
+++ b/test/runtime/compiler/object.ts
@@ -215,6 +215,91 @@ describe('type/compiler/Object', () => {
       z: 3,
     })
   })
+
+  it('Should validate nested schema additional properties of string', () => {
+    const T = Type.Object({
+      nested: Type.Object(
+        {
+          x: Type.Number(),
+          y: Type.Number(),
+        },
+        {
+          additionalProperties: Type.String(),
+        },
+      ),
+    })
+    Ok(T, {
+      nested: {
+        x: 1,
+        y: 2,
+        z: 'hello',
+      },
+    })
+    Fail(T, {
+      nested: {
+        x: 1,
+        y: 2,
+        z: 3,
+      },
+    })
+  })
+  it('Should validate nested schema additional properties of array', () => {
+    const T = Type.Object({
+      nested: Type.Object(
+        {
+          x: Type.Number(),
+          y: Type.Number(),
+        },
+        {
+          additionalProperties: Type.Array(Type.Number()),
+        },
+      ),
+    })
+    Ok(T, {
+      nested: {
+        x: 1,
+        y: 2,
+        z: [0, 1, 2],
+      },
+    })
+    Fail(T, {
+      nested: {
+        x: 1,
+        y: 2,
+        z: 3,
+      },
+    })
+  })
+  it('Should validate nested schema additional properties of object', () => {
+    const T = Type.Object({
+      nested: Type.Object(
+        {
+          x: Type.Number(),
+          y: Type.Number(),
+        },
+        {
+          additionalProperties: Type.Object({
+            z: Type.Number(),
+          }),
+        },
+      ),
+    })
+    Ok(T, {
+      nested: {
+        x: 1,
+        y: 2,
+        z: { z: 1 },
+      },
+    })
+    Fail(T, {
+      nested: {
+        x: 1,
+        y: 2,
+        z: 3,
+      },
+    })
+  })
+
   it('Should check for property key if property type is undefined', () => {
     const T = Type.Object({ x: Type.Undefined() })
     Ok(T, { x: undefined })


### PR DESCRIPTION
Currently the following schema:
```
Type.Object({nested: Type.Object({}, {additionalProperties: Type.String()})})
```
after being compiled using TypeCompiler fails to validate the following object:
```
{ nested: { foo: 'bar' }}
```
This is due to scoping bugs in the TypeCompiler. After reading the code of the compiler I also found the same bug with the unevaluatedProperties feature.