### PR TITLE
Resolve Numeric Constraint Reporting Error 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.19",
+  "version": "0.28.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.28.19",
+      "version": "0.28.20",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.28.19",
+  "version": "0.28.20",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -329,10 +329,10 @@ export namespace ValueErrors {
       yield { type: ValueErrorType.NumberExclusiveMaximum, schema, path, value, message: `Expected number to be less than ${schema.exclusiveMaximum}` }
     }
     if (IsDefined<number>(schema.minimum) && !(value >= schema.minimum)) {
-      yield { type: ValueErrorType.NumberMaximum, schema, path, value, message: `Expected number to be greater or equal to ${schema.minimum}` }
+      yield { type: ValueErrorType.NumberMinumum, schema, path, value, message: `Expected number to be greater or equal to ${schema.minimum}` }
     }
     if (IsDefined<number>(schema.maximum) && !(value <= schema.maximum)) {
-      yield { type: ValueErrorType.NumberMinumum, schema, path, value, message: `Expected number to be less or equal to ${schema.maximum}` }
+      yield { type: ValueErrorType.NumberMaximum, schema, path, value, message: `Expected number to be less or equal to ${schema.maximum}` }
     }
   }
   function* Object(schema: Types.TObject, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -66,7 +66,7 @@ export enum ValueErrorType {
   NumberMultipleOf,
   NumberExclusiveMinimum,
   NumberExclusiveMaximum,
-  NumberMinumum,
+  NumberMinimum,
   NumberMaximum,
   Object,
   ObjectMinProperties,
@@ -329,7 +329,7 @@ export namespace ValueErrors {
       yield { type: ValueErrorType.NumberExclusiveMaximum, schema, path, value, message: `Expected number to be less than ${schema.exclusiveMaximum}` }
     }
     if (IsDefined<number>(schema.minimum) && !(value >= schema.minimum)) {
-      yield { type: ValueErrorType.NumberMinumum, schema, path, value, message: `Expected number to be greater or equal to ${schema.minimum}` }
+      yield { type: ValueErrorType.NumberMinimum, schema, path, value, message: `Expected number to be greater or equal to ${schema.minimum}` }
     }
     if (IsDefined<number>(schema.maximum) && !(value <= schema.maximum)) {
       yield { type: ValueErrorType.NumberMaximum, schema, path, value, message: `Expected number to be less or equal to ${schema.maximum}` }


### PR DESCRIPTION
This PR applies a fix for the `minimum` / `maximum` reporting errors. These were reversed for `TNumber` where `minimum` was validated, but `maximum` was reported.