### PR TITLE
Scheduled Nightly Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
-name: GitHub CI
-
+name: Build
 on: [push, pull_request]
-
 jobs:
   TypeBox:
     runs-on: ${{ matrix.os }}
@@ -12,11 +10,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+
       - name: Install Packages
         run: npm install
+
       - name: Build Library
         run: npm run build
       - name: Test Library

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,31 @@
+name: Build Nightly
+on:
+  push:
+  schedule:
+    - cron: '0 18 * * *' # 6pm Daily
+jobs:
+  TypeBox:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: [20.x]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install Packages
+        run: npm install
+
+      - name: Install TypeScript Latest
+        run: npm install typescript@latest
+      - name: Build TypeBox
+        run: npm run build
+
+      - name: Install TypeScript Next
+        run: npm install typescript@next
+      - name: Build TypeBox
+        run: npm run build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,5 @@
 name: Build Nightly
 on:
-  push:
   schedule:
     - cron: '0 18 * * *' # 6pm Daily
 jobs:

--- a/hammer.mjs
+++ b/hammer.mjs
@@ -5,59 +5,59 @@ import { readFileSync } from 'fs'
 // Clean
 // -------------------------------------------------------------------------------
 export async function clean() {
-    await folder('target').delete()
+	await folder('target').delete()
 }
 // -------------------------------------------------------------------------------
 // Format
 // -------------------------------------------------------------------------------
 export async function format() {
-    await shell('prettier --no-semi --single-quote --print-width 240 --trailing-comma all --write src test example/index.ts benchmark')
+	await shell('prettier --no-semi --single-quote --print-width 240 --trailing-comma all --write src test example/index.ts benchmark')
 }
 // -------------------------------------------------------------------------------
 // Start
 // -------------------------------------------------------------------------------
 export async function start(example = 'index') {
-    await shell(`hammer run example/${example}.ts --dist target/example/${example}`)
+	await shell(`hammer run example/${example}.ts --dist target/example/${example}`)
 }
 // -------------------------------------------------------------------------------
 // Benchmark
 // -------------------------------------------------------------------------------
 export async function benchmark() {
-    await compression()
-    await measurement()
+	await compression()
+	await measurement()
 }
 // -------------------------------------------------------------------------------
 // Test
 // -------------------------------------------------------------------------------
 export async function test_static() {
-    await shell(`tsc -p test/static/tsconfig.json --noEmit --strict`)
+	await shell(`tsc -p test/static/tsconfig.json --noEmit --strict`)
 }
-export async function test_runtime(filter) {
-    await shell(`hammer build ./test/runtime/index.ts --dist target/test/runtime --platform node`)
-    await shell(`mocha target/test/runtime/index.js -g "${filter}"`)
+export async function test_runtime(filter = '') {
+	await shell(`hammer build ./test/runtime/index.ts --dist target/test/runtime --platform node`)
+	await shell(`mocha target/test/runtime/index.js -g "${filter}"`)
 }
 export async function test(filter = '') {
-    await test_static()
-    await test_runtime(filter)
+	await test_static()
+	await test_runtime(filter)
 }
 // -------------------------------------------------------------------------------
 // Build
 // -------------------------------------------------------------------------------
 export async function build(target = 'target/build') {
-    await test()
-    await folder(target).delete()
-    await shell(`tsc -p ./src/tsconfig.json --outDir ${target}`)
-    await folder(target).add('package.json')
-    await folder(target).add('readme.md')
-    await folder(target).add('license')
-    await shell(`cd ${target} && npm pack`)
+	await test()
+	await folder(target).delete()
+	await shell(`tsc -p ./src/tsconfig.json --outDir ${target}`)
+	await folder(target).add('package.json')
+	await folder(target).add('readme.md')
+	await folder(target).add('license')
+	await shell(`cd ${target} && npm pack`)
 }
 // -------------------------------------------------------------
 // Publish
 // -------------------------------------------------------------
 export async function publish(otp, target = 'target/build') {
-    const { version } = JSON.parse(readFileSync('package.json', 'utf8'))
-    await shell(`cd ${target} && npm publish sinclair-typebox-${version}.tgz --access=public --otp ${otp}`)
-    await shell(`git tag ${version}`)
-    await shell(`git push origin ${version}`)
+	const { version } = JSON.parse(readFileSync('package.json', 'utf8'))
+	await shell(`cd ${target} && npm publish sinclair-typebox-${version}.tgz --access=public --otp ${otp}`)
+	await shell(`git tag ${version}`)
+	await shell(`git push origin ${version}`)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.29.1",
+  "version": "0.29.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.29.1",
+      "version": "0.29.3",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,8 @@
 
 [![npm version](https://badge.fury.io/js/%40sinclair%2Ftypebox.svg)](https://badge.fury.io/js/%40sinclair%2Ftypebox)
 [![Downloads](https://img.shields.io/npm/dm/%40sinclair%2Ftypebox.svg)](https://www.npmjs.com/package/%40sinclair%2Ftypebox)
-[![GitHub CI](https://github.com/sinclairzx81/typebox/workflows/GitHub%20CI/badge.svg)](https://github.com/sinclairzx81/typebox/actions)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Build](https://github.com/sinclairzx81/typebox/actions/workflows/build.yml/badge.svg)](https://github.com/sinclairzx81/typebox/actions/workflows/build.yml)
+[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 </div>
 


### PR DESCRIPTION
This PR adds scheduled nightly builds for `latest` and `next` versions of TypeScript currently published on npm. This PR was prompted by a change in TypeScript 5.1.6 that resulted in deep instantiation errors in TypeBox that were not present on 5.1.3. 

The nightly builds should service as an early warning system for potential breaking changes in upcoming versions of TypeScript.