### PR TITLE
Compiler TypeScript Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.17",
+  "version": "0.28.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.28.17",
+      "version": "0.28.18",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.17",
+  "version": "0.28.18",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",


### PR DESCRIPTION
This PR is a subsequent update on https://github.com/sinclairzx81/typebox/pull/469 to add return type annotations on generated functions. 

```typescript
const T = Type.Object({
  x: Type.Number(),
  y: Type.Number(),
  z: Type.Number(),
})

const C = TypeCompiler.Code(T, [], { language: 'typescript' })

// produces

return function check(value: any): boolean {
  return (
    (typeof value === 'object' && value !== null && !Array.isArray(value)) &&
    (typeof value.x === 'number' && Number.isFinite(value.x)) &&
    (typeof value.y === 'number' && Number.isFinite(value.y)) &&
    (typeof value.z === 'number' && Number.isFinite(value.z))
 )
}
```