### PR TITLE
TypeCompiler Multiple Language Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.16",
+  "version": "0.28.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.28.16",
+      "version": "0.28.17",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.16",
+  "version": "0.28.17",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -185,7 +185,8 @@ export namespace TypeCompiler {
     if (IsNumber(schema.maxItems)) yield `${value}.length <= ${schema.maxItems}`
     if (schema.uniqueItems === true) yield `((function() { const set = new Set(); for(const element of ${value}) { const hashed = hash(element); if(set.has(hashed)) { return false } else { set.add(hashed) } } return true })())`
     const expression = CreateExpression(schema.items, references, 'value')
-    yield `${value}.every(value => ${expression})`
+    const parameter = CreateParameter('value')
+    yield `${value}.every((${parameter}) => ${expression})`
   }
   function* BigInt(schema: Types.TBigInt, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof ${value} === 'bigint')`
@@ -196,7 +197,7 @@ export namespace TypeCompiler {
     if (IsBigInt(schema.maximum)) yield `${value} <= BigInt(${schema.maximum})`
   }
   function* Boolean(schema: Types.TBoolean, references: Types.TSchema[], value: string): IterableIterator<string> {
-    yield `typeof ${value} === 'boolean'`
+    yield `(typeof ${value} === 'boolean')`
   }
   function* Constructor(schema: Types.TConstructor, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield* Visit(schema.returns, references, `${value}.prototype`)
@@ -209,7 +210,7 @@ export namespace TypeCompiler {
     if (IsNumber(schema.maximumTimestamp)) yield `${value}.getTime() <= ${schema.maximumTimestamp}`
   }
   function* Function(schema: Types.TFunction, references: Types.TSchema[], value: string): IterableIterator<string> {
-    yield `typeof ${value} === 'function'`
+    yield `(typeof ${value} === 'function')`
   }
   function* Integer(schema: Types.TInteger, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof ${value} === 'number' && Number.isInteger(${value}))`
