### PR TITLE
Support Enum Inference In Template Literal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.11",
+  "version": "0.28.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.28.11",
+      "version": "0.28.12",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",
@@ -18,7 +18,7 @@
         "chai": "^4.3.6",
         "mocha": "^9.2.2",
         "prettier": "^2.7.1",
-        "typescript": "^5.0.2"
+        "typescript": "^5.0.4"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
@@ -1410,9 +1410,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2442,9 +2442,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.11",
+  "version": "0.28.12",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",
@@ -42,6 +42,6 @@
     "chai": "^4.3.6",
     "mocha": "^9.2.2",
     "prettier": "^2.7.1",
-    "typescript": "^5.0.2"
+    "typescript": "^5.0.4"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1434,7 +1434,7 @@ TypeBox offers a small web based code generation tool that can be used to conver
 
 ## Ecosystem
 
-The following is a list of community packages that provide additional framework integration and tooling support for TypeBox.
+The following is a list of community packages that provide general tooling and framework support for TypeBox.
 
 | Package   |  Description |
 | ------------- | ------------- |

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -244,7 +244,7 @@ export interface TEnumOption<T> {
 export interface TEnum<T extends Record<string, string | number> = Record<string, string | number>> extends TSchema {
   [Kind]: 'Union'
   static: T[keyof T]
-  anyOf: TLiteral<string | number>[]
+  anyOf: TLiteral<T[keyof T]>[]
 }
 // --------------------------------------------------------------------------
 // TExtends

--- a/test/runtime/compiler/template-literal.ts
+++ b/test/runtime/compiler/template-literal.ts
@@ -183,4 +183,28 @@ describe('type/compiler/TemplateLiteral', () => {
     Ok(T, 'Adddd')
     Fail(T, 'X')
   })
+  it('Should validate enum (implicit)', () => {
+    enum E {
+      A,
+      B,
+      C,
+    }
+    const T = Type.TemplateLiteral([Type.Literal('hello'), Type.Enum(E)])
+    Ok(T, 'hello0')
+    Ok(T, 'hello1')
+    Ok(T, 'hello2')
+    Fail(T, 'hello3')
+  })
+  it('Should validate enum (explicit)', () => {
+    enum E {
+      A,
+      B = 'B',
+      C = 'C',
+    }
+    const T = Type.TemplateLiteral([Type.Literal('hello'), Type.Enum(E)])
+    Ok(T, 'hello0')
+    Ok(T, 'helloB')
+    Ok(T, 'helloC')
+    Fail(T, 'helloD')
+  })
 })

--- a/test/static/enum.ts
+++ b/test/static/enum.ts
@@ -1,12 +1,14 @@
 import { Expect } from './assert'
 import { Type, Static } from '@sinclair/typebox'
 
-enum E {
-  A,
-  B = 'hello',
-  C = 42,
+{
+  enum E {
+    A,
+    B = 'hello',
+    C = 42,
+  }
+
+  const T = Type.Enum(E)
+
+  Expect(T).ToBe<Static<typeof T>>() // ?
 }
-
-const T = Type.Enum(E)
-
-Expect(T).ToBe<Static<typeof T>>() // ?

--- a/test/static/template-literal.ts
+++ b/test/static/template-literal.ts
@@ -42,3 +42,31 @@ import { Type } from '@sinclair/typebox'
   const T = Type.TemplateLiteral([Type.Boolean()])
   Expect(T).ToInfer<`${boolean}`>()
 }
+{
+  // Enum Implicit
+  enum E {
+    A,
+    B,
+    C,
+  }
+  const A = Type.Enum(E)
+  const T = Type.TemplateLiteral([Type.Literal('hello'), A])
+  Expect(T).ToInfer<'hello0' | 'hello1' | 'hello2'>()
+}
+{
+  // Enum Explicit
+  enum E {
+    A,
+    B = 'B',
+    C = 'C',
+  }
+  const A = Type.Enum(E)
+  const T = Type.TemplateLiteral([Type.Literal('hello'), A])
+  Expect(T).ToInfer<'hello0' | 'helloB' | 'helloC'>()
+}
+{
+  // Enum Object Explicit
+  const A = Type.Enum(Object.freeze({ a: 'A', b: 'B' }))
+  const T = Type.TemplateLiteral([Type.Literal('hello'), A])
+  Expect(T).ToInfer<'helloA' | 'helloB'>()
+}


### PR DESCRIPTION
This PR updates the `TEnum` type to correctly infer keyed options of `enum`. Tests include both object literal and `enum` variants. These update resolve issue https://github.com/sinclairzx81/typebox/issues/444