### PR TITLE
Resolve Max Properties Error Message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.29.5",
+  "version": "0.29.6",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -391,7 +391,7 @@ export namespace ValueErrors {
       yield { type: ValueErrorType.ObjectMinProperties, schema, path, value, message: `Expected object to have at least ${schema.minProperties} properties` }
     }
     if (IsDefined<number>(schema.maxProperties) && !(globalThis.Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
-      yield { type: ValueErrorType.ObjectMaxProperties, schema, path, value, message: `Expected object to have less than ${schema.minProperties} properties` }
+      yield { type: ValueErrorType.ObjectMaxProperties, schema, path, value, message: `Expected object to have less than ${schema.maxProperties} properties` }
     }
     const [patternKey, patternSchema] = globalThis.Object.entries(schema.patternProperties)[0]
     const regex = new RegExp(patternKey)

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -342,7 +342,7 @@ export namespace ValueErrors {
       yield { type: ValueErrorType.ObjectMinProperties, schema, path, value, message: `Expected object to have at least ${schema.minProperties} properties` }
     }
     if (IsDefined<number>(schema.maxProperties) && !(globalThis.Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
-      yield { type: ValueErrorType.ObjectMaxProperties, schema, path, value, message: `Expected object to have less than ${schema.maxProperties} properties` }
+      yield { type: ValueErrorType.ObjectMaxProperties, schema, path, value, message: `Expected object to have no more than ${schema.maxProperties} properties` }
     }
     const requiredKeys = globalThis.Array.isArray(schema.required) ? schema.required : ([] as string[])
     const knownKeys = globalThis.Object.getOwnPropertyNames(schema.properties)
@@ -391,7 +391,7 @@ export namespace ValueErrors {
       yield { type: ValueErrorType.ObjectMinProperties, schema, path, value, message: `Expected object to have at least ${schema.minProperties} properties` }
     }
     if (IsDefined<number>(schema.maxProperties) && !(globalThis.Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
-      yield { type: ValueErrorType.ObjectMaxProperties, schema, path, value, message: `Expected object to have less than ${schema.maxProperties} properties` }
+      yield { type: ValueErrorType.ObjectMaxProperties, schema, path, value, message: `Expected object to have no more than ${schema.maxProperties} properties` }
     }
     const [patternKey, patternSchema] = globalThis.Object.entries(schema.patternProperties)[0]
     const regex = new RegExp(patternKey)


### PR DESCRIPTION
This PR is a follow on update for #501 to also correct the `maxProperties` reporting error message on Record. This PR also updates the error message text as per #501 suggestion. 