### PR TITLE
Assert Array Constraints Before Elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.12",
+  "version": "0.28.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.28.12",
+      "version": "0.28.13",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.12",
+  "version": "0.28.13",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -171,10 +171,10 @@ export namespace TypeCompiler {
   }
   function* Array(schema: Types.TArray, references: Types.TSchema[], value: string): IterableIterator<string> {
     const expression = CreateExpression(schema.items, references, 'value')
-    yield `Array.isArray(${value}) && ${value}.every(value => ${expression})`
     if (IsNumber(schema.minItems)) yield `${value}.length >= ${schema.minItems}`
     if (IsNumber(schema.maxItems)) yield `${value}.length <= ${schema.maxItems}`
     if (schema.uniqueItems === true) yield `((function() { const set = new Set(); for(const element of ${value}) { const hashed = hash(element); if(set.has(hashed)) { return false } else { set.add(hashed) } } return true })())`
+    yield `Array.isArray(${value}) && ${value}.every(value => ${expression})`
   }
   function* BigInt(schema: Types.TBigInt, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof ${value} === 'bigint')`


### PR DESCRIPTION
This PR corrects the order in which array assertions occur. Specifically checking `minItems` and `maxItems` before checking elements. This was noted on issue https://github.com/sinclairzx81/typebox/issues/447

This update only applies to compiler emit (Value Check and Error generation was correctly ordered). No additional tests are required for this PR.