### PR TITLE
Revision 0.29.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/readme.md
+++ b/readme.md
@@ -1473,6 +1473,7 @@ The following is a list of community packages that provide general tooling and f
 | [fetch-typebox](https://github.com/erfanium/fetch-typebox) | Drop-in replacement for fetch that brings easy integration with TypeBox |
 | [schema2typebox](https://github.com/xddq/schema2typebox)  | Creating TypeBox code from JSON schemas |
 | [ts2typebox](https://github.com/xddq/ts2typebox) | Creating TypeBox code from Typescript types |
+| [typebox-client](https://github.com/flodlc/typebox-client) | Type safe http client library for Fastify |
 | [typebox-validators](https://github.com/jtlapp/typebox-validators) | Advanced validators supporting discriminated and heterogeneous unions |
 
 <a name='benchmark'></a>

--- a/test/runtime/type/extends/not.ts
+++ b/test/runtime/type/extends/not.ts
@@ -6,6 +6,21 @@ import { Assert } from '../../assert/index'
 // Note: Not is equivalent to Unknown with the exception of nested negation.
 // ---------------------------------------------------------------------------
 describe('type/extends/Not', () => {
+  // -------------------------------------------------------------------------
+  // Issue: type T = number extends not number ? true : false // true
+  //        type T = number extends unknown ? true : false    // true
+  //
+  // TypeScript does not support type negation. The best TypeBox can do is
+  // treat "not" as "unknown". From this standpoint, the extends assignability
+  // check needs to return true for the following case to keep TypeBox aligned
+  // with TypeScript static inference.
+  // -------------------------------------------------------------------------
+  it('Should extend with nested negation', () => {
+    const A = Type.Number()
+    const B = Type.Not(Type.Number())
+    const R = TypeExtends.Extends(A, B)
+    Assert.isEqual(R, TypeExtendsResult.True) // we would expect false
+  })
   // ---------------------------------------------------------------------------
   // Nested
   // ---------------------------------------------------------------------------

--- a/test/runtime/type/extends/not.ts
+++ b/test/runtime/type/extends/not.ts
@@ -15,7 +15,7 @@ describe('type/extends/Not', () => {
   // check needs to return true for the following case to keep TypeBox aligned
   // with TypeScript static inference.
   // -------------------------------------------------------------------------
-  it('Should extend with nested negation', () => {
+  it('Should extend with unknown assignability check', () => {
     const A = Type.Number()
     const B = Type.Not(Type.Number())
     const R = TypeExtends.Extends(A, B)

--- a/test/static/not.ts
+++ b/test/static/not.ts
@@ -2,6 +2,21 @@ import { Expect } from './assert'
 import { Type } from '@sinclair/typebox'
 
 {
+  // -------------------------------------------------------------------------
+  // Issue: type T = number extends not number ? true : false // true
+  //        type T = number extends unknown ? true : false    // true
+  //
+  // TypeScript does not support type negation. The best TypeBox can do is
+  // treat "not" as "unknown". From this standpoint, the extends assignability
+  // check needs to return true for the following case to keep TypeBox aligned
+  // with TypeScript static inference.
+  // -------------------------------------------------------------------------
+  const A = Type.Number()
+  const B = Type.Not(Type.Number())
+  const T = Type.Extends(A, B, Type.Literal(true), Type.Literal(false))
+  Expect(T).ToInfer<true>()
+}
+{
   const T = Type.Not(Type.Number())
   Expect(T).ToInfer<unknown>()
 }


### PR DESCRIPTION
This PR implements a minor refactoring to the `TypeExtends` module and includes comments detailing some of the current assignability checks carried out for TemplateLiteral and Not types. This PR also includes static and runtime tests to document `unknown` extends behaviors for the Not type (with considerations for possible negated types being introduced as a TypeScript language feature)

The PR also adds `typebox-client` to the ecosystem section of the readme.