### PR TITLE
Check for Non-Terminating Recursive Types 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.18",
+  "version": "0.28.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.28.18",
+      "version": "0.28.19",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.18",
+  "version": "0.28.19",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/value.ts
+++ b/src/value/value.ts
@@ -27,7 +27,7 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import * as Types from '../typebox'
-import { ValueErrors, ValueErrorIterator, ValueError } from '../errors/index'
+import { ValueErrors, ValueErrorIterator } from '../errors/index'
 import { ValueMutate, Mutable } from './mutate'
 import { ValueHash } from './hash'
 import { ValueEqual } from './equal'

--- a/test/runtime/value/create/recursive.ts
+++ b/test/runtime/value/create/recursive.ts
@@ -15,7 +15,6 @@ describe('value/create/Recursive', () => {
       nodes: [],
     })
   })
-
   it('Should create default', () => {
     const T = Type.Recursive(
       (This) =>
@@ -26,5 +25,13 @@ describe('value/create/Recursive', () => {
       { default: 7 },
     )
     Assert.isEqual(Value.Create(T), 7)
+  })
+  it('Should throw on infinite type', () => {
+    const T = Type.Recursive((This) =>
+      Type.Object({
+        x: This,
+      }),
+    )
+    Assert.throws(() => Value.Create(T))
   })
 })

--- a/test/runtime/value/create/recursive.ts
+++ b/test/runtime/value/create/recursive.ts
@@ -34,4 +34,12 @@ describe('value/create/Recursive', () => {
     )
     Assert.throws(() => Value.Create(T))
   })
+  it('Should not throw on infinite type when finite sub-type is defined first', () => {
+    const T = Type.Recursive((This) =>
+      Type.Object({
+        x: Type.Union([Type.Null(), This]),
+      }),
+    )
+    Assert.isEqual(Value.Create(T), { x: null })
+  })
 })

--- a/test/runtime/value/create/recursive.ts
+++ b/test/runtime/value/create/recursive.ts
@@ -34,12 +34,20 @@ describe('value/create/Recursive', () => {
     )
     Assert.throws(() => Value.Create(T))
   })
-  it('Should not throw on infinite type when finite sub-type is defined first', () => {
+  it('Should not throw on recursive type when terminating sub type proceeds self', () => {
     const T = Type.Recursive((This) =>
       Type.Object({
         x: Type.Union([Type.Null(), This]),
       }),
     )
     Assert.isEqual(Value.Create(T), { x: null })
+  })
+  it('Should not throw on recursive type when self is optional', () => {
+    const T = Type.Recursive((This) =>
+      Type.Object({
+        x: Type.Optional(This),
+      }),
+    )
+    Assert.isEqual(Value.Create(T), {})
   })
 })

--- a/test/runtime/value/create/ref.ts
+++ b/test/runtime/value/create/ref.ts
@@ -27,4 +27,9 @@ describe('value/create/Ref', () => {
     const R = Type.Ref(T, { default: 'override' })
     Assert.isEqual(Value.Create(R), 'override') // terminated at R default value
   })
+  it('Should dereference remote schema via $ref', () => {
+    const R = Type.Number({ $id: 'S' })
+    const T = Type.Object({ x: Type.Ref(R) })
+    Assert.isEqual(Value.Create(T, [R]), { x: 0 })
+  })
 })


### PR DESCRIPTION
This PR implements an exception path for non-terminating recursive types that expand into infinite sized values.

```typescript
const T = Type.Recursive(This => Type.Object({
  x: This
}))

Value.Create(T) // throws RecursiveInstantiationError
```
This error can be mitigated by specifying a terminating type. Note that order matters where the terminating type should be specified first.

```typescript
const T = Type.Recursive(This => Type.Object({
  x: Type.Union([Type.Null(), This])
}))

Value.Create(T) // { x: null }
```
This PR also includes a fix for referenced / recursive types (which were incorrectly dereferencing referenced schemas)
