### PR TITLE
Revision 0.29.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -395,7 +395,7 @@ export interface TIntersect<T extends TSchema[] = TSchema[]> extends TSchema, In
 // prettier-ignore
 export type TKeyOfProperties<T extends TSchema> = Discard<Static<T> extends infer S
   ? UnionToTuple<{[K in keyof S]: TLiteral<Assert<K, TLiteralValue>>}[keyof S]>
-  : [], undefined> // optional properties evaluate to undefined here. discard
+  : [], undefined> // note: optional properties produce undefined types in tuple result. discard.
 // prettier-ignore
 export type TKeyOfIndicesArray<T extends TSchema[]> = UnionToTuple<keyof T & `${number}`>
 // prettier-ignore

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -393,9 +393,9 @@ export interface TIntersect<T extends TSchema[] = TSchema[]> extends TSchema, In
 // TKeyOf
 // --------------------------------------------------------------------------
 // prettier-ignore
-export type TKeyOfProperties<T extends TSchema> = Static<T> extends infer S
+export type TKeyOfProperties<T extends TSchema> = Discard<Static<T> extends infer S
   ? UnionToTuple<{[K in keyof S]: TLiteral<Assert<K, TLiteralValue>>}[keyof S]>
-  : []
+  : [], undefined> // optional properties evaluate to undefined here. discard
 // prettier-ignore
 export type TKeyOfIndicesArray<T extends TSchema[]> = UnionToTuple<keyof T & `${number}`>
 // prettier-ignore

--- a/test/static/keyof.ts
+++ b/test/static/keyof.ts
@@ -91,3 +91,12 @@ import { Type } from '@sinclair/typebox'
   const K = Type.KeyOf(T)
   Expect(K).ToInfer<'a' | 'b' | 'c' | 'd'>()
 }
+{
+  const T = Type.Object({
+    a: Type.Optional(Type.String()),
+    b: Type.Optional(Type.String()),
+    c: Type.Optional(Type.String()),
+  })
+  const K = Type.KeyOf(T)
+  Expect(K).ToInfer<'a' | 'b' | 'c'>()
+}


### PR DESCRIPTION
This PR implements a small fix for `Type.KeyOf` where optional properties were being omitted.

```typescript
const T = Type.Object({
  x: Type.Optional(Type.String())
})

const K = Type.KeyOf(T) // before: TNever
                        // after:  TLiteral<'x'>
```