### PR TITLE
Composite Type Optimization

### DIFF
--- a/hammer.mjs
+++ b/hammer.mjs
@@ -29,7 +29,14 @@ export async function benchmark() {
 // -------------------------------------------------------------------------------
 // Test
 // -------------------------------------------------------------------------------
+export async function test_typescript() {
+  for (const version of ['4.9.5', '5.0.4', '5.1.3', '5.1.6', 'next', 'latest']) {
+    await shell(`npm install typescript@${version} --no-save`)
+    await test_static()
+  }
+}
 export async function test_static() {
+  await shell(`tsc -v`)
   await shell(`tsc -p test/static/tsconfig.json --noEmit --strict`)
 }
 export async function test_runtime(filter = '') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.29.3",
+      "version": "0.29.4",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",
@@ -24,10 +24,13 @@
     "url": "https://github.com/sinclairzx81/typebox"
   },
   "scripts": {
+    "test:typescript": "hammer task test_typescript",
+    "test:static": "hammer task test_static",
+    "test:runtime": "hammer task test_runtime",
+    "test": "hammer task test",
     "clean": "hammer task clean",
     "format": "hammer task format",
     "start": "hammer task start",
-    "test": "hammer task test",
     "benchmark": "hammer task benchmark",
     "build": "hammer task build",
     "publish": "hammer task publish"

--- a/readme.md
+++ b/readme.md
@@ -900,7 +900,7 @@ const C = Type.Index(T, Type.KeyOf(T))               // const C = {
 
 ### Not Types
 
-TypeBox provides support for the `not` keyword with `Type.Not`. This type is synonymous with [negated types](https://github.com/microsoft/TypeScript/issues/4196) which are not supported in the TypeScript language. Partial inference of this type can be attained via the intersection of `T & not U` (where all Not types infer as `unknown`). This can be used in the following context to narrow for broader types.
+TypeBox provides support for the `not` keyword with `Type.Not`. This type is synonymous with [negated types](https://github.com/microsoft/TypeScript/issues/4196) which are not supported in the TypeScript language. Partial inference of this type can be attained via the intersection of `T & not U` (where all Not types infer as `unknown`). This approach can be used to narrow for broader types in the following context.
 
 ```typescript
 // TypeScript


### PR DESCRIPTION
This PR implements an optimization on Type.Composite as well as providing an evaluation path for a TS quirk when intersecting objects with certain property types. Excerpt from test case below:

```typescript
// ----------------------------------------------------------------------------
// Intersection Quirk
//
// TypeScript has an evaluation quirk for the following case where the first
// type evaluates the sub property as never, but the second evaluates the
// entire type as never. There is probably a reason for this behavior, but
// TypeBox supports the former evaluation.
//
// { x: number } & { x: string }  -> { x: number } & { x: string } => { x: never }
// { x: number } & { x: boolean } ->  never -> ...
// ----------------------------------------------------------------------------
{
  // prettier-ignore
  const T: TObject<{
    x: TIntersect<[TNumber, TBoolean]>
  }> = Type.Composite([
    Type.Object({ x: Type.Number() }),
    Type.Object({ x: Type.Boolean() })
  ])
}
```
This PR also adds automation tests for past and future revisions of the compiler. It also makes some minor updates to the documentation for Composite, TemplateLiteral, Indexed and Not type descriptions.