@@ -224,20 +225,20 @@ export namespace TypeCompiler {
     if (schema.unevaluatedProperties === false) {
       const keyCheck = PushLocal(`${new RegExp(Types.KeyResolver.ResolvePattern(schema))};`)
       const check2 = `Object.getOwnPropertyNames(${value}).every(key => ${keyCheck}.test(key))`
-      yield `${check1} && ${check2}`
+      yield `(${check1} && ${check2})`
     } else if (Types.TypeGuard.TSchema(schema.unevaluatedProperties)) {
       const keyCheck = PushLocal(`${new RegExp(Types.KeyResolver.ResolvePattern(schema))};`)
       const check2 = `Object.getOwnPropertyNames(${value}).every(key => ${keyCheck}.test(key) || ${CreateExpression(schema.unevaluatedProperties, references, `${value}[key]`)})`
-      yield `${check1} && ${check2}`
+      yield `(${check1} && ${check2})`
     } else {
-      yield `${check1}`
+      yield `(${check1})`
     }
   }
   function* Literal(schema: Types.TLiteral, references: Types.TSchema[], value: string): IterableIterator<string> {
     if (typeof schema.const === 'number' || typeof schema.const === 'boolean') {
-      yield `${value} === ${schema.const}`
+      yield `(${value} === ${schema.const})`
     } else {
-      yield `${value} === '${schema.const}'`
+      yield `(${value} === '${schema.const}')`
     }
   }
   function* Never(schema: Types.TNever, references: Types.TSchema[], value: string): IterableIterator<string> {
@@ -249,7 +250,7 @@ export namespace TypeCompiler {
     yield `!${left} && ${right}`
   }
   function* Null(schema: Types.TNull, references: Types.TSchema[], value: string): IterableIterator<string> {
-    yield `${value} === null`
+    yield `(${value} === null)`
   }
   function* Number(schema: Types.TNumber, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield IsNumberCheck(value)
@@ -310,7 +311,7 @@ export namespace TypeCompiler {
     // Reference: If we have seen this reference before we can just yield and
     // return the function call. If this isn't the case we defer to visit to
     // generate and set the function for subsequent passes.
-    if (state.function_names.has(schema.$ref)) return yield `${CreateFunctionName(schema.$ref)}(${value})`
+    if (state.functions.has(schema.$ref)) return yield `${CreateFunctionName(schema.$ref)}(${value})`
     yield* Visit(target, references, value)
   }
   function* String(schema: Types.TString, references: Types.TSchema[], value: string): IterableIterator<string> {
@@ -365,8 +366,8 @@ export namespace TypeCompiler {
     yield IsVoidCheck(value)
   }
   function* UserDefined(schema: Types.TSchema, references: Types.TSchema[], value: string): IterableIterator<string> {
-    const schema_key = `schema_key_${state.custom_types.size}`
-    state.custom_types.set(schema_key, schema)
+    const schema_key = `schema_key_${state.customs.size}`
+    state.customs.set(schema_key, schema)
     yield `custom('${schema[Types.Kind]}', '${schema_key}', ${value})`
   }
   function* Visit<T extends Types.TSchema>(schema: T, references: Types.TSchema[], value: string, root = false): IterableIterator<string> {
@@ -381,8 +382,8 @@ export namespace TypeCompiler {
     // by refactoring the logic below. Consider for review.
     if (IsString(schema.$id)) {
       const name = CreateFunctionName(schema.$id)
-      if (!state.function_names.has(schema.$id)) {
-        state.function_names.add(schema.$id)
+      if (!state.functions.has(schema.$id)) {
+        state.functions.add(schema.$id)
         const body = CreateFunction(name, schema, references, 'value')
         PushFunction(body)
       }
@@ -455,24 +456,25 @@ export namespace TypeCompiler {
   // -------------------------------------------------------------------
   // prettier-ignore
   const state = {
-    language: 'javascript',                   // target language
-    variables: new Set<string>(),             // local variables and functions
-    function_names: new Set<string>(),        // local function names used call ref validators
-    custom_types: new Map<string, unknown>(), // remote custom types used during compilation
+    language: 'javascript' as TypeCompilerOptions['language'], // target language
+    variables: new Set<string>(),                              // local variables
+    functions: new Set<string>(),                              // local functions
+    customs: new Map<string, unknown>(),                       // custom type data
   }
   function CreateExpression(schema: Types.TSchema, references: Types.TSchema[], value: string): string {
     return `(${[...Visit(schema, references, value)].join(' && ')})`
   }
-  function CreateAnnotation() {
-    return state.language === 'typescript' ? ': any' : ''
-  }
   function CreateFunctionName($id: string) {
     return `check_${Identifier.Encode($id)}`
   }
+  function CreateParameter(name: string) {
+    const annotation = state.language === 'typescript' ? ': any' : ''
+    return `${name}${annotation}`
+  }
   function CreateFunction(name: string, schema: Types.TSchema, references: Types.TSchema[], value: string): string {
     const expression = [...Visit(schema, references, value, true)].map((condition) => `    ${condition}`).join(' &&\n')
-    const annotation = CreateAnnotation()
-    return `function ${name}(value${annotation}) {\n  return (\n${expression}\n )\n}`
+    const parameter = CreateParameter('value')
+    return `function ${name}(${parameter}) {\n  return (\n${expression}\n )\n}`
   }
   function PushFunction(functionBody: string) {
     state.variables.add(functionBody)
@@ -489,20 +491,21 @@ export namespace TypeCompiler {
   // Compile
   // -------------------------------------------------------------------
   function Build<T extends Types.TSchema>(schema: T, references: Types.TSchema[]): string {
-    const annotation = CreateAnnotation()
     const check = CreateFunction('check', schema, references, 'value') // interior visit
     const locals = GetLocals()
+    const parameter = CreateParameter('value')
     // prettier-ignore
     return IsString(schema.$id) // ensure top level schemas with $id's are hoisted
-      ? `${locals.join('\n')}\nreturn function check(value${annotation}) {\n  return ${CreateFunctionName(schema.$id)}(value)\n}`
+      ? `${locals.join('\n')}\nreturn function check(${parameter}) {\n  return ${CreateFunctionName(schema.$id)}(value)\n}`
       : `${locals.join('\n')}\nreturn ${check}`
   }
   /** Returns the generated assertion code used to validate this type. */
   export function Code<T extends Types.TSchema>(schema: T, references: Types.TSchema[] = [], options: TypeCompilerOptions = { language: 'javascript' }) {
+    // compiler-reset
     state.language = options.language
     state.variables.clear()
-    state.function_names.clear()
-    state.custom_types.clear()
+    state.functions.clear()
+    state.customs.clear()
     if (!Types.TypeGuard.TSchema(schema)) throw new TypeCompilerTypeGuardError(schema)
     for (const schema of references) if (!Types.TypeGuard.TSchema(schema)) throw new TypeCompilerTypeGuardError(schema)
     return Build(schema, references)
@@ -510,12 +513,12 @@ export namespace TypeCompiler {
   /** Compiles the given type for runtime type checking. This compiler only accepts known TypeBox types non-inclusive of unsafe types. */
   export function Compile<T extends Types.TSchema>(schema: T, references: Types.TSchema[] = []): TypeCheck<T> {
     const code = Code(schema, references, { language: 'javascript' })
-    const custom_schemas = new Map(state.custom_types)
+    const customs = new Map(state.customs)
     const compiledFunction = globalThis.Function('custom', 'format', 'hash', code)
     const checkFunction = compiledFunction(
       (kind: string, schema_key: string, value: unknown) => {
-        if (!Types.TypeRegistry.Has(kind) || !custom_schemas.has(schema_key)) return false
-        const schema = custom_schemas.get(schema_key)!
+        if (!Types.TypeRegistry.Has(kind) || !customs.has(schema_key)) return false
+        const schema = customs.get(schema_key)!
         const func = Types.TypeRegistry.Get(kind)!
         return func(schema, value)
       },


### PR DESCRIPTION
This PR implements a TypeScript code generation target for the TypeCompiler. This target will emit type annotation for function arguments which allows the generated code to be used in a TypeScript context without "implicit any" errors.

TypeScript Code Generation is available via `TypeCompiler.Code()` only. This function is not overloaded, so callers will need to pass an empty references array before specifying the language target.

```typescript
const T = Type.Object({
  x: Type.Number(),
  y: Type.Number(),
  z: Type.Number(),
})

const C = TypeCompiler.Code(T, [], { language: 'typescript' })

// outputs

return function check(value: any) { // annotation prevents implicit any warnings.
  return (
    (typeof value === 'object' && value !== null && !Array.isArray(value)) &&
    (typeof value.x === 'number' && Number.isFinite(value.x)) &&
    (typeof value.y === 'number' && Number.isFinite(value.y)) &&
    (typeof value.z === 'number' && Number.isFinite(value.z))
 )
}
```