### PR TITLE
Array Assertion Order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.15",
+  "version": "0.28.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.28.15",
+      "version": "0.28.16",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.15",
+  "version": "0.28.16",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",


### PR DESCRIPTION
This PR implements a small reordering in array assertion, ensuring `Array.isArray(x)` before subsequent checks. Array iteration still still occurs post constraint checks.