### PR TITLE
Revision 0.30.0 Codec

### DIFF
--- a/benchmark/compression/module/typebox-value-cast.ts
+++ b/benchmark/compression/module/typebox-value-cast.ts
@@ -1,3 +1,0 @@
-import { Cast } from '@sinclair/typebox/value/cast'
-
-console.log(Cast)

--- a/benchmark/compression/module/typebox-value-check.ts
+++ b/benchmark/compression/module/typebox-value-check.ts
@@ -1,3 +1,0 @@
-import { Check } from '@sinclair/typebox/value/check'
-
-console.log(Check)

--- a/benchmark/compression/module/typebox-value-clone.ts
+++ b/benchmark/compression/module/typebox-value-clone.ts
@@ -1,3 +1,0 @@
-import { Clone } from '@sinclair/typebox/value/clone'
-
-console.log(Clone)

--- a/benchmark/compression/module/typebox-value-convert.ts
+++ b/benchmark/compression/module/typebox-value-convert.ts
@@ -1,3 +1,0 @@
-import { Convert } from '@sinclair/typebox/value/convert'
-
-console.log(Convert)

--- a/benchmark/compression/module/typebox-value-create.ts
+++ b/benchmark/compression/module/typebox-value-create.ts
@@ -1,3 +1,0 @@
-import { Create } from '@sinclair/typebox/value/create'
-
-console.log(Create)

--- a/benchmark/compression/module/typebox-value-delta.ts
+++ b/benchmark/compression/module/typebox-value-delta.ts
@@ -1,3 +1,0 @@
-import { Diff, Patch } from '@sinclair/typebox/value/delta'
-
-console.log(Diff, Patch)

--- a/benchmark/compression/module/typebox-value-equal.ts
+++ b/benchmark/compression/module/typebox-value-equal.ts
@@ -1,3 +1,0 @@
-import { Equal } from '@sinclair/typebox/value/equal'
-
-console.log(Equal)

--- a/benchmark/compression/module/typebox-value-guard.ts
+++ b/benchmark/compression/module/typebox-value-guard.ts
@@ -1,3 +1,0 @@
-import * as ValueGuard from '@sinclair/typebox/value/guard'
-
-console.log(ValueGuard)

--- a/benchmark/compression/module/typebox-value-hash.ts
+++ b/benchmark/compression/module/typebox-value-hash.ts
@@ -1,3 +1,0 @@
-import { Hash } from '@sinclair/typebox/value/hash'
-
-console.log(Hash)

--- a/benchmark/compression/module/typebox-value-mutate.ts
+++ b/benchmark/compression/module/typebox-value-mutate.ts
@@ -1,3 +1,0 @@
-import { Mutate } from '@sinclair/typebox/value/mutate'
-
-console.log(Mutate)

--- a/benchmark/compression/module/typebox-value-pointer.ts
+++ b/benchmark/compression/module/typebox-value-pointer.ts
@@ -1,3 +1,0 @@
-import { ValuePointer } from '@sinclair/typebox/value/pointer'
-
-console.log(ValuePointer)

--- a/changelog/0.30.0.md
+++ b/changelog/0.30.0.md
@@ -244,24 +244,13 @@ For information on configuring custom formats on Ajv, refer to https://ajv.js.or
 
 // Revision 0.30.0
 //
-┌───────────────────────┬────────────┬────────────┬─────────────┐
-│        (index)        │  Compiled  │  Minified  │ Compression │
-├───────────────────────┼────────────┼────────────┼─────────────┤
-│ typebox/compiler      │ '128.5 kb' │ ' 58.7 kb' │  '2.19 x'   │
-│ typebox/errors        │ '110.7 kb' │ ' 50.1 kb' │  '2.21 x'   │
-│ typebox/system        │ ' 75.4 kb' │ ' 31.3 kb' │  '2.41 x'   │
-│ typebox/value/cast    │ '123.0 kb' │ ' 51.8 kb' │  '2.37 x'   │
-│ typebox/value/check   │ ' 95.3 kb' │ ' 40.0 kb' │  '2.38 x'   │
-│ typebox/value/clone   │ '  3.0 kb' │ '  1.3 kb' │  '2.23 x'   │
-│ typebox/value/convert │ '108.1 kb' │ ' 45.6 kb' │  '2.37 x'   │
-│ typebox/value/create  │ '108.8 kb' │ ' 46.1 kb' │  '2.36 x'   │
-│ typebox/value/delta   │ ' 85.2 kb' │ ' 35.7 kb' │  '2.38 x'   │
-│ typebox/value/equal   │ '  2.9 kb' │ '  1.5 kb' │  '1.97 x'   │
-│ typebox/value/guard   │ '  2.8 kb' │ '  1.4 kb' │  '1.99 x'   │
-│ typebox/value/hash    │ '  4.1 kb' │ '  1.9 kb' │  '2.09 x'   │
-│ typebox/value/mutate  │ '  8.7 kb' │ '  3.5 kb' │  '2.46 x'   │
-│ typebox/value/pointer │ '  3.2 kb' │ '  1.2 kb' │  '2.61 x'   │
-│ typebox/value         │ '180.6 kb' │ ' 80.2 kb' │  '2.25 x'   │
-│ typebox               │ ' 74.3 kb' │ ' 30.8 kb' │  '2.41 x'   │
-└───────────────────────┴────────────┴────────────┴─────────────┘
+┌──────────────────────┬────────────┬────────────┬─────────────┐
+│       (index)        │  Compiled  │  Minified  │ Compression │
+├──────────────────────┼────────────┼────────────┼─────────────┤
+│ typebox/compiler     │ '128.9 kb' │ ' 58.5 kb' │  '2.20 x'   │
+│ typebox/errors       │ '111.1 kb' │ ' 49.8 kb' │  '2.23 x'   │
+│ typebox/system       │ ' 75.9 kb' │ ' 31.4 kb' │  '2.42 x'   │
+│ typebox/value        │ '180.4 kb' │ ' 79.0 kb' │  '2.28 x'   │
+│ typebox              │ ' 74.8 kb' │ ' 31.0 kb' │  '2.42 x'   │
+└──────────────────────┴────────────┴────────────┴─────────────┘
 ```

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,7 +1,7 @@
 import { TypeSystem } from '@sinclair/typebox/system'
 import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
-import { Type, TypeGuard, Kind, Static, TSchema, Optional } from '@sinclair/typebox'
+import { Type, TypeGuard, Kind, Static, TSchema, Optional, TNumber } from '@sinclair/typebox'
 
 // Modifiers
 //  - Deprecate Modifier Symbol
@@ -31,7 +31,27 @@ import { Type, TypeGuard, Kind, Static, TSchema, Optional } from '@sinclair/type
 //  - add common value guard utility - (done)
 //  - figure out what to do with non-nomimal-object
 //    - rename is-plain-object
+// Transform
+//  - Going to move this into examples as I'm not
+//    comfortable going out with this functionality.
+//    The problem is stacked transforms can't be
+//    validated, and generally this thing needs more
+//    design before going out on a release.
 
-import { Check } from '@sinclair/typebox/value/check'
-import { Cast } from '@sinclair/typebox/value/cast'
-import { Convert } from '@sinclair/typebox/value/convert'
+import { Transform, Encode, Decode } from './transform'
+
+// Applies codec functions to a type
+const Timestamp = Transform(Type.Number(), {
+  decode: (value) => new Date(value),
+  encode: (value) => value.getTime(),
+})
+// Transform type can be nested within objects
+const N = Type.Object({
+  timestamp: Timestamp,
+})
+
+// Decodes as { timestamp: Date }
+const D = Decode(N, { timestamp: Date.now() })
+
+// Encodes as { timestamp: number }
+const E = Encode(N, D)

--- a/example/transform/index.ts
+++ b/example/transform/index.ts
@@ -1,0 +1,29 @@
+/*--------------------------------------------------------------------------
+
+@sinclair/typebox/transform
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
+export * from './transform'

--- a/example/transform/readme.md
+++ b/example/transform/readme.md
@@ -1,0 +1,23 @@
+# Transform
+
+Use Transform to apply codec functions to a type. Transform is designed to be used with the Decode and Encode functions to handle automatic encode and decode of JSON values. The following shows transforming Date objects to and from number types.
+
+```typescript
+import { Transform, Encode, Decode } from './transform'
+
+// Applies codec functions to a type
+const Timestamp = Transform(Type.Number(), {
+  decode: (value) => new Date(value),
+  encode: (value) => value.getTime(),
+})
+// Transform type can be nested within objects
+const N = Type.Object({
+  timestamp: Timestamp
+})
+
+// Decodes as { timestamp: Date }
+const D = Decode(N, { timestamp: Date.now() })
+
+// Encodes as { timestamp: number }
+const E = Encode(N, D)
+```

--- a/example/transform/transform.ts
+++ b/example/transform/transform.ts
@@ -1,0 +1,352 @@
+/*--------------------------------------------------------------------------
+
+@sinclair/typebox/transform
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2023 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
+import * as Types from '@sinclair/typebox'
+import * as ValueGuard from '@sinclair/typebox/value/guard'
+import * as ValueCheck from '@sinclair/typebox/value/check'
+
+// --------------------------------------------------------------------------
+// Symbols
+// --------------------------------------------------------------------------
+export const TransformSymbol = Symbol.for('TypeBox.Transform')
+
+// ----------------------------------------------------------------------------------------------
+// Errors
+// ----------------------------------------------------------------------------------------------
+export class TransformDecodeError extends Error {
+  constructor(public readonly schema: Types.TSchema, public readonly value: unknown) {
+    super('ValueTransform: Unable to decode value as it does not match schema')
+  }
+}
+export class TransformEncodeError extends Error {
+  constructor(public readonly schema: Types.TSchema, public readonly value: unknown) {
+    super('ValueTransform: The encode resulted in an invalid value')
+  }
+}
+export class ValueTransformUnknownTypeError extends Error {
+  constructor(public readonly schema: Types.TSchema) {
+    super('Unknown type')
+  }
+}
+export class ValueTransformDereferenceError extends Error {
+  constructor(public readonly schema: Types.TRef | Types.TThis) {
+    super(`Unable to dereference schema with $id '${schema.$ref}'`)
+  }
+}
+export class ValueTransformFallthroughError extends Error {
+  constructor(public readonly schema: Types.TSchema, public readonly value: unknown, public mode: ValueTransformMode) {
+    super('Unexpected transform error')
+  }
+}
+export class ValueTransformCodecError extends Error {
+  constructor(public readonly schema: Types.TSchema, public readonly value: unknown, public mode: ValueTransformMode, error: any) {
+    super(`${error instanceof Error ? error.message : 'Unknown'}`)
+  }
+}
+export type ValueTransformMode = 'encode' | 'decode'
+
+// ----------------------------------------------------------------------------------------------
+// Apply
+// ----------------------------------------------------------------------------------------------
+function Apply(schema: Types.TSchema, value: any, mode: ValueTransformMode) {
+  try {
+    if (!HasTransform(schema)) return value
+    const transform = schema[TransformSymbol] as unknown as TransformCodec
+    if (mode === 'decode' && typeof transform.decode === 'function') return transform.decode(value)
+    if (mode === 'encode' && typeof transform.encode === 'function') return transform.encode(value)
+    return value
+  } catch (error) {
+    throw new ValueTransformCodecError(schema, value, mode, error)
+  }
+}
+// --------------------------------------------------------------------------
+// Guards
+// --------------------------------------------------------------------------
+function HasTransform(schema: Types.TSchema): schema is Types.TSchema & { [TransformSymbol]: TransformCodec } {
+  return ValueGuard.HasPropertyKey(schema, TransformSymbol)
+}
+// ----------------------------------------------------------------------------------------------
+// Transform
+// ----------------------------------------------------------------------------------------------
+function TAny(schema: Types.TAny, references: Types.TSchema[], value: any, mode: ValueTransformMode): any {
+  return Apply(schema, value, mode)
+}
+function TArray(schema: Types.TArray, references: Types.TSchema[], value: any, mode: ValueTransformMode): any {
+  if (ValueGuard.IsArray(value)) {
+    const inner = value.map((value) => Visit(schema.items, references, value, mode))
+    return Apply(schema, inner, mode)
+  }
+  throw new ValueTransformFallthroughError(schema, value, mode)
+}
+function TBigInt(schema: Types.TBigInt, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TBoolean(schema: Types.TBoolean, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TConstructor(schema: Types.TConstructor, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TDate(schema: Types.TDate, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TFunction(schema: Types.TFunction, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TInteger(schema: Types.TInteger, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TIntersect(schema: Types.TIntersect, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TLiteral(schema: Types.TLiteral, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TNever(schema: Types.TNever, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TNull(schema: Types.TNull, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TNumber(schema: Types.TNumber, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TObject(schema: Types.TObject, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Object.keys(schema.properties).reduce((acc, key) => {
+    return value[key] !== undefined ? { ...acc, [key]: Visit(schema.properties[key], references, value[key], mode) } : { ...acc }
+  }, value)
+}
+function TPromise(schema: Types.TSchema, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TRecord(schema: Types.TRecord<any, any>, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  const propertyKey = Object.getOwnPropertyNames(schema.patternProperties)[0]
+  const property = schema.patternProperties[propertyKey]
+  const result = {} as Record<string, unknown>
+  for (const [propKey, propValue] of Object.entries(value)) {
+    result[propKey] = Visit(property, references, propValue, mode)
+  }
+  return Apply(schema, result, mode)
+}
+function TRef(schema: Types.TRef<any>, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  const index = references.findIndex((foreign) => foreign.$id === schema.$ref)
+  if (index === -1) throw new ValueTransformDereferenceError(schema)
+  const target = references[index]
+  const resolved = Visit(target, references, value, mode)
+  return Apply(schema, resolved, mode)
+}
+function TString(schema: Types.TString, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TSymbol(schema: Types.TSymbol, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TTemplateLiteral(schema: Types.TTemplateLiteral, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TThis(schema: Types.TThis, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  const index = references.findIndex((foreign) => foreign.$id === schema.$ref)
+  if (index === -1) throw new ValueTransformDereferenceError(schema)
+  const target = references[index]
+  const resolved = Visit(target, references, value, mode)
+  return Apply(schema, resolved, mode)
+}
+function TTuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  if (ValueGuard.IsArray(value)) return value
+  if (!ValueGuard.IsUndefined(schema.items)) return value
+  // prettier-ignore
+  return Apply(schema, value.map((value: any, index: any) => {
+    return index < schema.items!.length ? Visit(schema.items![index], references, value, mode) : value
+  }), mode)
+}
+function TUndefined(schema: Types.TUndefined, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TUnion(schema: Types.TUnion, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  for (const subschema of schema.anyOf) {
+    const inner = Visit(subschema, references, value, mode)
+    if (ValueCheck.Check(subschema, references, inner)) {
+      return Apply(schema, inner, mode)
+    }
+  }
+  throw new ValueTransformFallthroughError(schema, value, mode)
+}
+function TUint8Array(schema: Types.TUint8Array, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TUnknown(schema: Types.TUnknown, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TVoid(schema: Types.TVoid, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+function TUserDefined(schema: Types.TSchema, references: Types.TSchema[], value: any, mode: ValueTransformMode) {
+  return Apply(schema, value, mode)
+}
+export function Visit(schema: Types.TSchema, references: Types.TSchema[], value: any, mode: ValueTransformMode): any {
+  const references_ = ValueGuard.IsString(schema.$id) ? [...references, schema] : references
+  const schema_ = schema as any
+  switch (schema[Types.Kind]) {
+    case 'Any':
+      return TAny(schema_, references_, value, mode)
+    case 'Array':
+      return TArray(schema_, references_, value, mode)
+    case 'BigInt':
+      return TBigInt(schema_, references_, value, mode)
+    case 'Boolean':
+      return TBoolean(schema_, references_, value, mode)
+    case 'Constructor':
+      return TConstructor(schema_, references_, value, mode)
+    case 'Date':
+      return TDate(schema_, references_, value, mode)
+    case 'Function':
+      return TFunction(schema_, references_, value, mode)
+    case 'Integer':
+      return TInteger(schema_, references_, value, mode)
+    case 'Intersect':
+      return TIntersect(schema_, references_, value, mode)
+    case 'Literal':
+      return TLiteral(schema_, references_, value, mode)
+    case 'Never':
+      return TNever(schema_, references_, value, mode)
+    case 'Null':
+      return TNull(schema_, references_, value, mode)
+    case 'Number':
+      return TNumber(schema_, references_, value, mode)
+    case 'Object':
+      return TObject(schema_, references_, value, mode)
+    case 'Promise':
+      return TPromise(schema_, references_, value, mode)
+    case 'Record':
+      return TRecord(schema_, references_, value, mode)
+    case 'Ref':
+      return TRef(schema_, references_, value, mode)
+    case 'String':
+      return TString(schema_, references_, value, mode)
+    case 'Symbol':
+      return TSymbol(schema_, references_, value, mode)
+    case 'TemplateLiteral':
+      return TTemplateLiteral(schema_, references_, value, mode)
+    case 'This':
+      return TThis(schema_, references_, value, mode)
+    case 'Tuple':
+      return TTuple(schema_, references_, value, mode)
+    case 'Undefined':
+      return TUndefined(schema_, references_, value, mode)
+    case 'Union':
+      return TUnion(schema_, references_, value, mode)
+    case 'Uint8Array':
+      return TUint8Array(schema_, references_, value, mode)
+    case 'Unknown':
+      return TUnknown(schema_, references_, value, mode)
+    case 'Void':
+      return TVoid(schema_, references_, value, mode)
+    default:
+      if (!Types.TypeRegistry.Has(schema_[Types.Kind])) throw new ValueTransformUnknownTypeError(schema_)
+      return TUserDefined(schema_, references_, value, mode)
+  }
+}
+// --------------------------------------------------------------------------
+// Transform Unwrap
+// --------------------------------------------------------------------------
+// prettier-ignore
+export type TransformUnwrapProperties<T extends Types.TProperties> = {
+  [K in keyof T]: TransformUnwrap<T[K]>
+}
+// prettier-ignore
+export type TransformUnwrapRest<T extends Types.TSchema[]> = T extends [infer L, ...infer R]
+  ? [TransformUnwrap<Types.AssertType<L>>, ...TransformUnwrapRest<Types.AssertRest<R>>]
+  : []
+// prettier-ignore
+export type TransformUnwrap<T extends Types.TSchema> =
+  T extends TTransform<infer _, infer R> ? Types.TUnsafe<R> : 
+  T extends Types.TConstructor<infer P, infer R> ? Types.TConstructor<Types.AssertRest<TransformUnwrapRest<P>>, TransformUnwrap<R>> :
+  T extends Types.TFunction<infer P, infer R> ? Types.TFunction<Types.AssertRest<TransformUnwrapRest<P>>, TransformUnwrap<R>> :
+  T extends Types.TIntersect<infer S> ? Types.TIntersect<Types.AssertRest<TransformUnwrapRest<S>>> :
+  T extends Types.TUnion<infer S> ? Types.TUnion<Types.AssertRest<TransformUnwrapRest<S>>> :
+  T extends Types.TNot<infer S> ? Types.TNot<TransformUnwrap<S>> :
+  T extends Types.TTuple<infer S> ? Types.TTuple<Types.AssertRest<TransformUnwrapRest<S>>> :
+  T extends Types.TAsyncIterator<infer S> ? Types.TAsyncIterator<TransformUnwrap<S>> :
+  T extends Types.TIterator<infer S> ? Types.TIterator<TransformUnwrap<S>> :
+  T extends Types.TObject<infer S> ? Types.TObject<Types.Evaluate<TransformUnwrapProperties<S>>> :
+  T extends Types.TRecord<infer K, infer S> ? Types.TRecord<K, TransformUnwrap<S>> :
+  T extends Types.TArray<infer S> ? Types.TArray<TransformUnwrap<S>> :
+  T extends Types.TPromise<infer S> ? Types.TPromise<TransformUnwrap<S>> :
+  T
+// --------------------------------------------------------------------------
+// Transform Types
+// --------------------------------------------------------------------------
+export type TransformFunction<T = any, U = any> = (value: T) => U
+
+export interface TransformCodec<Input extends Types.TSchema = Types.TSchema, Output extends unknown = unknown> {
+  decode: TransformFunction<Types.Static<Input>, Output>
+  encode: TransformFunction<Output, Types.Static<Input>>
+}
+export interface TTransform<Input extends Types.TSchema = Types.TSchema, Output extends unknown = unknown> extends Types.TSchema {
+  static: Types.Static<Input>
+  [TransformSymbol]: TransformCodec<Input, Output>
+  [key: string]: any
+}
+// --------------------------------------------------------------------------
+// Transform Functions
+// --------------------------------------------------------------------------
+/** Creates a transform type by applying transform codec */
+export function Transform<
+  Input extends Types.TSchema, 
+  Output extends unknown
+>(schema: Input, codec: TransformCodec<Input, Output>): TTransform<Input, Output> {
+  if (!HasTransform(schema)) return { ...schema, [TransformSymbol]: codec } as TTransform<Input, Output>
+  const mapped_encode = (value: unknown) => codec.encode(schema[TransformSymbol].encode(value) as any)
+  const mapped_decode = (value: unknown) => codec.decode(schema[TransformSymbol].decode(value))
+  const mapped_codec = { encode: mapped_encode, decode: mapped_decode }
+  return { ...schema, [TransformSymbol]: mapped_codec } as TTransform<Input, Output>
+}
+/** Decodes a value using the given type. Will apply an transform codecs found for any sub type */
+export function Decode<T extends Types.TSchema>(schema: T, references: Types.TSchema[], value: Types.Static<T>): Types.Static<TransformUnwrap<T>>
+/** Decodes a value using the given type. Will apply an transform codecs found for any sub type */
+export function Decode<T extends Types.TSchema>(schema: T, value: Types.Static<T>): Types.Static<TransformUnwrap<T>>
+/** Decodes a value using the given type. Will apply an transform codecs found for any sub type */
+export function Decode(...args: any[]) {
+  const [schema, references, value] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], [], args[1]]
+  const check = ValueCheck.Check(schema, references, value)
+  if (!check) throw new TransformDecodeError(schema, value)
+  const decoded = Visit(schema, references, value, 'decode')
+  return decoded
+}
+/** Encodes a value using the given type. Will apply an transforms found for any sub type */
+export function Encode<T extends Types.TSchema>(schema: T, references: Types.TSchema[], value: Types.Static<TransformUnwrap<T>>): Types.Static<T>
+/** Encodes a value using the given type. Will apply an transforms found for any sub type */
+export function Encode<T extends Types.TSchema>(schema: T, value: Types.Static<TransformUnwrap<T>>): Types.Static<T>
+/** Encodes a value using the given type. Will apply an transforms found for any sub type */
+export function Encode(...args: any[]) {
+  const [schema, references, value] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], [], args[1]]
+  const encoded = Visit(schema, references, value, 'encode')
+  const check = ValueCheck.Check(schema, references, encoded)
+  if (!check) throw new TransformEncodeError(schema, value)
+  return encoded
+}

--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,11 @@ License MIT
   - [Errors](#values-errors)
   - [Mutate](#values-mutate)
   - [Pointer](#values-pointer)
+  - [Transform](#values-transform)
+- [Transforms](#transforms)
+  - [Types](#transforms-types)
+  - [Decode](#transforms-decode)
+  - [Encode](#transforms-encode)
 - [TypeCheck](#typecheck)
   - [Ajv](#typecheck-ajv)
   - [TypeCompiler](#typecheck-typecompiler)
@@ -1584,26 +1589,15 @@ This benchmark measures validation performance for varying types. You can review
 The following table lists esbuild compiled and minified sizes for each TypeBox module.
 
 ```typescript
-┌───────────────────────┬────────────┬────────────┬─────────────┐
-│        (index)        │  Compiled  │  Minified  │ Compression │
-├───────────────────────┼────────────┼────────────┼─────────────┤
-│ typebox/compiler      │ '128.5 kb' │ ' 58.7 kb' │  '2.19 x'   │
-│ typebox/errors        │ '110.7 kb' │ ' 50.1 kb' │  '2.21 x'   │
-│ typebox/system        │ ' 75.4 kb' │ ' 31.3 kb' │  '2.41 x'   │
-│ typebox/value/cast    │ '123.0 kb' │ ' 51.8 kb' │  '2.37 x'   │
-│ typebox/value/check   │ ' 95.3 kb' │ ' 40.0 kb' │  '2.38 x'   │
-│ typebox/value/clone   │ '  3.0 kb' │ '  1.3 kb' │  '2.23 x'   │
-│ typebox/value/convert │ '108.1 kb' │ ' 45.6 kb' │  '2.37 x'   │
-│ typebox/value/create  │ '108.8 kb' │ ' 46.1 kb' │  '2.36 x'   │
-│ typebox/value/delta   │ ' 85.2 kb' │ ' 35.7 kb' │  '2.38 x'   │
-│ typebox/value/equal   │ '  2.9 kb' │ '  1.5 kb' │  '1.97 x'   │
-│ typebox/value/guard   │ '  2.8 kb' │ '  1.4 kb' │  '1.99 x'   │
-│ typebox/value/hash    │ '  4.1 kb' │ '  1.9 kb' │  '2.09 x'   │
-│ typebox/value/mutate  │ '  8.7 kb' │ '  3.5 kb' │  '2.46 x'   │
-│ typebox/value/pointer │ '  3.2 kb' │ '  1.2 kb' │  '2.61 x'   │
-│ typebox/value         │ '180.6 kb' │ ' 80.2 kb' │  '2.25 x'   │
-│ typebox               │ ' 74.3 kb' │ ' 30.8 kb' │  '2.41 x'   │
-└───────────────────────┴────────────┴────────────┴─────────────┘
+┌──────────────────────┬────────────┬────────────┬─────────────┐
+│       (index)        │  Compiled  │  Minified  │ Compression │
+├──────────────────────┼────────────┼────────────┼─────────────┤
+│ typebox/compiler     │ '128.6 kb' │ ' 58.3 kb' │  '2.20 x'   │
+│ typebox/errors       │ '110.8 kb' │ ' 49.7 kb' │  '2.23 x'   │
+│ typebox/system       │ ' 75.6 kb' │ ' 31.3 kb' │  '2.42 x'   │
+│ typebox/value        │ '191.3 kb' │ ' 83.4 kb' │  '2.29 x'   │
+│ typebox              │ ' 74.5 kb' │ ' 30.8 kb' │  '2.42 x'   │
+└──────────────────────┴────────────┴────────────┴─────────────┘
 ```
 
 <a name='contribute'></a>

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -145,7 +145,7 @@ export namespace TypeCompiler {
     return typeof value === 'bigint'
   }
   function IsNumber(value: unknown): value is number {
-    return typeof value === 'number' && globalThis.Number.isFinite(value)
+    return typeof value === 'number' && Number.isFinite(value)
   }
   function IsString(value: unknown): value is string {
     return typeof value === 'string'
@@ -179,10 +179,10 @@ export namespace TypeCompiler {
   // -------------------------------------------------------------------
   // Types
   // -------------------------------------------------------------------
-  function* Any(schema: Types.TAny, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TAny(schema: Types.TAny, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield 'true'
   }
-  function* Array(schema: Types.TArray, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TArray(schema: Types.TArray, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `Array.isArray(${value})`
     const [parameter, accumulator] = [CreateParameter('value', 'any'), CreateParameter('acc', 'number')]
     if (IsNumber(schema.minItems)) yield `${value}.length >= ${schema.minItems}`
@@ -204,10 +204,10 @@ export namespace TypeCompiler {
       yield `((${parameter}) => { ${block} )(${value})`
     }
   }
-  function* AsyncIterator(schema: Types.TAsyncIterator, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TAsyncIterator(schema: Types.TAsyncIterator, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof value === 'object' && Symbol.asyncIterator in ${value})`
   }
-  function* BigInt(schema: Types.TBigInt, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TBigInt(schema: Types.TBigInt, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof ${value} === 'bigint')`
     if (IsBigInt(schema.multipleOf)) yield `(${value} % BigInt(${schema.multipleOf})) === 0`
     if (IsBigInt(schema.exclusiveMinimum)) yield `${value} > BigInt(${schema.exclusiveMinimum})`
@@ -215,23 +215,23 @@ export namespace TypeCompiler {
     if (IsBigInt(schema.minimum)) yield `${value} >= BigInt(${schema.minimum})`
     if (IsBigInt(schema.maximum)) yield `${value} <= BigInt(${schema.maximum})`
   }
-  function* Boolean(schema: Types.TBoolean, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TBoolean(schema: Types.TBoolean, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof ${value} === 'boolean')`
   }
-  function* Constructor(schema: Types.TConstructor, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TConstructor(schema: Types.TConstructor, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield* Visit(schema.returns, references, `${value}.prototype`)
   }
-  function* Date(schema: Types.TDate, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TDate(schema: Types.TDate, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(${value} instanceof Date) && Number.isFinite(${value}.getTime())`
     if (IsNumber(schema.exclusiveMinimumTimestamp)) yield `${value}.getTime() > ${schema.exclusiveMinimumTimestamp}`
     if (IsNumber(schema.exclusiveMaximumTimestamp)) yield `${value}.getTime() < ${schema.exclusiveMaximumTimestamp}`
     if (IsNumber(schema.minimumTimestamp)) yield `${value}.getTime() >= ${schema.minimumTimestamp}`
     if (IsNumber(schema.maximumTimestamp)) yield `${value}.getTime() <= ${schema.maximumTimestamp}`
   }
-  function* Function(schema: Types.TFunction, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TFunction(schema: Types.TFunction, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof ${value} === 'function')`
   }
-  function* Integer(schema: Types.TInteger, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TInteger(schema: Types.TInteger, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof ${value} === 'number' && Number.isInteger(${value}))`
     if (IsNumber(schema.multipleOf)) yield `(${value} % ${schema.multipleOf}) === 0`
     if (IsNumber(schema.exclusiveMinimum)) yield `${value} > ${schema.exclusiveMinimum}`
@@ -239,7 +239,7 @@ export namespace TypeCompiler {
     if (IsNumber(schema.minimum)) yield `${value} >= ${schema.minimum}`
     if (IsNumber(schema.maximum)) yield `${value} <= ${schema.maximum}`
   }
-  function* Intersect(schema: Types.TIntersect, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TIntersect(schema: Types.TIntersect, references: Types.TSchema[], value: string): IterableIterator<string> {
     const check1 = schema.allOf.map((schema: Types.TSchema) => CreateExpression(schema, references, value)).join(' && ')
     if (schema.unevaluatedProperties === false) {
       const keyCheck = PushLocal(`${new RegExp(Types.KeyResolver.ResolvePattern(schema))};`)
@@ -253,27 +253,27 @@ export namespace TypeCompiler {
       yield `(${check1})`
     }
   }
-  function* Iterator(schema: Types.TIterator, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TIterator(schema: Types.TIterator, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof value === 'object' && Symbol.iterator in ${value})`
   }
-  function* Literal(schema: Types.TLiteral, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TLiteral(schema: Types.TLiteral, references: Types.TSchema[], value: string): IterableIterator<string> {
     if (typeof schema.const === 'number' || typeof schema.const === 'boolean') {
       yield `(${value} === ${schema.const})`
     } else {
       yield `(${value} === '${schema.const}')`
     }
   }
-  function* Never(schema: Types.TNever, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TNever(schema: Types.TNever, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `false`
   }
-  function* Not(schema: Types.TNot, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TNot(schema: Types.TNot, references: Types.TSchema[], value: string): IterableIterator<string> {
     const expression = CreateExpression(schema.not, references, value)
     yield `(!${expression})`
   }
-  function* Null(schema: Types.TNull, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TNull(schema: Types.TNull, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(${value} === null)`
   }
-  function* Number(schema: Types.TNumber, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TNumber(schema: Types.TNumber, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield IsNumberCheck(value)
     if (IsNumber(schema.multipleOf)) yield `(${value} % ${schema.multipleOf}) === 0`
     if (IsNumber(schema.exclusiveMinimum)) yield `${value} > ${schema.exclusiveMinimum}`
@@ -281,11 +281,11 @@ export namespace TypeCompiler {
     if (IsNumber(schema.minimum)) yield `${value} >= ${schema.minimum}`
     if (IsNumber(schema.maximum)) yield `${value} <= ${schema.maximum}`
   }
-  function* Object(schema: Types.TObject, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TObject(schema: Types.TObject, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield IsObjectCheck(value)
     if (IsNumber(schema.minProperties)) yield `Object.getOwnPropertyNames(${value}).length >= ${schema.minProperties}`
     if (IsNumber(schema.maxProperties)) yield `Object.getOwnPropertyNames(${value}).length <= ${schema.maxProperties}`
-    const knownKeys = globalThis.Object.getOwnPropertyNames(schema.properties)
+    const knownKeys = Object.getOwnPropertyNames(schema.properties)
     for (const knownKey of knownKeys) {
       const memberExpression = MemberExpression.Encode(value, knownKey)
       const property = schema.properties[knownKey]
@@ -311,21 +311,21 @@ export namespace TypeCompiler {
       yield `(Object.getOwnPropertyNames(${value}).every(key => ${keys}.includes(key) || ${expression}))`
     }
   }
-  function* Promise(schema: Types.TPromise<any>, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TPromise(schema: Types.TPromise<any>, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof value === 'object' && typeof ${value}.then === 'function')`
   }
-  function* Record(schema: Types.TRecord<any, any>, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TRecord(schema: Types.TRecord<any, any>, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield IsRecordCheck(value)
     if (IsNumber(schema.minProperties)) yield `Object.getOwnPropertyNames(${value}).length >= ${schema.minProperties}`
     if (IsNumber(schema.maxProperties)) yield `Object.getOwnPropertyNames(${value}).length <= ${schema.maxProperties}`
-    const [patternKey, patternSchema] = globalThis.Object.entries(schema.patternProperties)[0]
+    const [patternKey, patternSchema] = Object.entries(schema.patternProperties)[0]
     const local = PushLocal(`new RegExp(/${patternKey}/)`)
     const check1 = CreateExpression(patternSchema, references, 'value')
     const check2 = Types.TypeGuard.TSchema(schema.additionalProperties) ? CreateExpression(schema.additionalProperties, references, value) : schema.additionalProperties === false ? 'false' : 'true'
     const expression = `(${local}.test(key) ? ${check1} : ${check2})`
     yield `(Object.entries(${value}).every(([key, value]) => ${expression}))`
   }
-  function* Ref(schema: Types.TRef<any>, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TRef(schema: Types.TRef<any>, references: Types.TSchema[], value: string): IterableIterator<string> {
     const index = references.findIndex((foreign) => foreign.$id === schema.$ref)
     if (index === -1) throw new TypeCompilerDereferenceError(schema)
     const target = references[index]
@@ -334,7 +334,7 @@ export namespace TypeCompiler {
     if (state.functions.has(schema.$ref)) return yield `${CreateFunctionName(schema.$ref)}(${value})`
     yield* Visit(target, references, value)
   }
-  function* String(schema: Types.TString, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TString(schema: Types.TString, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof ${value} === 'string')`
     if (IsNumber(schema.minLength)) yield `${value}.length >= ${schema.minLength}`
     if (IsNumber(schema.maxLength)) yield `${value}.length <= ${schema.maxLength}`
@@ -346,19 +346,19 @@ export namespace TypeCompiler {
       yield `format('${schema.format}', ${value})`
     }
   }
-  function* Symbol(schema: Types.TSymbol, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TSymbol(schema: Types.TSymbol, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof ${value} === 'symbol')`
   }
-  function* TemplateLiteral(schema: Types.TTemplateLiteral, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TTemplateLiteral(schema: Types.TTemplateLiteral, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `(typeof ${value} === 'string')`
     const local = PushLocal(`${new RegExp(schema.pattern)};`)
     yield `${local}.test(${value})`
   }
-  function* This(schema: Types.TThis, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TThis(schema: Types.TThis, references: Types.TSchema[], value: string): IterableIterator<string> {
     const func = CreateFunctionName(schema.$ref)
     yield `${func}(${value})`
   }
-  function* Tuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TTuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `Array.isArray(${value})`
     if (schema.items === undefined) return yield `${value}.length === 0`
     yield `(${value}.length === ${schema.maxItems})`
@@ -367,25 +367,25 @@ export namespace TypeCompiler {
       yield `${expression}`
     }
   }
-  function* Undefined(schema: Types.TUndefined, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TUndefined(schema: Types.TUndefined, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `${value} === undefined`
   }
-  function* Union(schema: Types.TUnion<any[]>, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TUnion(schema: Types.TUnion<any[]>, references: Types.TSchema[], value: string): IterableIterator<string> {
     const expressions = schema.anyOf.map((schema: Types.TSchema) => CreateExpression(schema, references, value))
     yield `(${expressions.join(' || ')})`
   }
-  function* Uint8Array(schema: Types.TUint8Array, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TUint8Array(schema: Types.TUint8Array, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield `${value} instanceof Uint8Array`
     if (IsNumber(schema.maxByteLength)) yield `(${value}.length <= ${schema.maxByteLength})`
     if (IsNumber(schema.minByteLength)) yield `(${value}.length >= ${schema.minByteLength})`
   }
-  function* Unknown(schema: Types.TUnknown, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TUnknown(schema: Types.TUnknown, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield 'true'
   }
-  function* Void(schema: Types.TVoid, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TVoid(schema: Types.TVoid, references: Types.TSchema[], value: string): IterableIterator<string> {
     yield IsVoidCheck(value)
   }
-  function* UserDefined(schema: Types.TSchema, references: Types.TSchema[], value: string): IterableIterator<string> {
+  function* TUserDefined(schema: Types.TSchema, references: Types.TSchema[], value: string): IterableIterator<string> {
     const schema_key = `schema_key_${state.customs.size}`
     state.customs.set(schema_key, schema)
     yield `custom('${schema[Types.Kind]}', '${schema_key}', ${value})`
@@ -409,68 +409,68 @@ export namespace TypeCompiler {
     }
     switch (schema_[Types.Kind]) {
       case 'Any':
-        return yield* Any(schema_, references_, value)
+        return yield* TAny(schema_, references_, value)
       case 'Array':
-        return yield* Array(schema_, references_, value)
+        return yield* TArray(schema_, references_, value)
       case 'AsyncIterator':
-        return yield* AsyncIterator(schema_, references_, value)
+        return yield* TAsyncIterator(schema_, references_, value)
       case 'BigInt':
-        return yield* BigInt(schema_, references_, value)
+        return yield* TBigInt(schema_, references_, value)
       case 'Boolean':
-        return yield* Boolean(schema_, references_, value)
+        return yield* TBoolean(schema_, references_, value)
       case 'Constructor':
-        return yield* Constructor(schema_, references_, value)
+        return yield* TConstructor(schema_, references_, value)
       case 'Date':
-        return yield* Date(schema_, references_, value)
+        return yield* TDate(schema_, references_, value)
       case 'Function':
-        return yield* Function(schema_, references_, value)
+        return yield* TFunction(schema_, references_, value)
       case 'Integer':
-        return yield* Integer(schema_, references_, value)
+        return yield* TInteger(schema_, references_, value)
       case 'Intersect':
-        return yield* Intersect(schema_, references_, value)
+        return yield* TIntersect(schema_, references_, value)
       case 'Iterator':
-        return yield* Iterator(schema_, references_, value)
+        return yield* TIterator(schema_, references_, value)
       case 'Literal':
-        return yield* Literal(schema_, references_, value)
+        return yield* TLiteral(schema_, references_, value)
       case 'Never':
-        return yield* Never(schema_, references_, value)
+        return yield* TNever(schema_, references_, value)
       case 'Not':
-        return yield* Not(schema_, references_, value)
+        return yield* TNot(schema_, references_, value)
       case 'Null':
-        return yield* Null(schema_, references_, value)
+        return yield* TNull(schema_, references_, value)
       case 'Number':
-        return yield* Number(schema_, references_, value)
+        return yield* TNumber(schema_, references_, value)
       case 'Object':
-        return yield* Object(schema_, references_, value)
+        return yield* TObject(schema_, references_, value)
       case 'Promise':
-        return yield* Promise(schema_, references_, value)
+        return yield* TPromise(schema_, references_, value)
       case 'Record':
-        return yield* Record(schema_, references_, value)
+        return yield* TRecord(schema_, references_, value)
       case 'Ref':
-        return yield* Ref(schema_, references_, value)
+        return yield* TRef(schema_, references_, value)
       case 'String':
-        return yield* String(schema_, references_, value)
+        return yield* TString(schema_, references_, value)
       case 'Symbol':
-        return yield* Symbol(schema_, references_, value)
+        return yield* TSymbol(schema_, references_, value)
       case 'TemplateLiteral':
-        return yield* TemplateLiteral(schema_, references_, value)
+        return yield* TTemplateLiteral(schema_, references_, value)
       case 'This':
-        return yield* This(schema_, references_, value)
+        return yield* TThis(schema_, references_, value)
       case 'Tuple':
-        return yield* Tuple(schema_, references_, value)
+        return yield* TTuple(schema_, references_, value)
       case 'Undefined':
-        return yield* Undefined(schema_, references_, value)
+        return yield* TUndefined(schema_, references_, value)
       case 'Union':
-        return yield* Union(schema_, references_, value)
+        return yield* TUnion(schema_, references_, value)
       case 'Uint8Array':
-        return yield* Uint8Array(schema_, references_, value)
+        return yield* TUint8Array(schema_, references_, value)
       case 'Unknown':
-        return yield* Unknown(schema_, references_, value)
+        return yield* TUnknown(schema_, references_, value)
       case 'Void':
-        return yield* Void(schema_, references_, value)
+        return yield* TVoid(schema_, references_, value)
       default:
         if (!Types.TypeRegistry.Has(schema_[Types.Kind])) throw new TypeCompilerUnknownTypeError(schema)
-        return yield* UserDefined(schema_, references_, value)
+        return yield* TUserDefined(schema_, references_, value)
     }
   }
   // -------------------------------------------------------------------

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -27,9 +27,9 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import * as Types from '../typebox'
+import { TypeSystem } from '../system/index'
 import * as ValueHash from '../value/hash'
 import * as ValueGuard from '../value/guard'
-import { TypeSystem } from '../system/index'
 
 // --------------------------------------------------------------------------
 // ValueErrorType
@@ -115,7 +115,7 @@ export interface ValueError {
 // --------------------------------------------------------------------------
 export class ValueErrorIterator {
   constructor(private readonly iterator: IterableIterator<ValueError>) {}
-  public [globalThis.Symbol.iterator]() {
+  public [Symbol.iterator]() {
     return this.iterator
   }
   /** Returns the first value error or undefined if no errors */
@@ -154,11 +154,11 @@ function IsObject(value: unknown): value is Record<keyof any, unknown> {
   return TypeSystem.AllowArrayObjects ? isObject : isObject && !ValueGuard.IsArray(value)
 }
 function IsRecordObject(value: unknown): value is Record<keyof any, unknown> {
-  return IsObject(value) && !(value instanceof globalThis.Date) && !(value instanceof globalThis.Uint8Array)
+  return IsObject(value) && !(value instanceof Date) && !(value instanceof Uint8Array)
 }
 function IsNumber(value: unknown): value is number {
   const isNumber = ValueGuard.IsNumber(value)
-  return TypeSystem.AllowNaN ? isNumber : isNumber && globalThis.Number.isFinite(value)
+  return TypeSystem.AllowNaN ? isNumber : isNumber && Number.isFinite(value)
 }
 function IsVoid(value: unknown): value is void {
   const isUndefined = ValueGuard.IsUndefined(value)
@@ -167,8 +167,8 @@ function IsVoid(value: unknown): value is void {
 // --------------------------------------------------------------------------
 // Types
 // --------------------------------------------------------------------------
-function* Any(schema: Types.TAny, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {}
-function* Array(schema: Types.TArray, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TAny(schema: Types.TAny, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {}
+function* TArray(schema: Types.TArray, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsArray(value)) {
     return yield { type: ValueErrorType.Array, schema, path, value, message: `Expected array` }
   }
@@ -202,16 +202,16 @@ function* Array(schema: Types.TArray, references: Types.TSchema[], path: string,
     yield { type: ValueErrorType.ArrayMaxContains, schema, path, value, message: `Expected array to contain no more than ${schema.maxContains} matching types` }
   }
 }
-function* AsyncIterator(schema: Types.TAsyncIterator, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TAsyncIterator(schema: Types.TAsyncIterator, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsAsyncIterator(value)) {
     yield { type: ValueErrorType.AsyncIterator, schema, path, value, message: `Expected value to be an async iterator` }
   }
 }
-function* BigInt(schema: Types.TBigInt, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TBigInt(schema: Types.TBigInt, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsBigInt(value)) {
     return yield { type: ValueErrorType.BigInt, schema, path, value, message: `Expected bigint` }
   }
-  if (IsDefined<bigint>(schema.multipleOf) && !(value % schema.multipleOf === globalThis.BigInt(0))) {
+  if (IsDefined<bigint>(schema.multipleOf) && !(value % schema.multipleOf === BigInt(0))) {
     yield { type: ValueErrorType.BigIntMultipleOf, schema, path, value, message: `Expected bigint to be a multiple of ${schema.multipleOf}` }
   }
   if (IsDefined<bigint>(schema.exclusiveMinimum) && !(value > schema.exclusiveMinimum)) {
@@ -227,19 +227,19 @@ function* BigInt(schema: Types.TBigInt, references: Types.TSchema[], path: strin
     yield { type: ValueErrorType.BigIntMaximum, schema, path, value, message: `Expected bigint to be less or equal to ${schema.maximum}` }
   }
 }
-function* Boolean(schema: Types.TBoolean, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TBoolean(schema: Types.TBoolean, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsBoolean(value)) {
     return yield { type: ValueErrorType.Boolean, schema, path, value, message: `Expected boolean` }
   }
 }
-function* Constructor(schema: Types.TConstructor, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TConstructor(schema: Types.TConstructor, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   yield* Visit(schema.returns, references, path, value.prototype)
 }
-function* Date(schema: Types.TDate, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TDate(schema: Types.TDate, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsDate(value)) {
     return yield { type: ValueErrorType.Date, schema, path, value, message: `Expected Date object` }
   }
-  if (!globalThis.isFinite(value.getTime())) {
+  if (!isFinite(value.getTime())) {
     return yield { type: ValueErrorType.Date, schema, path, value, message: `Invalid Date` }
   }
   if (IsDefined<number>(schema.exclusiveMinimumTimestamp) && !(value.getTime() > schema.exclusiveMinimumTimestamp)) {
@@ -255,12 +255,12 @@ function* Date(schema: Types.TDate, references: Types.TSchema[], path: string, v
     yield { type: ValueErrorType.DateMaximumTimestamp, schema, path, value, message: `Expected Date timestamp to be less or equal to ${schema.maximum}` }
   }
 }
-function* Function(schema: Types.TFunction, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TFunction(schema: Types.TFunction, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsFunction(value)) {
     return yield { type: ValueErrorType.Function, schema, path, value, message: `Expected function` }
   }
 }
-function* Integer(schema: Types.TInteger, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TInteger(schema: Types.TInteger, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsInteger(value)) {
     return yield { type: ValueErrorType.Integer, schema, path, value, message: `Expected integer` }
   }
@@ -280,7 +280,7 @@ function* Integer(schema: Types.TInteger, references: Types.TSchema[], path: str
     yield { type: ValueErrorType.IntegerMaximum, schema, path, value, message: `Expected integer to be less or equal to ${schema.maximum}` }
   }
 }
-function* Intersect(schema: Types.TIntersect, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TIntersect(schema: Types.TIntersect, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   for (const inner of schema.allOf) {
     const next = Visit(inner, references, path, value).next()
     if (!next.done) {
@@ -291,7 +291,7 @@ function* Intersect(schema: Types.TIntersect, references: Types.TSchema[], path:
   }
   if (schema.unevaluatedProperties === false) {
     const keyCheck = new RegExp(Types.KeyResolver.ResolvePattern(schema))
-    for (const valueKey of globalThis.Object.getOwnPropertyNames(value)) {
+    for (const valueKey of Object.getOwnPropertyNames(value)) {
       if (!keyCheck.test(valueKey)) {
         yield { type: ValueErrorType.IntersectUnevaluatedProperties, schema, path: `${path}/${valueKey}`, value, message: `Unexpected property` }
       }
@@ -299,7 +299,7 @@ function* Intersect(schema: Types.TIntersect, references: Types.TSchema[], path:
   }
   if (typeof schema.unevaluatedProperties === 'object') {
     const keyCheck = new RegExp(Types.KeyResolver.ResolvePattern(schema))
-    for (const valueKey of globalThis.Object.getOwnPropertyNames(value)) {
+    for (const valueKey of Object.getOwnPropertyNames(value)) {
       if (!keyCheck.test(valueKey)) {
         const next = Visit(schema.unevaluatedProperties, references, `${path}/${valueKey}`, value[valueKey]).next()
         if (!next.done) {
@@ -311,31 +311,31 @@ function* Intersect(schema: Types.TIntersect, references: Types.TSchema[], path:
     }
   }
 }
-function* Iterator(schema: Types.TIterator, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
-  if (!(IsObject(value) && globalThis.Symbol.iterator in value)) {
+function* TIterator(schema: Types.TIterator, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+  if (!(IsObject(value) && Symbol.iterator in value)) {
     yield { type: ValueErrorType.Iterator, schema, path, value, message: `Expected value to be an iterator` }
   }
 }
-function* Literal(schema: Types.TLiteral, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TLiteral(schema: Types.TLiteral, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!(value === schema.const)) {
     const error = typeof schema.const === 'string' ? `'${schema.const}'` : schema.const
     return yield { type: ValueErrorType.Literal, schema, path, value, message: `Expected ${error}` }
   }
 }
-function* Never(schema: Types.TNever, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TNever(schema: Types.TNever, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   yield { type: ValueErrorType.Never, schema, path, value, message: `Value cannot be validated` }
 }
-function* Not(schema: Types.TNot, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TNot(schema: Types.TNot, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (Visit(schema.not, references, path, value).next().done === true) {
     yield { type: ValueErrorType.Not, schema, path, value, message: `Value should not validate` }
   }
 }
-function* Null(schema: Types.TNull, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TNull(schema: Types.TNull, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsNull(value)) {
     return yield { type: ValueErrorType.Null, schema, path, value, message: `Expected null` }
   }
 }
-function* Number(schema: Types.TNumber, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TNumber(schema: Types.TNumber, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!IsNumber(value)) {
     return yield { type: ValueErrorType.Number, schema, path, value, message: `Expected number` }
   }
@@ -355,19 +355,19 @@ function* Number(schema: Types.TNumber, references: Types.TSchema[], path: strin
     yield { type: ValueErrorType.NumberMaximum, schema, path, value, message: `Expected number to be less or equal to ${schema.maximum}` }
   }
 }
-function* Object(schema: Types.TObject, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TObject(schema: Types.TObject, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!IsObject(value)) {
     return yield { type: ValueErrorType.Object, schema, path, value, message: `Expected object` }
   }
-  if (IsDefined<number>(schema.minProperties) && !(globalThis.Object.getOwnPropertyNames(value).length >= schema.minProperties)) {
+  if (IsDefined<number>(schema.minProperties) && !(Object.getOwnPropertyNames(value).length >= schema.minProperties)) {
     yield { type: ValueErrorType.ObjectMinProperties, schema, path, value, message: `Expected object to have at least ${schema.minProperties} properties` }
   }
-  if (IsDefined<number>(schema.maxProperties) && !(globalThis.Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
+  if (IsDefined<number>(schema.maxProperties) && !(Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
     yield { type: ValueErrorType.ObjectMaxProperties, schema, path, value, message: `Expected object to have no more than ${schema.maxProperties} properties` }
   }
-  const requiredKeys = globalThis.Array.isArray(schema.required) ? schema.required : ([] as string[])
-  const knownKeys = globalThis.Object.getOwnPropertyNames(schema.properties)
-  const unknownKeys = globalThis.Object.getOwnPropertyNames(value)
+  const requiredKeys = Array.isArray(schema.required) ? schema.required : ([] as string[])
+  const knownKeys = Object.getOwnPropertyNames(schema.properties)
+  const unknownKeys = Object.getOwnPropertyNames(value)
   for (const knownKey of knownKeys) {
     const property = schema.properties[knownKey]
     if (schema.required && schema.required.includes(knownKey)) {
@@ -399,24 +399,24 @@ function* Object(schema: Types.TObject, references: Types.TSchema[], path: strin
     }
   }
 }
-function* Promise(schema: Types.TPromise, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TPromise(schema: Types.TPromise, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsPromise(value)) {
     yield { type: ValueErrorType.Promise, schema, path, value, message: `Expected Promise` }
   }
 }
-function* Record(schema: Types.TRecord, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TRecord(schema: Types.TRecord, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!IsRecordObject(value)) {
     return yield { type: ValueErrorType.Object, schema, path, value, message: `Expected record object` }
   }
-  if (IsDefined<number>(schema.minProperties) && !(globalThis.Object.getOwnPropertyNames(value).length >= schema.minProperties)) {
+  if (IsDefined<number>(schema.minProperties) && !(Object.getOwnPropertyNames(value).length >= schema.minProperties)) {
     yield { type: ValueErrorType.ObjectMinProperties, schema, path, value, message: `Expected object to have at least ${schema.minProperties} properties` }
   }
-  if (IsDefined<number>(schema.maxProperties) && !(globalThis.Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
+  if (IsDefined<number>(schema.maxProperties) && !(Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
     yield { type: ValueErrorType.ObjectMaxProperties, schema, path, value, message: `Expected object to have no more than ${schema.maxProperties} properties` }
   }
-  const [patternKey, patternSchema] = globalThis.Object.entries(schema.patternProperties)[0]
+  const [patternKey, patternSchema] = Object.entries(schema.patternProperties)[0]
   const regex = new RegExp(patternKey)
-  for (const [propertyKey, propertyValue] of globalThis.Object.entries(value)) {
+  for (const [propertyKey, propertyValue] of Object.entries(value)) {
     if (regex.test(propertyKey)) {
       yield* Visit(patternSchema, references, `${path}/${propertyKey}`, propertyValue)
       continue
@@ -431,13 +431,13 @@ function* Record(schema: Types.TRecord, references: Types.TSchema[], path: strin
     }
   }
 }
-function* Ref(schema: Types.TRef<any>, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TRef(schema: Types.TRef<any>, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   const index = references.findIndex((foreign) => foreign.$id === schema.$ref)
   if (index === -1) throw new ValueErrorsDereferenceError(schema)
   const target = references[index]
   yield* Visit(target, references, path, value)
 }
-function* String(schema: Types.TString, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TString(schema: Types.TString, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsString(value)) {
     return yield { type: ValueErrorType.String, schema, path, value, message: 'Expected string' }
   }
@@ -464,12 +464,12 @@ function* String(schema: Types.TString, references: Types.TSchema[], path: strin
     }
   }
 }
-function* Symbol(schema: Types.TSymbol, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TSymbol(schema: Types.TSymbol, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsSymbol(value)) {
     return yield { type: ValueErrorType.Symbol, schema, path, value, message: 'Expected symbol' }
   }
 }
-function* TemplateLiteral(schema: Types.TTemplateLiteral, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TTemplateLiteral(schema: Types.TTemplateLiteral, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsString(value)) {
     return yield { type: ValueErrorType.String, schema, path, value, message: 'Expected string' }
   }
@@ -478,14 +478,14 @@ function* TemplateLiteral(schema: Types.TTemplateLiteral, references: Types.TSch
     yield { type: ValueErrorType.StringPattern, schema, path, value, message: `Expected string to match pattern ${schema.pattern}` }
   }
 }
-function* This(schema: Types.TThis, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TThis(schema: Types.TThis, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   const index = references.findIndex((foreign) => foreign.$id === schema.$ref)
   if (index === -1) throw new ValueErrorsDereferenceError(schema)
   const target = references[index]
   yield* Visit(target, references, path, value)
 }
-function* Tuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
-  if (!globalThis.Array.isArray(value)) {
+function* TTuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+  if (!ValueGuard.IsArray(value)) {
     return yield { type: ValueErrorType.Array, schema, path, value, message: 'Expected Array' }
   }
   if (schema.items === undefined && !(value.length === 0)) {
@@ -501,12 +501,12 @@ function* Tuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], path: 
     yield* Visit(schema.items[i], references, `${path}/${i}`, value[i])
   }
 }
-function* Undefined(schema: Types.TUndefined, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TUndefined(schema: Types.TUndefined, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!(value === undefined)) {
     yield { type: ValueErrorType.Undefined, schema, path, value, message: `Expected undefined` }
   }
 }
-function* Union(schema: Types.TUnion, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TUnion(schema: Types.TUnion, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   const errors: ValueError[] = []
   for (const inner of schema.anyOf) {
     const variantErrors = [...Visit(inner, references, path, value)]
@@ -520,7 +520,7 @@ function* Union(schema: Types.TUnion, references: Types.TSchema[], path: string,
     yield error
   }
 }
-function* Uint8Array(schema: Types.TUint8Array, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TUint8Array(schema: Types.TUint8Array, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!ValueGuard.IsUint8Array(value)) {
     return yield { type: ValueErrorType.Uint8Array, schema, path, value, message: `Expected Uint8Array` }
   }
@@ -531,13 +531,13 @@ function* Uint8Array(schema: Types.TUint8Array, references: Types.TSchema[], pat
     yield { type: ValueErrorType.Uint8ArrayMinByteLength, schema, path, value, message: `Expected Uint8Array to have a byte length greater or equal to ${schema.maxByteLength}` }
   }
 }
-function* Unknown(schema: Types.TUnknown, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {}
-function* Void(schema: Types.TVoid, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TUnknown(schema: Types.TUnknown, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {}
+function* TVoid(schema: Types.TVoid, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   if (!IsVoid(value)) {
     return yield { type: ValueErrorType.Void, schema, path, value, message: `Expected void` }
   }
 }
-function* UserDefined(schema: Types.TSchema, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
+function* TUserDefined(schema: Types.TSchema, references: Types.TSchema[], path: string, value: any): IterableIterator<ValueError> {
   const check = Types.TypeRegistry.Get(schema[Types.Kind])!
   if (!check(schema, value)) {
     return yield { type: ValueErrorType.Custom, schema, path, value, message: `Expected kind ${schema[Types.Kind]}` }
@@ -548,68 +548,68 @@ function* Visit<T extends Types.TSchema>(schema: T, references: Types.TSchema[],
   const schema_ = schema as any
   switch (schema_[Types.Kind]) {
     case 'Any':
-      return yield* Any(schema_, references_, path, value)
+      return yield* TAny(schema_, references_, path, value)
     case 'Array':
-      return yield* Array(schema_, references_, path, value)
+      return yield* TArray(schema_, references_, path, value)
     case 'AsyncIterator':
-      return yield* AsyncIterator(schema_, references_, path, value)
+      return yield* TAsyncIterator(schema_, references_, path, value)
     case 'BigInt':
-      return yield* BigInt(schema_, references_, path, value)
+      return yield* TBigInt(schema_, references_, path, value)
     case 'Boolean':
-      return yield* Boolean(schema_, references_, path, value)
+      return yield* TBoolean(schema_, references_, path, value)
     case 'Constructor':
-      return yield* Constructor(schema_, references_, path, value)
+      return yield* TConstructor(schema_, references_, path, value)
     case 'Date':
-      return yield* Date(schema_, references_, path, value)
+      return yield* TDate(schema_, references_, path, value)
     case 'Function':
-      return yield* Function(schema_, references_, path, value)
+      return yield* TFunction(schema_, references_, path, value)
     case 'Integer':
-      return yield* Integer(schema_, references_, path, value)
+      return yield* TInteger(schema_, references_, path, value)
     case 'Intersect':
-      return yield* Intersect(schema_, references_, path, value)
+      return yield* TIntersect(schema_, references_, path, value)
     case 'Iterator':
-      return yield* Iterator(schema_, references_, path, value)
+      return yield* TIterator(schema_, references_, path, value)
     case 'Literal':
-      return yield* Literal(schema_, references_, path, value)
+      return yield* TLiteral(schema_, references_, path, value)
     case 'Never':
-      return yield* Never(schema_, references_, path, value)
+      return yield* TNever(schema_, references_, path, value)
     case 'Not':
-      return yield* Not(schema_, references_, path, value)
+      return yield* TNot(schema_, references_, path, value)
     case 'Null':
-      return yield* Null(schema_, references_, path, value)
+      return yield* TNull(schema_, references_, path, value)
     case 'Number':
-      return yield* Number(schema_, references_, path, value)
+      return yield* TNumber(schema_, references_, path, value)
     case 'Object':
-      return yield* Object(schema_, references_, path, value)
+      return yield* TObject(schema_, references_, path, value)
     case 'Promise':
-      return yield* Promise(schema_, references_, path, value)
+      return yield* TPromise(schema_, references_, path, value)
     case 'Record':
-      return yield* Record(schema_, references_, path, value)
+      return yield* TRecord(schema_, references_, path, value)
     case 'Ref':
-      return yield* Ref(schema_, references_, path, value)
+      return yield* TRef(schema_, references_, path, value)
     case 'String':
-      return yield* String(schema_, references_, path, value)
+      return yield* TString(schema_, references_, path, value)
     case 'Symbol':
-      return yield* Symbol(schema_, references_, path, value)
+      return yield* TSymbol(schema_, references_, path, value)
     case 'TemplateLiteral':
-      return yield* TemplateLiteral(schema_, references_, path, value)
+      return yield* TTemplateLiteral(schema_, references_, path, value)
     case 'This':
-      return yield* This(schema_, references_, path, value)
+      return yield* TThis(schema_, references_, path, value)
     case 'Tuple':
-      return yield* Tuple(schema_, references_, path, value)
+      return yield* TTuple(schema_, references_, path, value)
     case 'Undefined':
-      return yield* Undefined(schema_, references_, path, value)
+      return yield* TUndefined(schema_, references_, path, value)
     case 'Union':
-      return yield* Union(schema_, references_, path, value)
+      return yield* TUnion(schema_, references_, path, value)
     case 'Uint8Array':
-      return yield* Uint8Array(schema_, references_, path, value)
+      return yield* TUint8Array(schema_, references_, path, value)
     case 'Unknown':
-      return yield* Unknown(schema_, references_, path, value)
+      return yield* TUnknown(schema_, references_, path, value)
     case 'Void':
-      return yield* Void(schema_, references_, path, value)
+      return yield* TVoid(schema_, references_, path, value)
     default:
       if (!Types.TypeRegistry.Has(schema_[Types.Kind])) throw new ValueErrorsUnknownTypeError(schema)
-      return yield* UserDefined(schema_, references_, path, value)
+      return yield* TUserDefined(schema_, references_, path, value)
   }
 }
 /** Returns an iterator for each error in this value. */

--- a/src/value/cast.ts
+++ b/src/value/cast.ts
@@ -76,8 +76,8 @@ namespace UnionCastCreate {
   function Score(schema: Types.TSchema, references: Types.TSchema[], value: any): number {
     if (schema[Types.Kind] === 'Object' && typeof value === 'object' && !ValueGuard.IsNull(value)) {
       const object = schema as Types.TObject
-      const keys = globalThis.Object.getOwnPropertyNames(value)
-      const entries = globalThis.Object.entries(object.properties)
+      const keys = Object.getOwnPropertyNames(value)
+      const entries = Object.entries(object.properties)
       const [point, max] = [1 / entries.length, entries.length]
       return entries.reduce((acc, [key, schema]) => {
         const literal = schema[Types.Kind] === 'Literal' && schema.const === value[key] ? max : 0
@@ -112,13 +112,13 @@ namespace UnionCastCreate {
 // --------------------------------------------------------------------------
 // Cast
 // --------------------------------------------------------------------------
-function Any(schema: Types.TAny, references: Types.TSchema[], value: any): any {
+function TAny(schema: Types.TAny, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
 }
-function Array(schema: Types.TArray, references: Types.TSchema[], value: any): any {
+function TArray(schema: Types.TArray, references: Types.TSchema[], value: any): any {
   if (ValueCheck.Check(schema, references, value)) return ValueClone.Clone(value)
   const created = ValueGuard.IsArray(value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
-  const minimum = ValueGuard.IsNumber(schema.minItems) && created.length < schema.minItems ? [...created, ...globalThis.Array.from({ length: schema.minItems - created.length }, () => null)] : created
+  const minimum = ValueGuard.IsNumber(schema.minItems) && created.length < schema.minItems ? [...created, ...Array.from({ length: schema.minItems - created.length }, () => null)] : created
   const maximum = ValueGuard.IsNumber(schema.maxItems) && minimum.length > schema.maxItems ? minimum.slice(0, schema.maxItems) : minimum
   const casted = maximum.map((value: unknown) => Visit(schema.items, references, value))
   if (schema.uniqueItems !== true) return casted
@@ -126,133 +126,133 @@ function Array(schema: Types.TArray, references: Types.TSchema[], value: any): a
   if (!ValueCheck.Check(schema, references, unique)) throw new ValueCastArrayUniqueItemsTypeError(schema, unique)
   return unique
 }
-function AsyncIterator(schema: Types.TAsyncIterator, references: Types.TSchema[], value: any): any {
+function TAsyncIterator(schema: Types.TAsyncIterator, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
 }
-function BigInt(schema: Types.TBigInt, references: Types.TSchema[], value: any): any {
+function TBigInt(schema: Types.TBigInt, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
 }
-function Boolean(schema: Types.TBoolean, references: Types.TSchema[], value: any): any {
+function TBoolean(schema: Types.TBoolean, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
 }
-function Constructor(schema: Types.TConstructor, references: Types.TSchema[], value: any): any {
+function TConstructor(schema: Types.TConstructor, references: Types.TSchema[], value: any): any {
   if (ValueCheck.Check(schema, references, value)) return ValueCreate.Create(schema, references)
   const required = new Set(schema.returns.required || [])
   const result = function () {}
-  for (const [key, property] of globalThis.Object.entries(schema.returns.properties)) {
+  for (const [key, property] of Object.entries(schema.returns.properties)) {
     if (!required.has(key) && value.prototype[key] === undefined) continue
     result.prototype[key] = Visit(property as Types.TSchema, references, value.prototype[key])
   }
   return result
 }
-function Date(schema: Types.TDate, references: Types.TSchema[], value: any): any {
+function TDate(schema: Types.TDate, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
 }
-function Function(schema: Types.TFunction, references: Types.TSchema[], value: any): any {
+function TFunction(schema: Types.TFunction, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
 }
-function Integer(schema: Types.TInteger, references: Types.TSchema[], value: any): any {
+function TInteger(schema: Types.TInteger, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
 }
-function Intersect(schema: Types.TIntersect, references: Types.TSchema[], value: any): any {
+function TIntersect(schema: Types.TIntersect, references: Types.TSchema[], value: any): any {
   const created = ValueCreate.Create(schema, references)
   const mapped = ValueGuard.IsPlainObject(created) && ValueGuard.IsPlainObject(value) ? { ...(created as any), ...value } : value
   return ValueCheck.Check(schema, references, mapped) ? mapped : ValueCreate.Create(schema, references)
 }
-function Iterator(schema: Types.TIterator, references: Types.TSchema[], value: any): any {
+function TIterator(schema: Types.TIterator, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
 }
-function Literal(schema: Types.TLiteral, references: Types.TSchema[], value: any): any {
+function TLiteral(schema: Types.TLiteral, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
 }
-function Never(schema: Types.TNever, references: Types.TSchema[], value: any): any {
+function TNever(schema: Types.TNever, references: Types.TSchema[], value: any): any {
   throw new ValueCastNeverTypeError(schema)
 }
-function Not(schema: Types.TNot, references: Types.TSchema[], value: any): any {
+function TNot(schema: Types.TNot, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
 }
-function Null(schema: Types.TNull, references: Types.TSchema[], value: any): any {
+function TNull(schema: Types.TNull, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
 }
-function Number(schema: Types.TNumber, references: Types.TSchema[], value: any): any {
+function TNumber(schema: Types.TNumber, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
 }
-function Object(schema: Types.TObject, references: Types.TSchema[], value: any): any {
+function TObject(schema: Types.TObject, references: Types.TSchema[], value: any): any {
   if (ValueCheck.Check(schema, references, value)) return value
   if (value === null || typeof value !== 'object') return ValueCreate.Create(schema, references)
   const required = new Set(schema.required || [])
   const result = {} as Record<string, any>
-  for (const [key, property] of globalThis.Object.entries(schema.properties)) {
+  for (const [key, property] of Object.entries(schema.properties)) {
     if (!required.has(key) && value[key] === undefined) continue
     result[key] = Visit(property, references, value[key])
   }
   // additional schema properties
   if (typeof schema.additionalProperties === 'object') {
-    const propertyNames = globalThis.Object.getOwnPropertyNames(schema.properties)
-    for (const propertyName of globalThis.Object.getOwnPropertyNames(value)) {
+    const propertyNames = Object.getOwnPropertyNames(schema.properties)
+    for (const propertyName of Object.getOwnPropertyNames(value)) {
       if (propertyNames.includes(propertyName)) continue
       result[propertyName] = Visit(schema.additionalProperties, references, value[propertyName])
     }
   }
   return result
 }
-function Promise(schema: Types.TSchema, references: Types.TSchema[], value: any): any {
+function TPromise(schema: Types.TSchema, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
 }
-function Record(schema: Types.TRecord<any, any>, references: Types.TSchema[], value: any): any {
+function TRecord(schema: Types.TRecord<any, any>, references: Types.TSchema[], value: any): any {
   if (ValueCheck.Check(schema, references, value)) return ValueClone.Clone(value)
-  if (value === null || typeof value !== 'object' || globalThis.Array.isArray(value) || value instanceof globalThis.Date) return ValueCreate.Create(schema, references)
-  const subschemaPropertyName = globalThis.Object.getOwnPropertyNames(schema.patternProperties)[0]
+  if (value === null || typeof value !== 'object' || Array.isArray(value) || value instanceof Date) return ValueCreate.Create(schema, references)
+  const subschemaPropertyName = Object.getOwnPropertyNames(schema.patternProperties)[0]
   const subschema = schema.patternProperties[subschemaPropertyName]
   const result = {} as Record<string, any>
-  for (const [propKey, propValue] of globalThis.Object.entries(value)) {
+  for (const [propKey, propValue] of Object.entries(value)) {
     result[propKey] = Visit(subschema, references, propValue)
   }
   return result
 }
-function Ref(schema: Types.TRef<any>, references: Types.TSchema[], value: any): any {
+function TRef(schema: Types.TRef<any>, references: Types.TSchema[], value: any): any {
   const index = references.findIndex((foreign) => foreign.$id === schema.$ref)
   if (index === -1) throw new ValueCastDereferenceError(schema)
   const target = references[index]
   return Visit(target, references, value)
 }
-function String(schema: Types.TString, references: Types.TSchema[], value: any): any {
+function TString(schema: Types.TString, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? value : ValueCreate.Create(schema, references)
 }
-function Symbol(schema: Types.TSymbol, references: Types.TSchema[], value: any): any {
+function TSymbol(schema: Types.TSymbol, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
 }
-function TemplateLiteral(schema: Types.TSymbol, references: Types.TSchema[], value: any): any {
+function TTemplateLiteral(schema: Types.TSymbol, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
 }
-function This(schema: Types.TThis, references: Types.TSchema[], value: any): any {
+function TThis(schema: Types.TThis, references: Types.TSchema[], value: any): any {
   const index = references.findIndex((foreign) => foreign.$id === schema.$ref)
   if (index === -1) throw new ValueCastDereferenceError(schema)
   const target = references[index]
   return Visit(target, references, value)
 }
-function Tuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], value: any): any {
+function TTuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], value: any): any {
   if (ValueCheck.Check(schema, references, value)) return ValueClone.Clone(value)
   if (!ValueGuard.IsArray(value)) return ValueCreate.Create(schema, references)
   if (schema.items === undefined) return []
   return schema.items.map((schema, index) => Visit(schema, references, value[index]))
 }
-function Undefined(schema: Types.TUndefined, references: Types.TSchema[], value: any): any {
+function TUndefined(schema: Types.TUndefined, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
 }
-function Union(schema: Types.TUnion, references: Types.TSchema[], value: any): any {
+function TUnion(schema: Types.TUnion, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : UnionCastCreate.Create(schema, references, value)
 }
-function Uint8Array(schema: Types.TUint8Array, references: Types.TSchema[], value: any): any {
+function TUint8Array(schema: Types.TUint8Array, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
 }
-function Unknown(schema: Types.TUnknown, references: Types.TSchema[], value: any): any {
+function TUnknown(schema: Types.TUnknown, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
 }
-function Void(schema: Types.TVoid, references: Types.TSchema[], value: any): any {
+function TVoid(schema: Types.TVoid, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
 }
-function UserDefined(schema: Types.TSchema, references: Types.TSchema[], value: any): any {
+function TUserDefined(schema: Types.TSchema, references: Types.TSchema[], value: any): any {
   return ValueCheck.Check(schema, references, value) ? ValueClone.Clone(value) : ValueCreate.Create(schema, references)
 }
 export function Visit(schema: Types.TSchema, references: Types.TSchema[], value: any): any {
@@ -260,68 +260,68 @@ export function Visit(schema: Types.TSchema, references: Types.TSchema[], value:
   const schema_ = schema as any
   switch (schema[Types.Kind]) {
     case 'Any':
-      return Any(schema_, references_, value)
+      return TAny(schema_, references_, value)
     case 'Array':
-      return Array(schema_, references_, value)
+      return TArray(schema_, references_, value)
     case 'AsyncIterator':
-      return AsyncIterator(schema_, references_, value)
+      return TAsyncIterator(schema_, references_, value)
     case 'BigInt':
-      return BigInt(schema_, references_, value)
+      return TBigInt(schema_, references_, value)
     case 'Boolean':
-      return Boolean(schema_, references_, value)
+      return TBoolean(schema_, references_, value)
     case 'Constructor':
-      return Constructor(schema_, references_, value)
+      return TConstructor(schema_, references_, value)
     case 'Date':
-      return Date(schema_, references_, value)
+      return TDate(schema_, references_, value)
     case 'Function':
-      return Function(schema_, references_, value)
+      return TFunction(schema_, references_, value)
     case 'Integer':
-      return Integer(schema_, references_, value)
+      return TInteger(schema_, references_, value)
     case 'Intersect':
-      return Intersect(schema_, references_, value)
+      return TIntersect(schema_, references_, value)
     case 'Iterator':
-      return Iterator(schema_, references_, value)
+      return TIterator(schema_, references_, value)
     case 'Literal':
-      return Literal(schema_, references_, value)
+      return TLiteral(schema_, references_, value)
     case 'Never':
-      return Never(schema_, references_, value)
+      return TNever(schema_, references_, value)
     case 'Not':
-      return Not(schema_, references_, value)
+      return TNot(schema_, references_, value)
     case 'Null':
-      return Null(schema_, references_, value)
+      return TNull(schema_, references_, value)
     case 'Number':
-      return Number(schema_, references_, value)
+      return TNumber(schema_, references_, value)
     case 'Object':
-      return Object(schema_, references_, value)
+      return TObject(schema_, references_, value)
     case 'Promise':
-      return Promise(schema_, references_, value)
+      return TPromise(schema_, references_, value)
     case 'Record':
-      return Record(schema_, references_, value)
+      return TRecord(schema_, references_, value)
     case 'Ref':
-      return Ref(schema_, references_, value)
+      return TRef(schema_, references_, value)
     case 'String':
-      return String(schema_, references_, value)
+      return TString(schema_, references_, value)
     case 'Symbol':
-      return Symbol(schema_, references_, value)
+      return TSymbol(schema_, references_, value)
     case 'TemplateLiteral':
-      return TemplateLiteral(schema_, references_, value)
+      return TTemplateLiteral(schema_, references_, value)
     case 'This':
-      return This(schema_, references_, value)
+      return TThis(schema_, references_, value)
     case 'Tuple':
-      return Tuple(schema_, references_, value)
+      return TTuple(schema_, references_, value)
     case 'Undefined':
-      return Undefined(schema_, references_, value)
+      return TUndefined(schema_, references_, value)
     case 'Union':
-      return Union(schema_, references_, value)
+      return TUnion(schema_, references_, value)
     case 'Uint8Array':
-      return Uint8Array(schema_, references_, value)
+      return TUint8Array(schema_, references_, value)
     case 'Unknown':
-      return Unknown(schema_, references_, value)
+      return TUnknown(schema_, references_, value)
     case 'Void':
-      return Void(schema_, references_, value)
+      return TVoid(schema_, references_, value)
     default:
       if (!Types.TypeRegistry.Has(schema_[Types.Kind])) throw new ValueCastUnknownTypeError(schema_)
-      return UserDefined(schema_, references_, value)
+      return TUserDefined(schema_, references_, value)
   }
 }
 // --------------------------------------------------------------------------

--- a/src/value/check.ts
+++ b/src/value/check.ts
@@ -67,11 +67,11 @@ function IsObject(value: unknown): value is Record<keyof any, unknown> {
   return TypeSystem.AllowArrayObjects ? isObject : isObject && !ValueGuard.IsArray(value)
 }
 function IsRecordObject(value: unknown): value is Record<keyof any, unknown> {
-  return IsObject(value) && !(value instanceof globalThis.Date) && !(value instanceof globalThis.Uint8Array)
+  return IsObject(value) && !(value instanceof Date) && !(value instanceof Uint8Array)
 }
 function IsNumber(value: unknown): value is number {
   const isNumber = ValueGuard.IsNumber(value)
-  return TypeSystem.AllowNaN ? isNumber : isNumber && globalThis.Number.isFinite(value)
+  return TypeSystem.AllowNaN ? isNumber : isNumber && Number.isFinite(value)
 }
 function IsVoid(value: unknown): value is void {
   const isUndefined = ValueGuard.IsUndefined(value)
@@ -80,11 +80,11 @@ function IsVoid(value: unknown): value is void {
 // --------------------------------------------------------------------------
 // Types
 // --------------------------------------------------------------------------
-function Any(schema: Types.TAny, references: Types.TSchema[], value: any): boolean {
+function TAny(schema: Types.TAny, references: Types.TSchema[], value: any): boolean {
   return true
 }
-function Array(schema: Types.TArray, references: Types.TSchema[], value: any): boolean {
-  if (!globalThis.Array.isArray(value)) {
+function TArray(schema: Types.TArray, references: Types.TSchema[], value: any): boolean {
+  if (!Array.isArray(value)) {
     return false
   }
   if (IsDefined<number>(schema.minItems) && !(value.length >= schema.minItems)) {
@@ -117,14 +117,14 @@ function Array(schema: Types.TArray, references: Types.TSchema[], value: any): b
   }
   return true
 }
-function AsyncIterator(schema: Types.TAsyncIterator, references: Types.TSchema[], value: any): boolean {
-  return IsObject(value) && globalThis.Symbol.asyncIterator in value
+function TAsyncIterator(schema: Types.TAsyncIterator, references: Types.TSchema[], value: any): boolean {
+  return IsObject(value) && Symbol.asyncIterator in value
 }
-function BigInt(schema: Types.TBigInt, references: Types.TSchema[], value: any): boolean {
+function TBigInt(schema: Types.TBigInt, references: Types.TSchema[], value: any): boolean {
   if (!ValueGuard.IsBigInt(value)) {
     return false
   }
-  if (IsDefined<bigint>(schema.multipleOf) && !(value % schema.multipleOf === globalThis.BigInt(0))) {
+  if (IsDefined<bigint>(schema.multipleOf) && !(value % schema.multipleOf === BigInt(0))) {
     return false
   }
   if (IsDefined<bigint>(schema.exclusiveMinimum) && !(value > schema.exclusiveMinimum)) {
@@ -141,14 +141,14 @@ function BigInt(schema: Types.TBigInt, references: Types.TSchema[], value: any):
   }
   return true
 }
-function Boolean(schema: Types.TBoolean, references: Types.TSchema[], value: any): boolean {
+function TBoolean(schema: Types.TBoolean, references: Types.TSchema[], value: any): boolean {
   return typeof value === 'boolean'
 }
-function Constructor(schema: Types.TConstructor, references: Types.TSchema[], value: any): boolean {
+function TConstructor(schema: Types.TConstructor, references: Types.TSchema[], value: any): boolean {
   return Visit(schema.returns, references, value.prototype)
 }
-function Date(schema: Types.TDate, references: Types.TSchema[], value: any): boolean {
-  if (!(value instanceof globalThis.Date)) {
+function TDate(schema: Types.TDate, references: Types.TSchema[], value: any): boolean {
+  if (!(value instanceof Date)) {
     return false
   }
   if (!IsNumber(value.getTime())) {
@@ -168,10 +168,10 @@ function Date(schema: Types.TDate, references: Types.TSchema[], value: any): boo
   }
   return true
 }
-function Function(schema: Types.TFunction, references: Types.TSchema[], value: any): boolean {
+function TFunction(schema: Types.TFunction, references: Types.TSchema[], value: any): boolean {
   return typeof value === 'function'
 }
-function Integer(schema: Types.TInteger, references: Types.TSchema[], value: any): boolean {
+function TInteger(schema: Types.TInteger, references: Types.TSchema[], value: any): boolean {
   if (!ValueGuard.IsInteger(value)) {
     return false
   }
@@ -192,36 +192,36 @@ function Integer(schema: Types.TInteger, references: Types.TSchema[], value: any
   }
   return true
 }
-function Intersect(schema: Types.TIntersect, references: Types.TSchema[], value: any): boolean {
+function TIntersect(schema: Types.TIntersect, references: Types.TSchema[], value: any): boolean {
   const check1 = schema.allOf.every((schema) => Visit(schema, references, value))
   if (schema.unevaluatedProperties === false) {
     const keyPattern = new RegExp(Types.KeyResolver.ResolvePattern(schema))
-    const check2 = globalThis.Object.getOwnPropertyNames(value).every((key) => keyPattern.test(key))
+    const check2 = Object.getOwnPropertyNames(value).every((key) => keyPattern.test(key))
     return check1 && check2
   } else if (Types.TypeGuard.TSchema(schema.unevaluatedProperties)) {
     const keyCheck = new RegExp(Types.KeyResolver.ResolvePattern(schema))
-    const check2 = globalThis.Object.getOwnPropertyNames(value).every((key) => keyCheck.test(key) || Visit(schema.unevaluatedProperties as Types.TSchema, references, value[key]))
+    const check2 = Object.getOwnPropertyNames(value).every((key) => keyCheck.test(key) || Visit(schema.unevaluatedProperties as Types.TSchema, references, value[key]))
     return check1 && check2
   } else {
     return check1
   }
 }
-function Iterator(schema: Types.TIterator, references: Types.TSchema[], value: any): boolean {
-  return IsObject(value) && globalThis.Symbol.iterator in value
+function TIterator(schema: Types.TIterator, references: Types.TSchema[], value: any): boolean {
+  return IsObject(value) && Symbol.iterator in value
 }
-function Literal(schema: Types.TLiteral, references: Types.TSchema[], value: any): boolean {
+function TLiteral(schema: Types.TLiteral, references: Types.TSchema[], value: any): boolean {
   return value === schema.const
 }
-function Never(schema: Types.TNever, references: Types.TSchema[], value: any): boolean {
+function TNever(schema: Types.TNever, references: Types.TSchema[], value: any): boolean {
   return false
 }
-function Not(schema: Types.TNot, references: Types.TSchema[], value: any): boolean {
+function TNot(schema: Types.TNot, references: Types.TSchema[], value: any): boolean {
   return !Visit(schema.not, references, value)
 }
-function Null(schema: Types.TNull, references: Types.TSchema[], value: any): boolean {
+function TNull(schema: Types.TNull, references: Types.TSchema[], value: any): boolean {
   return value === null
 }
-function Number(schema: Types.TNumber, references: Types.TSchema[], value: any): boolean {
+function TNumber(schema: Types.TNumber, references: Types.TSchema[], value: any): boolean {
   if (!IsNumber(value)) {
     return false
   }
@@ -242,17 +242,17 @@ function Number(schema: Types.TNumber, references: Types.TSchema[], value: any):
   }
   return true
 }
-function Object(schema: Types.TObject, references: Types.TSchema[], value: any): boolean {
+function TObject(schema: Types.TObject, references: Types.TSchema[], value: any): boolean {
   if (!IsObject(value)) {
     return false
   }
-  if (IsDefined<number>(schema.minProperties) && !(globalThis.Object.getOwnPropertyNames(value).length >= schema.minProperties)) {
+  if (IsDefined<number>(schema.minProperties) && !(Object.getOwnPropertyNames(value).length >= schema.minProperties)) {
     return false
   }
-  if (IsDefined<number>(schema.maxProperties) && !(globalThis.Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
+  if (IsDefined<number>(schema.maxProperties) && !(Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
     return false
   }
-  const knownKeys = globalThis.Object.getOwnPropertyNames(schema.properties)
+  const knownKeys = Object.getOwnPropertyNames(schema.properties)
   for (const knownKey of knownKeys) {
     const property = schema.properties[knownKey]
     if (schema.required && schema.required.includes(knownKey)) {
@@ -269,7 +269,7 @@ function Object(schema: Types.TObject, references: Types.TSchema[], value: any):
     }
   }
   if (schema.additionalProperties === false) {
-    const valueKeys = globalThis.Object.getOwnPropertyNames(value)
+    const valueKeys = Object.getOwnPropertyNames(value)
     // optimization: value is valid if schemaKey length matches the valueKey length
     if (schema.required && schema.required.length === knownKeys.length && valueKeys.length === knownKeys.length) {
       return true
@@ -277,28 +277,28 @@ function Object(schema: Types.TObject, references: Types.TSchema[], value: any):
       return valueKeys.every((valueKey) => knownKeys.includes(valueKey))
     }
   } else if (typeof schema.additionalProperties === 'object') {
-    const valueKeys = globalThis.Object.getOwnPropertyNames(value)
+    const valueKeys = Object.getOwnPropertyNames(value)
     return valueKeys.every((key) => knownKeys.includes(key) || Visit(schema.additionalProperties as Types.TSchema, references, value[key]))
   } else {
     return true
   }
 }
-function Promise(schema: Types.TPromise<any>, references: Types.TSchema[], value: any): boolean {
+function TPromise(schema: Types.TPromise<any>, references: Types.TSchema[], value: any): boolean {
   return typeof value === 'object' && typeof value.then === 'function'
 }
-function Record(schema: Types.TRecord<any, any>, references: Types.TSchema[], value: any): boolean {
+function TRecord(schema: Types.TRecord<any, any>, references: Types.TSchema[], value: any): boolean {
   if (!IsRecordObject(value)) {
     return false
   }
-  if (IsDefined<number>(schema.minProperties) && !(globalThis.Object.getOwnPropertyNames(value).length >= schema.minProperties)) {
+  if (IsDefined<number>(schema.minProperties) && !(Object.getOwnPropertyNames(value).length >= schema.minProperties)) {
     return false
   }
-  if (IsDefined<number>(schema.maxProperties) && !(globalThis.Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
+  if (IsDefined<number>(schema.maxProperties) && !(Object.getOwnPropertyNames(value).length <= schema.maxProperties)) {
     return false
   }
-  const [patternKey, patternSchema] = globalThis.Object.entries(schema.patternProperties)[0]
+  const [patternKey, patternSchema] = Object.entries(schema.patternProperties)[0]
   const regex = new RegExp(patternKey)
-  return globalThis.Object.entries(value).every(([key, value]) => {
+  return Object.entries(value).every(([key, value]) => {
     if (regex.test(key)) {
       return Visit(patternSchema, references, value)
     }
@@ -311,13 +311,13 @@ function Record(schema: Types.TRecord<any, any>, references: Types.TSchema[], va
     return true
   })
 }
-function Ref(schema: Types.TRef<any>, references: Types.TSchema[], value: any): boolean {
+function TRef(schema: Types.TRef<any>, references: Types.TSchema[], value: any): boolean {
   const index = references.findIndex((foreign) => foreign.$id === schema.$ref)
   if (index === -1) throw new ValueCheckDereferenceError(schema)
   const target = references[index]
   return Visit(target, references, value)
 }
-function String(schema: Types.TString, references: Types.TSchema[], value: any): boolean {
+function TString(schema: Types.TString, references: Types.TSchema[], value: any): boolean {
   if (!ValueGuard.IsString(value)) {
     return false
   }
@@ -338,26 +338,26 @@ function String(schema: Types.TString, references: Types.TSchema[], value: any):
   }
   return true
 }
-function Symbol(schema: Types.TSymbol, references: Types.TSchema[], value: any): boolean {
+function TSymbol(schema: Types.TSymbol, references: Types.TSchema[], value: any): boolean {
   if (!(typeof value === 'symbol')) {
     return false
   }
   return true
 }
-function TemplateLiteral(schema: Types.TTemplateLiteralKind, references: Types.TSchema[], value: any): boolean {
+function TTemplateLiteral(schema: Types.TTemplateLiteralKind, references: Types.TSchema[], value: any): boolean {
   if (!ValueGuard.IsString(value)) {
     return false
   }
   return new RegExp(schema.pattern).test(value)
 }
-function This(schema: Types.TThis, references: Types.TSchema[], value: any): boolean {
+function TThis(schema: Types.TThis, references: Types.TSchema[], value: any): boolean {
   const index = references.findIndex((foreign) => foreign.$id === schema.$ref)
   if (index === -1) throw new ValueCheckDereferenceError(schema)
   const target = references[index]
   return Visit(target, references, value)
 }
-function Tuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], value: any): boolean {
-  if (!globalThis.Array.isArray(value)) {
+function TTuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], value: any): boolean {
+  if (!ValueGuard.IsArray(value)) {
     return false
   }
   if (schema.items === undefined && !(value.length === 0)) {
@@ -374,14 +374,14 @@ function Tuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], value: 
   }
   return true
 }
-function Undefined(schema: Types.TUndefined, references: Types.TSchema[], value: any): boolean {
+function TUndefined(schema: Types.TUndefined, references: Types.TSchema[], value: any): boolean {
   return value === undefined
 }
-function Union(schema: Types.TUnion<any[]>, references: Types.TSchema[], value: any): boolean {
+function TUnion(schema: Types.TUnion<any[]>, references: Types.TSchema[], value: any): boolean {
   return schema.anyOf.some((inner) => Visit(inner, references, value))
 }
-function Uint8Array(schema: Types.TUint8Array, references: Types.TSchema[], value: any): boolean {
-  if (!(value instanceof globalThis.Uint8Array)) {
+function TUint8Array(schema: Types.TUint8Array, references: Types.TSchema[], value: any): boolean {
+  if (!(value instanceof Uint8Array)) {
     return false
   }
   if (IsDefined<number>(schema.maxByteLength) && !(value.length <= schema.maxByteLength)) {
@@ -392,13 +392,13 @@ function Uint8Array(schema: Types.TUint8Array, references: Types.TSchema[], valu
   }
   return true
 }
-function Unknown(schema: Types.TUnknown, references: Types.TSchema[], value: any): boolean {
+function TUnknown(schema: Types.TUnknown, references: Types.TSchema[], value: any): boolean {
   return true
 }
-function Void(schema: Types.TVoid, references: Types.TSchema[], value: any): boolean {
+function TVoid(schema: Types.TVoid, references: Types.TSchema[], value: any): boolean {
   return IsVoid(value)
 }
-function UserDefined(schema: Types.TSchema, references: Types.TSchema[], value: unknown): boolean {
+function TUserDefined(schema: Types.TSchema, references: Types.TSchema[], value: unknown): boolean {
   if (!Types.TypeRegistry.Has(schema[Types.Kind])) return false
   const func = Types.TypeRegistry.Get(schema[Types.Kind])!
   return func(schema, value)
@@ -408,68 +408,68 @@ function Visit<T extends Types.TSchema>(schema: T, references: Types.TSchema[], 
   const schema_ = schema as any
   switch (schema_[Types.Kind]) {
     case 'Any':
-      return Any(schema_, references_, value)
+      return TAny(schema_, references_, value)
     case 'Array':
-      return Array(schema_, references_, value)
+      return TArray(schema_, references_, value)
     case 'AsyncIterator':
-      return AsyncIterator(schema_, references_, value)
+      return TAsyncIterator(schema_, references_, value)
     case 'BigInt':
-      return BigInt(schema_, references_, value)
+      return TBigInt(schema_, references_, value)
     case 'Boolean':
-      return Boolean(schema_, references_, value)
+      return TBoolean(schema_, references_, value)
     case 'Constructor':
-      return Constructor(schema_, references_, value)
+      return TConstructor(schema_, references_, value)
     case 'Date':
-      return Date(schema_, references_, value)
+      return TDate(schema_, references_, value)
     case 'Function':
-      return Function(schema_, references_, value)
+      return TFunction(schema_, references_, value)
     case 'Integer':
-      return Integer(schema_, references_, value)
+      return TInteger(schema_, references_, value)
     case 'Intersect':
-      return Intersect(schema_, references_, value)
+      return TIntersect(schema_, references_, value)
     case 'Iterator':
-      return Iterator(schema_, references_, value)
+      return TIterator(schema_, references_, value)
     case 'Literal':
-      return Literal(schema_, references_, value)
+      return TLiteral(schema_, references_, value)
     case 'Never':
-      return Never(schema_, references_, value)
+      return TNever(schema_, references_, value)
     case 'Not':
-      return Not(schema_, references_, value)
+      return TNot(schema_, references_, value)
     case 'Null':
-      return Null(schema_, references_, value)
+      return TNull(schema_, references_, value)
     case 'Number':
-      return Number(schema_, references_, value)
+      return TNumber(schema_, references_, value)
     case 'Object':
-      return Object(schema_, references_, value)
+      return TObject(schema_, references_, value)
     case 'Promise':
-      return Promise(schema_, references_, value)
+      return TPromise(schema_, references_, value)
     case 'Record':
-      return Record(schema_, references_, value)
+      return TRecord(schema_, references_, value)
     case 'Ref':
-      return Ref(schema_, references_, value)
+      return TRef(schema_, references_, value)
     case 'String':
-      return String(schema_, references_, value)
+      return TString(schema_, references_, value)
     case 'Symbol':
-      return Symbol(schema_, references_, value)
+      return TSymbol(schema_, references_, value)
     case 'TemplateLiteral':
-      return TemplateLiteral(schema_, references_, value)
+      return TTemplateLiteral(schema_, references_, value)
     case 'This':
-      return This(schema_, references_, value)
+      return TThis(schema_, references_, value)
     case 'Tuple':
-      return Tuple(schema_, references_, value)
+      return TTuple(schema_, references_, value)
     case 'Undefined':
-      return Undefined(schema_, references_, value)
+      return TUndefined(schema_, references_, value)
     case 'Union':
-      return Union(schema_, references_, value)
+      return TUnion(schema_, references_, value)
     case 'Uint8Array':
-      return Uint8Array(schema_, references_, value)
+      return TUint8Array(schema_, references_, value)
     case 'Unknown':
-      return Unknown(schema_, references_, value)
+      return TUnknown(schema_, references_, value)
     case 'Void':
-      return Void(schema_, references_, value)
+      return TVoid(schema_, references_, value)
     default:
       if (!Types.TypeRegistry.Has(schema_[Types.Kind])) throw new ValueCheckUnknownTypeError(schema_)
-      return UserDefined(schema_, references_, value)
+      return TUserDefined(schema_, references_, value)
   }
 }
 // --------------------------------------------------------------------------

--- a/src/value/clone.ts
+++ b/src/value/clone.ts
@@ -31,35 +31,35 @@ import * as ValueGuard from './guard'
 // --------------------------------------------------------------------------
 // Clonable
 // --------------------------------------------------------------------------
-function Array(value: ValueGuard.ArrayType): any {
-  return value.map((element: any) => Clone(element))
-}
-function Date(value: Date): any {
-  return new globalThis.Date(value.toISOString())
-}
-function Object(value: ValueGuard.ObjectType): any {
-  const keys = [...globalThis.Object.getOwnPropertyNames(value), ...globalThis.Object.getOwnPropertySymbols(value)]
+function ObjectType(value: ValueGuard.ObjectType): any {
+  const keys = [...Object.getOwnPropertyNames(value), ...Object.getOwnPropertySymbols(value)]
   return keys.reduce((acc, key) => ({ ...acc, [key]: Clone(value[key]) }), {})
 }
-function TypedArray(value: ValueGuard.TypedArrayType): any {
+function ArrayType(value: ValueGuard.ArrayType): any {
+  return value.map((element: any) => Clone(element))
+}
+function TypedArrayType(value: ValueGuard.TypedArrayType): any {
   return value.slice()
 }
-function Value(value: ValueGuard.ValueType): any {
+function DateType(value: Date): any {
+  return new Date(value.toISOString())
+}
+function ValueType(value: ValueGuard.ValueType): any {
   return value
 }
 // --------------------------------------------------------------------------
 // Non-Clonable
 // --------------------------------------------------------------------------
-function AsyncIterator(value: AsyncIterableIterator<unknown>): any {
+function AsyncIteratorType(value: AsyncIterableIterator<unknown>): any {
   return value
 }
-function Iterator(value: IterableIterator<unknown>): any {
+function IteratorType(value: IterableIterator<unknown>): any {
   return value
 }
-function Function(value: Function): any {
+function FunctionType(value: Function): any {
   return value
 }
-function Promise(value: Promise<unknown>): any {
+function PromiseType(value: Promise<unknown>): any {
   return value
 }
 // --------------------------------------------------------------------------
@@ -67,14 +67,14 @@ function Promise(value: Promise<unknown>): any {
 // --------------------------------------------------------------------------
 /** Returns a clone of the given value */
 export function Clone<T extends unknown>(value: T): T {
-  if (ValueGuard.IsArray(value)) return Array(value)
-  if (ValueGuard.IsAsyncIterator(value)) return AsyncIterator(value)
-  if (ValueGuard.IsFunction(value)) return Function(value)
-  if (ValueGuard.IsIterator(value)) return Iterator(value)
-  if (ValueGuard.IsPromise(value)) return Promise(value)
-  if (ValueGuard.IsDate(value)) return Date(value)
-  if (ValueGuard.IsPlainObject(value)) return Object(value)
-  if (ValueGuard.IsTypedArray(value)) return TypedArray(value)
-  if (ValueGuard.IsValueType(value)) return Value(value)
+  if (ValueGuard.IsArray(value)) return ArrayType(value)
+  if (ValueGuard.IsAsyncIterator(value)) return AsyncIteratorType(value)
+  if (ValueGuard.IsFunction(value)) return FunctionType(value)
+  if (ValueGuard.IsIterator(value)) return IteratorType(value)
+  if (ValueGuard.IsPromise(value)) return PromiseType(value)
+  if (ValueGuard.IsDate(value)) return DateType(value)
+  if (ValueGuard.IsPlainObject(value)) return ObjectType(value)
+  if (ValueGuard.IsTypedArray(value)) return TypedArrayType(value)
+  if (ValueGuard.IsValueType(value)) return ValueType(value)
   throw new Error('ValueClone: Unable to clone value')
 }

--- a/src/value/convert.ts
+++ b/src/value/convert.ts
@@ -54,10 +54,10 @@ function IsValueToString(value: unknown): value is { toString: () => string } {
   return ValueGuard.IsBigInt(value) || ValueGuard.IsBoolean(value) || ValueGuard.IsNumber(value)
 }
 function IsValueTrue(value: unknown): value is true {
-  return value === true || (ValueGuard.IsNumber(value) && value === 1) || (ValueGuard.IsBigInt(value) && value === globalThis.BigInt('1')) || (ValueGuard.IsString(value) && (value.toLowerCase() === 'true' || value === '1'))
+  return value === true || (ValueGuard.IsNumber(value) && value === 1) || (ValueGuard.IsBigInt(value) && value === BigInt('1')) || (ValueGuard.IsString(value) && (value.toLowerCase() === 'true' || value === '1'))
 }
 function IsValueFalse(value: unknown): value is false {
-  return value === false || (ValueGuard.IsNumber(value) && value === 0) || (ValueGuard.IsBigInt(value) && value === globalThis.BigInt('0')) || (ValueGuard.IsString(value) && (value.toLowerCase() === 'false' || value === '0'))
+  return value === false || (ValueGuard.IsNumber(value) && value === 0) || (ValueGuard.IsBigInt(value) && value === BigInt('0')) || (ValueGuard.IsString(value) && (value.toLowerCase() === 'false' || value === '0'))
 }
 function IsTimeStringWithTimeZone(value: unknown): value is string {
   return ValueGuard.IsString(value) && /^(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)$/i.test(value)
@@ -104,7 +104,7 @@ function TryConvertBoolean(value: unknown) {
   return IsValueTrue(value) ? true : IsValueFalse(value) ? false : value
 }
 function TryConvertBigInt(value: unknown) {
-  return IsStringNumeric(value) ? globalThis.BigInt(parseInt(value)) : ValueGuard.IsNumber(value) ? globalThis.BigInt(value | 0) : IsValueFalse(value) ? 0 : IsValueTrue(value) ? 1 : value
+  return IsStringNumeric(value) ? BigInt(parseInt(value)) : ValueGuard.IsNumber(value) ? BigInt(value | 0) : IsValueFalse(value) ? 0 : IsValueTrue(value) ? 1 : value
 }
 function TryConvertString(value: unknown) {
   return IsValueToString(value) ? value.toString() : ValueGuard.IsSymbol(value) && value.description !== undefined ? value.description.toString() : value
@@ -131,117 +131,117 @@ function TryConvertDate(value: unknown) {
   return ValueGuard.IsDate(value)
     ? value
     : ValueGuard.IsNumber(value)
-    ? new globalThis.Date(value)
+    ? new Date(value)
     : IsValueTrue(value)
-    ? new globalThis.Date(1)
+    ? new Date(1)
     : IsValueFalse(value)
-    ? new globalThis.Date(0)
+    ? new Date(0)
     : IsStringNumeric(value)
-    ? new globalThis.Date(parseInt(value))
+    ? new Date(parseInt(value))
     : IsTimeStringWithoutTimeZone(value)
-    ? new globalThis.Date(`1970-01-01T${value}.000Z`)
+    ? new Date(`1970-01-01T${value}.000Z`)
     : IsTimeStringWithTimeZone(value)
-    ? new globalThis.Date(`1970-01-01T${value}`)
+    ? new Date(`1970-01-01T${value}`)
     : IsDateTimeStringWithoutTimeZone(value)
-    ? new globalThis.Date(`${value}.000Z`)
+    ? new Date(`${value}.000Z`)
     : IsDateTimeStringWithTimeZone(value)
-    ? new globalThis.Date(value)
+    ? new Date(value)
     : IsDateString(value)
-    ? new globalThis.Date(`${value}T00:00:00.000Z`)
+    ? new Date(`${value}T00:00:00.000Z`)
     : value
 }
 // --------------------------------------------------------------------------
 // Cast
 // --------------------------------------------------------------------------
-function Any(schema: Types.TAny, references: Types.TSchema[], value: any): any {
+function TAny(schema: Types.TAny, references: Types.TSchema[], value: any): any {
   return value
 }
-function Array(schema: Types.TArray, references: Types.TSchema[], value: any): any {
+function TArray(schema: Types.TArray, references: Types.TSchema[], value: any): any {
   if (ValueGuard.IsArray(value)) {
     return value.map((value) => Visit(schema.items, references, value))
   }
   return value
 }
-function AsyncIterator(schema: Types.TAsyncIterator, references: Types.TSchema[], value: any): any {
+function TAsyncIterator(schema: Types.TAsyncIterator, references: Types.TSchema[], value: any): any {
   return value
 }
-function BigInt(schema: Types.TBigInt, references: Types.TSchema[], value: any): unknown {
+function TBigInt(schema: Types.TBigInt, references: Types.TSchema[], value: any): unknown {
   return TryConvertBigInt(value)
 }
-function Boolean(schema: Types.TBoolean, references: Types.TSchema[], value: any): unknown {
+function TBoolean(schema: Types.TBoolean, references: Types.TSchema[], value: any): unknown {
   return TryConvertBoolean(value)
 }
-function Constructor(schema: Types.TConstructor, references: Types.TSchema[], value: any): unknown {
+function TConstructor(schema: Types.TConstructor, references: Types.TSchema[], value: any): unknown {
   return ValueClone.Clone(value)
 }
-function Date(schema: Types.TDate, references: Types.TSchema[], value: any): unknown {
+function TDate(schema: Types.TDate, references: Types.TSchema[], value: any): unknown {
   return TryConvertDate(value)
 }
-function Function(schema: Types.TFunction, references: Types.TSchema[], value: any): unknown {
+function TFunction(schema: Types.TFunction, references: Types.TSchema[], value: any): unknown {
   return value
 }
-function Integer(schema: Types.TInteger, references: Types.TSchema[], value: any): unknown {
+function TInteger(schema: Types.TInteger, references: Types.TSchema[], value: any): unknown {
   return TryConvertInteger(value)
 }
-function Intersect(schema: Types.TIntersect, references: Types.TSchema[], value: any): unknown {
+function TIntersect(schema: Types.TIntersect, references: Types.TSchema[], value: any): unknown {
   return value
 }
-function Iterator(schema: Types.TIterator, references: Types.TSchema[], value: any): unknown {
+function TIterator(schema: Types.TIterator, references: Types.TSchema[], value: any): unknown {
   return value
 }
-function Literal(schema: Types.TLiteral, references: Types.TSchema[], value: any): unknown {
+function TLiteral(schema: Types.TLiteral, references: Types.TSchema[], value: any): unknown {
   return TryConvertLiteral(schema, value)
 }
-function Never(schema: Types.TNever, references: Types.TSchema[], value: any): unknown {
+function TNever(schema: Types.TNever, references: Types.TSchema[], value: any): unknown {
   return value
 }
-function Null(schema: Types.TNull, references: Types.TSchema[], value: any): unknown {
+function TNull(schema: Types.TNull, references: Types.TSchema[], value: any): unknown {
   return TryConvertNull(value)
 }
-function Number(schema: Types.TNumber, references: Types.TSchema[], value: any): unknown {
+function TNumber(schema: Types.TNumber, references: Types.TSchema[], value: any): unknown {
   return TryConvertNumber(value)
 }
-function Object(schema: Types.TObject, references: Types.TSchema[], value: any): unknown {
+function TObject(schema: Types.TObject, references: Types.TSchema[], value: any): unknown {
   if (ValueGuard.IsObject(value))
-    return globalThis.Object.keys(schema.properties).reduce((acc, key) => {
+    return Object.getOwnPropertyNames(schema.properties).reduce((acc, key) => {
       return value[key] !== undefined ? { ...acc, [key]: Visit(schema.properties[key], references, value[key]) } : { ...acc }
     }, value)
   return value
 }
-function Promise(schema: Types.TSchema, references: Types.TSchema[], value: any): unknown {
+function TPromise(schema: Types.TSchema, references: Types.TSchema[], value: any): unknown {
   return value
 }
-function Record(schema: Types.TRecord<any, any>, references: Types.TSchema[], value: any): unknown {
-  const propertyKey = globalThis.Object.getOwnPropertyNames(schema.patternProperties)[0]
+function TRecord(schema: Types.TRecord<any, any>, references: Types.TSchema[], value: any): unknown {
+  const propertyKey = Object.getOwnPropertyNames(schema.patternProperties)[0]
   const property = schema.patternProperties[propertyKey]
   const result = {} as Record<string, unknown>
-  for (const [propKey, propValue] of globalThis.Object.entries(value)) {
+  for (const [propKey, propValue] of Object.entries(value)) {
     result[propKey] = Visit(property, references, propValue)
   }
   return result
 }
-function Ref(schema: Types.TRef<any>, references: Types.TSchema[], value: any): unknown {
+function TRef(schema: Types.TRef<any>, references: Types.TSchema[], value: any): unknown {
   const index = references.findIndex((foreign) => foreign.$id === schema.$ref)
   if (index === -1) throw new ValueConvertDereferenceError(schema)
   const target = references[index]
   return Visit(target, references, value)
 }
-function String(schema: Types.TString, references: Types.TSchema[], value: any): unknown {
+function TString(schema: Types.TString, references: Types.TSchema[], value: any): unknown {
   return TryConvertString(value)
 }
-function Symbol(schema: Types.TSymbol, references: Types.TSchema[], value: any): unknown {
+function TSymbol(schema: Types.TSymbol, references: Types.TSchema[], value: any): unknown {
   return value
 }
-function TemplateLiteral(schema: Types.TTemplateLiteral, references: Types.TSchema[], value: any) {
+function TTemplateLiteral(schema: Types.TTemplateLiteral, references: Types.TSchema[], value: any) {
   return value
 }
-function This(schema: Types.TThis, references: Types.TSchema[], value: any): unknown {
+function TThis(schema: Types.TThis, references: Types.TSchema[], value: any): unknown {
   const index = references.findIndex((foreign) => foreign.$id === schema.$ref)
   if (index === -1) throw new ValueConvertDereferenceError(schema)
   const target = references[index]
   return Visit(target, references, value)
 }
-function Tuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], value: any): unknown {
+function TTuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], value: any): unknown {
   if (ValueGuard.IsArray(value) && !ValueGuard.IsUndefined(schema.items)) {
     return value.map((value, index) => {
       return index < schema.items!.length ? Visit(schema.items![index], references, value) : value
@@ -249,10 +249,10 @@ function Tuple(schema: Types.TTuple<any[]>, references: Types.TSchema[], value: 
   }
   return value
 }
-function Undefined(schema: Types.TUndefined, references: Types.TSchema[], value: any): unknown {
+function TUndefined(schema: Types.TUndefined, references: Types.TSchema[], value: any): unknown {
   return TryConvertUndefined(value)
 }
-function Union(schema: Types.TUnion, references: Types.TSchema[], value: any): unknown {
+function TUnion(schema: Types.TUnion, references: Types.TSchema[], value: any): unknown {
   for (const subschema of schema.anyOf) {
     const converted = Visit(subschema, references, value)
     if (ValueCheck.Check(subschema, references, converted)) {
@@ -261,16 +261,16 @@ function Union(schema: Types.TUnion, references: Types.TSchema[], value: any): u
   }
   return value
 }
-function Uint8Array(schema: Types.TUint8Array, references: Types.TSchema[], value: any): unknown {
+function TUint8Array(schema: Types.TUint8Array, references: Types.TSchema[], value: any): unknown {
   return value
 }
-function Unknown(schema: Types.TUnknown, references: Types.TSchema[], value: any): unknown {
+function TUnknown(schema: Types.TUnknown, references: Types.TSchema[], value: any): unknown {
   return value
 }
-function Void(schema: Types.TVoid, references: Types.TSchema[], value: any): unknown {
+function TVoid(schema: Types.TVoid, references: Types.TSchema[], value: any): unknown {
   return value
 }
-function UserDefined(schema: Types.TSchema, references: Types.TSchema[], value: any): unknown {
+function TUserDefined(schema: Types.TSchema, references: Types.TSchema[], value: any): unknown {
   return value
 }
 export function Visit(schema: Types.TSchema, references: Types.TSchema[], value: any): unknown {
@@ -278,66 +278,66 @@ export function Visit(schema: Types.TSchema, references: Types.TSchema[], value:
   const schema_ = schema as any
   switch (schema[Types.Kind]) {
     case 'Any':
-      return Any(schema_, references_, value)
+      return TAny(schema_, references_, value)
     case 'Array':
-      return Array(schema_, references_, value)
+      return TArray(schema_, references_, value)
     case 'AsyncIterator':
-      return AsyncIterator(schema_, references_, value)
+      return TAsyncIterator(schema_, references_, value)
     case 'BigInt':
-      return BigInt(schema_, references_, value)
+      return TBigInt(schema_, references_, value)
     case 'Boolean':
-      return Boolean(schema_, references_, value)
+      return TBoolean(schema_, references_, value)
     case 'Constructor':
-      return Constructor(schema_, references_, value)
+      return TConstructor(schema_, references_, value)
     case 'Date':
-      return Date(schema_, references_, value)
+      return TDate(schema_, references_, value)
     case 'Function':
-      return Function(schema_, references_, value)
+      return TFunction(schema_, references_, value)
     case 'Integer':
-      return Integer(schema_, references_, value)
+      return TInteger(schema_, references_, value)
     case 'Intersect':
-      return Intersect(schema_, references_, value)
+      return TIntersect(schema_, references_, value)
     case 'Iterator':
-      return Iterator(schema_, references_, value)
+      return TIterator(schema_, references_, value)
     case 'Literal':
-      return Literal(schema_, references_, value)
+      return TLiteral(schema_, references_, value)
     case 'Never':
-      return Never(schema_, references_, value)
+      return TNever(schema_, references_, value)
     case 'Null':
-      return Null(schema_, references_, value)
+      return TNull(schema_, references_, value)
     case 'Number':
-      return Number(schema_, references_, value)
+      return TNumber(schema_, references_, value)
     case 'Object':
-      return Object(schema_, references_, value)
+      return TObject(schema_, references_, value)
     case 'Promise':
-      return Promise(schema_, references_, value)
+      return TPromise(schema_, references_, value)
     case 'Record':
-      return Record(schema_, references_, value)
+      return TRecord(schema_, references_, value)
     case 'Ref':
-      return Ref(schema_, references_, value)
+      return TRef(schema_, references_, value)
     case 'String':
-      return String(schema_, references_, value)
+      return TString(schema_, references_, value)
     case 'Symbol':
-      return Symbol(schema_, references_, value)
+      return TSymbol(schema_, references_, value)
     case 'TemplateLiteral':
-      return TemplateLiteral(schema_, references_, value)
+      return TTemplateLiteral(schema_, references_, value)
     case 'This':
-      return This(schema_, references_, value)
+      return TThis(schema_, references_, value)
     case 'Tuple':
-      return Tuple(schema_, references_, value)
+      return TTuple(schema_, references_, value)
     case 'Undefined':
-      return Undefined(schema_, references_, value)
+      return TUndefined(schema_, references_, value)
     case 'Union':
-      return Union(schema_, references_, value)
+      return TUnion(schema_, references_, value)
     case 'Uint8Array':
-      return Uint8Array(schema_, references_, value)
+      return TUint8Array(schema_, references_, value)
     case 'Unknown':
-      return Unknown(schema_, references_, value)
+      return TUnknown(schema_, references_, value)
     case 'Void':
-      return Void(schema_, references_, value)
+      return TVoid(schema_, references_, value)
     default:
       if (!Types.TypeRegistry.Has(schema_[Types.Kind])) throw new ValueConvertUnknownTypeError(schema_)
-      return UserDefined(schema_, references_, value)
+      return TUserDefined(schema_, references_, value)
   }
 }
 // --------------------------------------------------------------------------

--- a/src/value/create.ts
+++ b/src/value/create.ts
@@ -71,14 +71,14 @@ export class ValueCreateRecursiveInstantiationError extends Error {
 // --------------------------------------------------------------------------
 // Types
 // --------------------------------------------------------------------------
-function Any(schema: Types.TAny, references: Types.TSchema[]): any {
+function TAny(schema: Types.TAny, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     return {}
   }
 }
-function Array(schema: Types.TArray, references: Types.TSchema[]): any {
+function TArray(schema: Types.TArray, references: Types.TSchema[]): any {
   if (schema.uniqueItems === true && !ValueGuard.HasPropertyKey(schema, 'default')) {
     throw new Error('ValueCreate.Array: Array with the uniqueItems constraint requires a default value')
   } else if ('contains' in schema && !ValueGuard.HasPropertyKey(schema, 'default')) {
@@ -86,43 +86,43 @@ function Array(schema: Types.TArray, references: Types.TSchema[]): any {
   } else if ('default' in schema) {
     return schema.default
   } else if (schema.minItems !== undefined) {
-    return globalThis.Array.from({ length: schema.minItems }).map((item) => {
+    return Array.from({ length: schema.minItems }).map((item) => {
       return Visit(schema.items, references)
     })
   } else {
     return []
   }
 }
-function AsyncIterator(schema: Types.TAsyncIterator, references: Types.TSchema[]) {
+function TAsyncIterator(schema: Types.TAsyncIterator, references: Types.TSchema[]) {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     return (async function* () {})()
   }
 }
-function BigInt(schema: Types.TBigInt, references: Types.TSchema[]): any {
+function TBigInt(schema: Types.TBigInt, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
-    return globalThis.BigInt(0)
+    return BigInt(0)
   }
 }
-function Boolean(schema: Types.TBoolean, references: Types.TSchema[]): any {
+function TBoolean(schema: Types.TBoolean, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     return false
   }
 }
-function Constructor(schema: Types.TConstructor, references: Types.TSchema[]): any {
+function TConstructor(schema: Types.TConstructor, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     const value = Visit(schema.returns, references) as any
-    if (typeof value === 'object' && !globalThis.Array.isArray(value)) {
+    if (typeof value === 'object' && !Array.isArray(value)) {
       return class {
         constructor() {
-          for (const [key, val] of globalThis.Object.entries(value)) {
+          for (const [key, val] of Object.entries(value)) {
             const self = this as any
             self[key] = val
           }
@@ -133,23 +133,23 @@ function Constructor(schema: Types.TConstructor, references: Types.TSchema[]): a
     }
   }
 }
-function Date(schema: Types.TDate, references: Types.TSchema[]): any {
+function TDate(schema: Types.TDate, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else if (schema.minimumTimestamp !== undefined) {
-    return new globalThis.Date(schema.minimumTimestamp)
+    return new Date(schema.minimumTimestamp)
   } else {
-    return new globalThis.Date(0)
+    return new Date(0)
   }
 }
-function Function(schema: Types.TFunction, references: Types.TSchema[]): any {
+function TFunction(schema: Types.TFunction, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     return () => Visit(schema.returns, references)
   }
 }
-function Integer(schema: Types.TInteger, references: Types.TSchema[]): any {
+function TInteger(schema: Types.TInteger, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else if (schema.minimum !== undefined) {
@@ -158,7 +158,7 @@ function Integer(schema: Types.TInteger, references: Types.TSchema[]): any {
     return 0
   }
 }
-function Intersect(schema: Types.TIntersect, references: Types.TSchema[]): any {
+function TIntersect(schema: Types.TIntersect, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
@@ -173,38 +173,38 @@ function Intersect(schema: Types.TIntersect, references: Types.TSchema[]): any {
     return value
   }
 }
-function Iterator(schema: Types.TIterator, references: Types.TSchema[]) {
+function TIterator(schema: Types.TIterator, references: Types.TSchema[]) {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     return (function* () {})()
   }
 }
-function Literal(schema: Types.TLiteral, references: Types.TSchema[]): any {
+function TLiteral(schema: Types.TLiteral, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     return schema.const
   }
 }
-function Never(schema: Types.TNever, references: Types.TSchema[]): any {
+function TNever(schema: Types.TNever, references: Types.TSchema[]): any {
   throw new ValueCreateNeverTypeError(schema)
 }
-function Not(schema: Types.TNot, references: Types.TSchema[]): any {
+function TNot(schema: Types.TNot, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     throw new ValueCreateNotTypeError(schema)
   }
 }
-function Null(schema: Types.TNull, references: Types.TSchema[]): any {
+function TNull(schema: Types.TNull, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     return null
   }
 }
-function Number(schema: Types.TNumber, references: Types.TSchema[]): any {
+function TNumber(schema: Types.TNumber, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else if (schema.minimum !== undefined) {
@@ -213,28 +213,28 @@ function Number(schema: Types.TNumber, references: Types.TSchema[]): any {
     return 0
   }
 }
-function Object(schema: Types.TObject, references: Types.TSchema[]): any {
+function TObject(schema: Types.TObject, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     const required = new Set(schema.required)
     return (
       schema.default ||
-      globalThis.Object.entries(schema.properties).reduce((acc, [key, schema]) => {
+      Object.entries(schema.properties).reduce((acc, [key, schema]) => {
         return required.has(key) ? { ...acc, [key]: Visit(schema, references) } : { ...acc }
       }, {})
     )
   }
 }
-function Promise(schema: Types.TPromise<any>, references: Types.TSchema[]): any {
+function TPromise(schema: Types.TPromise<any>, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
-    return globalThis.Promise.resolve(Visit(schema.item, references))
+    return Promise.resolve(Visit(schema.item, references))
   }
 }
-function Record(schema: Types.TRecord<any, any>, references: Types.TSchema[]): any {
-  const [keyPattern, valueSchema] = globalThis.Object.entries(schema.patternProperties)[0]
+function TRecord(schema: Types.TRecord<any, any>, references: Types.TSchema[]): any {
+  const [keyPattern, valueSchema] = Object.entries(schema.patternProperties)[0]
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else if (!(keyPattern === Types.PatternStringExact || keyPattern === Types.PatternNumberExact)) {
@@ -246,7 +246,7 @@ function Record(schema: Types.TRecord<any, any>, references: Types.TSchema[]): a
     return {}
   }
 }
-function Ref(schema: Types.TRef<any>, references: Types.TSchema[]): any {
+function TRef(schema: Types.TRef<any>, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
@@ -256,7 +256,7 @@ function Ref(schema: Types.TRef<any>, references: Types.TSchema[]): any {
     return Visit(target, references)
   }
 }
-function String(schema: Types.TString, references: Types.TSchema[]): any {
+function TString(schema: Types.TString, references: Types.TSchema[]): any {
   if (schema.pattern !== undefined) {
     if (!ValueGuard.HasPropertyKey(schema, 'default')) {
       throw new Error('ValueCreate.String: String types with patterns must specify a default value')
@@ -273,7 +273,7 @@ function String(schema: Types.TString, references: Types.TSchema[]): any {
     if (ValueGuard.HasPropertyKey(schema, 'default')) {
       return schema.default
     } else if (schema.minLength !== undefined) {
-      return globalThis.Array.from({ length: schema.minLength })
+      return Array.from({ length: schema.minLength })
         .map(() => '.')
         .join('')
     } else {
@@ -281,16 +281,16 @@ function String(schema: Types.TString, references: Types.TSchema[]): any {
     }
   }
 }
-function Symbol(schema: Types.TString, references: Types.TSchema[]): any {
+function TSymbol(schema: Types.TString, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else if ('value' in schema) {
-    return globalThis.Symbol.for(schema.value)
+    return Symbol.for(schema.value)
   } else {
-    return globalThis.Symbol()
+    return Symbol()
   }
 }
-function TemplateLiteral(schema: Types.TTemplateLiteral, references: Types.TSchema[]) {
+function TTemplateLiteral(schema: Types.TTemplateLiteral, references: Types.TSchema[]) {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   }
@@ -299,7 +299,7 @@ function TemplateLiteral(schema: Types.TTemplateLiteral, references: Types.TSche
   const sequence = Types.TemplateLiteralGenerator.Generate(expression)
   return sequence.next().value
 }
-function This(schema: Types.TThis, references: Types.TSchema[]): any {
+function TThis(schema: Types.TThis, references: Types.TSchema[]): any {
   if (recursiveDepth++ > recursiveMaxDepth) throw new ValueCreateRecursiveInstantiationError(schema, recursiveMaxDepth)
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
@@ -310,24 +310,24 @@ function This(schema: Types.TThis, references: Types.TSchema[]): any {
     return Visit(target, references)
   }
 }
-function Tuple(schema: Types.TTuple<any[]>, references: Types.TSchema[]): any {
+function TTuple(schema: Types.TTuple<any[]>, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   }
   if (schema.items === undefined) {
     return []
   } else {
-    return globalThis.Array.from({ length: schema.minItems }).map((_, index) => Visit((schema.items as any[])[index], references))
+    return Array.from({ length: schema.minItems }).map((_, index) => Visit((schema.items as any[])[index], references))
   }
 }
-function Undefined(schema: Types.TUndefined, references: Types.TSchema[]): any {
+function TUndefined(schema: Types.TUndefined, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     return undefined
   }
 }
-function Union(schema: Types.TUnion<any[]>, references: Types.TSchema[]): any {
+function TUnion(schema: Types.TUnion<any[]>, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else if (schema.anyOf.length === 0) {
@@ -336,30 +336,30 @@ function Union(schema: Types.TUnion<any[]>, references: Types.TSchema[]): any {
     return Visit(schema.anyOf[0], references)
   }
 }
-function Uint8Array(schema: Types.TUint8Array, references: Types.TSchema[]): any {
+function TUint8Array(schema: Types.TUint8Array, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else if (schema.minByteLength !== undefined) {
-    return new globalThis.Uint8Array(schema.minByteLength)
+    return new Uint8Array(schema.minByteLength)
   } else {
-    return new globalThis.Uint8Array(0)
+    return new Uint8Array(0)
   }
 }
-function Unknown(schema: Types.TUnknown, references: Types.TSchema[]): any {
+function TUnknown(schema: Types.TUnknown, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     return {}
   }
 }
-function Void(schema: Types.TVoid, references: Types.TSchema[]): any {
+function TVoid(schema: Types.TVoid, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
     return void 0
   }
 }
-function UserDefined(schema: Types.TSchema, references: Types.TSchema[]): any {
+function TUserDefined(schema: Types.TSchema, references: Types.TSchema[]): any {
   if (ValueGuard.HasPropertyKey(schema, 'default')) {
     return schema.default
   } else {
@@ -372,68 +372,68 @@ export function Visit(schema: Types.TSchema, references: Types.TSchema[]): unkno
   const schema_ = schema as any
   switch (schema_[Types.Kind]) {
     case 'Any':
-      return Any(schema_, references_)
+      return TAny(schema_, references_)
     case 'Array':
-      return Array(schema_, references_)
+      return TArray(schema_, references_)
     case 'AsyncIterator':
-      return AsyncIterator(schema_, references_)
+      return TAsyncIterator(schema_, references_)
     case 'BigInt':
-      return BigInt(schema_, references_)
+      return TBigInt(schema_, references_)
     case 'Boolean':
-      return Boolean(schema_, references_)
+      return TBoolean(schema_, references_)
     case 'Constructor':
-      return Constructor(schema_, references_)
+      return TConstructor(schema_, references_)
     case 'Date':
-      return Date(schema_, references_)
+      return TDate(schema_, references_)
     case 'Function':
-      return Function(schema_, references_)
+      return TFunction(schema_, references_)
     case 'Integer':
-      return Integer(schema_, references_)
+      return TInteger(schema_, references_)
     case 'Intersect':
-      return Intersect(schema_, references_)
+      return TIntersect(schema_, references_)
     case 'Iterator':
-      return Iterator(schema_, references_)
+      return TIterator(schema_, references_)
     case 'Literal':
-      return Literal(schema_, references_)
+      return TLiteral(schema_, references_)
     case 'Never':
-      return Never(schema_, references_)
+      return TNever(schema_, references_)
     case 'Not':
-      return Not(schema_, references_)
+      return TNot(schema_, references_)
     case 'Null':
-      return Null(schema_, references_)
+      return TNull(schema_, references_)
     case 'Number':
-      return Number(schema_, references_)
+      return TNumber(schema_, references_)
     case 'Object':
-      return Object(schema_, references_)
+      return TObject(schema_, references_)
     case 'Promise':
-      return Promise(schema_, references_)
+      return TPromise(schema_, references_)
     case 'Record':
-      return Record(schema_, references_)
+      return TRecord(schema_, references_)
     case 'Ref':
-      return Ref(schema_, references_)
+      return TRef(schema_, references_)
     case 'String':
-      return String(schema_, references_)
+      return TString(schema_, references_)
     case 'Symbol':
-      return Symbol(schema_, references_)
+      return TSymbol(schema_, references_)
     case 'TemplateLiteral':
-      return TemplateLiteral(schema_, references_)
+      return TTemplateLiteral(schema_, references_)
     case 'This':
-      return This(schema_, references_)
+      return TThis(schema_, references_)
     case 'Tuple':
-      return Tuple(schema_, references_)
+      return TTuple(schema_, references_)
     case 'Undefined':
-      return Undefined(schema_, references_)
+      return TUndefined(schema_, references_)
     case 'Union':
-      return Union(schema_, references_)
+      return TUnion(schema_, references_)
     case 'Uint8Array':
-      return Uint8Array(schema_, references_)
+      return TUint8Array(schema_, references_)
     case 'Unknown':
-      return Unknown(schema_, references_)
+      return TUnknown(schema_, references_)
     case 'Void':
-      return Void(schema_, references_)
+      return TVoid(schema_, references_)
     default:
       if (!Types.TypeRegistry.Has(schema_[Types.Kind])) throw new ValueCreateUnknownTypeError(schema_)
-      return UserDefined(schema_, references_)
+      return TUserDefined(schema_, references_)
   }
 }
 // --------------------------------------------------------------------------

--- a/src/value/equal.ts
+++ b/src/value/equal.ts
@@ -31,22 +31,22 @@ import * as ValueGuard from './guard'
 // --------------------------------------------------------------------------
 // Equality Checks
 // --------------------------------------------------------------------------
-function Object(left: ValueGuard.ObjectType, right: unknown): boolean {
+function ObjectType(left: ValueGuard.ObjectType, right: unknown): boolean {
   if (!ValueGuard.IsPlainObject(right)) return false
-  const leftKeys = [...globalThis.Object.keys(left), ...globalThis.Object.getOwnPropertySymbols(left)]
-  const rightKeys = [...globalThis.Object.keys(right), ...globalThis.Object.getOwnPropertySymbols(right)]
+  const leftKeys = [...Object.keys(left), ...Object.getOwnPropertySymbols(left)]
+  const rightKeys = [...Object.keys(right), ...Object.getOwnPropertySymbols(right)]
   if (leftKeys.length !== rightKeys.length) return false
   return leftKeys.every((key) => Equal(left[key], right[key]))
 }
-function Date(left: Date, right: unknown): any {
+function DateType(left: Date, right: unknown): any {
   return ValueGuard.IsDate(right) && left.getTime() === right.getTime()
 }
-function Array(left: ValueGuard.ArrayType, right: unknown): any {
+function ArrayType(left: ValueGuard.ArrayType, right: unknown): any {
   if (!ValueGuard.IsArray(right) || left.length !== right.length) return false
   return left.every((value, index) => Equal(value, right[index]))
 }
-function TypedArray(left: ValueGuard.TypedArrayType, right: unknown): any {
-  if (!ValueGuard.IsTypedArray(right) || left.length !== right.length || globalThis.Object.getPrototypeOf(left).constructor.name !== globalThis.Object.getPrototypeOf(right).constructor.name) return false
+function TypedArrayType(left: ValueGuard.TypedArrayType, right: unknown): any {
+  if (!ValueGuard.IsTypedArray(right) || left.length !== right.length || Object.getPrototypeOf(left).constructor.name !== Object.getPrototypeOf(right).constructor.name) return false
   return left.every((value, index) => Equal(value, right[index]))
 }
 function ValueType(left: ValueGuard.ValueType, right: unknown): any {
@@ -57,10 +57,10 @@ function ValueType(left: ValueGuard.ValueType, right: unknown): any {
 // --------------------------------------------------------------------------
 /** Returns true if the left value deep-equals the right */
 export function Equal<T>(left: T, right: unknown): right is T {
-  if (ValueGuard.IsPlainObject(left)) return Object(left, right)
-  if (ValueGuard.IsDate(left)) return Date(left, right)
-  if (ValueGuard.IsTypedArray(left)) return TypedArray(left, right)
-  if (ValueGuard.IsArray(left)) return Array(left, right)
+  if (ValueGuard.IsPlainObject(left)) return ObjectType(left, right)
+  if (ValueGuard.IsDate(left)) return DateType(left, right)
+  if (ValueGuard.IsTypedArray(left)) return TypedArrayType(left, right)
+  if (ValueGuard.IsArray(left)) return ArrayType(left, right)
   if (ValueGuard.IsValueType(left)) return ValueType(left, right)
   throw new Error('ValueEquals: Unable to compare value')
 }

--- a/src/value/guard.ts
+++ b/src/value/guard.ts
@@ -65,15 +65,15 @@ export function IsTypedArray(value: unknown): value is TypedArrayType {
 }
 /** Returns true if this value is a Promise */
 export function IsPromise(value: unknown): value is Promise<unknown> {
-  return value instanceof globalThis.Promise
+  return value instanceof Promise
 }
 /** Returns true if the value is a Uint8Array */
 export function IsUint8Array(value: unknown): value is Uint8Array {
-  return value instanceof globalThis.Uint8Array
+  return value instanceof Uint8Array
 }
 /** Returns true if this value is a Date */
 export function IsDate(value: unknown): value is Date {
-  return value instanceof globalThis.Date
+  return value instanceof Date
 }
 // --------------------------------------------------------------------------
 // Standard
@@ -98,7 +98,7 @@ export function IsObject(value: unknown): value is ObjectType {
 }
 /** Returns true if this value is an array, but not a typed array */
 export function IsArray(value: unknown): value is ArrayType {
-  return globalThis.Array.isArray(value) && !ArrayBuffer.isView(value)
+  return Array.isArray(value) && !ArrayBuffer.isView(value)
 }
 /** Returns true if this value is an undefined */
 export function IsUndefined(value: unknown): value is undefined {
@@ -118,7 +118,7 @@ export function IsNumber(value: unknown): value is number {
 }
 /** Returns true if this value is an integer */
 export function IsInteger(value: unknown): value is number {
-  return IsNumber(value) && globalThis.Number.isInteger(value)
+  return IsNumber(value) && Number.isInteger(value)
 }
 /** Returns true if this value is bigint */
 export function IsBigInt(value: unknown): value is bigint {

--- a/src/value/hash.ts
+++ b/src/value/hash.ts
@@ -55,84 +55,84 @@ export enum ByteMarker {
 // --------------------------------------------------------------------------
 // State
 // --------------------------------------------------------------------------
-let Accumulator = globalThis.BigInt('14695981039346656037')
-const [Prime, Size] = [globalThis.BigInt('1099511628211'), globalThis.BigInt('2') ** globalThis.BigInt('64')]
-const Bytes = globalThis.Array.from({ length: 256 }).map((_, i) => globalThis.BigInt(i))
-const F64 = new globalThis.Float64Array(1)
-const F64In = new globalThis.DataView(F64.buffer)
-const F64Out = new globalThis.Uint8Array(F64.buffer)
+let Accumulator = BigInt('14695981039346656037')
+const [Prime, Size] = [BigInt('1099511628211'), BigInt('2') ** BigInt('64')]
+const Bytes = Array.from({ length: 256 }).map((_, i) => BigInt(i))
+const F64 = new Float64Array(1)
+const F64In = new DataView(F64.buffer)
+const F64Out = new Uint8Array(F64.buffer)
 // --------------------------------------------------------------------------
 // Hashing Functions
 // --------------------------------------------------------------------------
-function Array(value: Array<unknown>) {
+function ArrayType(value: Array<unknown>) {
   FNV1A64(ByteMarker.Array)
   for (const item of value) {
     Visit(item)
   }
 }
-function Boolean(value: boolean) {
+function BooleanType(value: boolean) {
   FNV1A64(ByteMarker.Boolean)
   FNV1A64(value ? 1 : 0)
 }
-function BigInt(value: bigint) {
+function BigIntType(value: bigint) {
   FNV1A64(ByteMarker.BigInt)
   F64In.setBigInt64(0, value)
   for (const byte of F64Out) {
     FNV1A64(byte)
   }
 }
-function Date(value: Date) {
+function DateType(value: Date) {
   FNV1A64(ByteMarker.Date)
   Visit(value.getTime())
 }
-function Null(value: null) {
+function NullType(value: null) {
   FNV1A64(ByteMarker.Null)
 }
-function Number(value: number) {
+function NumberType(value: number) {
   FNV1A64(ByteMarker.Number)
   F64In.setFloat64(0, value)
   for (const byte of F64Out) {
     FNV1A64(byte)
   }
 }
-function Object(value: Record<string, unknown>) {
+function ObjectType(value: Record<string, unknown>) {
   FNV1A64(ByteMarker.Object)
   for (const key of globalThis.Object.keys(value).sort()) {
     Visit(key)
     Visit(value[key])
   }
 }
-function String(value: string) {
+function StringType(value: string) {
   FNV1A64(ByteMarker.String)
   for (let i = 0; i < value.length; i++) {
     FNV1A64(value.charCodeAt(i))
   }
 }
-function Symbol(value: symbol) {
+function SymbolType(value: symbol) {
   FNV1A64(ByteMarker.Symbol)
   Visit(value.description)
 }
-function Uint8Array(value: Uint8Array) {
+function Uint8ArrayType(value: Uint8Array) {
   FNV1A64(ByteMarker.Uint8Array)
   for (let i = 0; i < value.length; i++) {
     FNV1A64(value[i])
   }
 }
-function Undefined(value: undefined) {
+function UndefinedType(value: undefined) {
   return FNV1A64(ByteMarker.Undefined)
 }
 function Visit(value: any) {
-  if (ValueGuard.IsArray(value)) return Array(value)
-  if (ValueGuard.IsBoolean(value)) return Boolean(value)
-  if (ValueGuard.IsBigInt(value)) return BigInt(value)
-  if (ValueGuard.IsDate(value)) return Date(value)
-  if (ValueGuard.IsNull(value)) return Null(value)
-  if (ValueGuard.IsNumber(value)) return Number(value)
-  if (ValueGuard.IsPlainObject(value)) return Object(value)
-  if (ValueGuard.IsString(value)) return String(value)
-  if (ValueGuard.IsSymbol(value)) return Symbol(value)
-  if (ValueGuard.IsUint8Array(value)) return Uint8Array(value)
-  if (ValueGuard.IsUndefined(value)) return Undefined(value)
+  if (ValueGuard.IsArray(value)) return ArrayType(value)
+  if (ValueGuard.IsBoolean(value)) return BooleanType(value)
+  if (ValueGuard.IsBigInt(value)) return BigIntType(value)
+  if (ValueGuard.IsDate(value)) return DateType(value)
+  if (ValueGuard.IsNull(value)) return NullType(value)
+  if (ValueGuard.IsNumber(value)) return NumberType(value)
+  if (ValueGuard.IsPlainObject(value)) return ObjectType(value)
+  if (ValueGuard.IsString(value)) return StringType(value)
+  if (ValueGuard.IsSymbol(value)) return SymbolType(value)
+  if (ValueGuard.IsUint8Array(value)) return Uint8ArrayType(value)
+  if (ValueGuard.IsUndefined(value)) return UndefinedType(value)
   throw new ValueHashError(value)
 }
 function FNV1A64(byte: number) {
@@ -144,7 +144,7 @@ function FNV1A64(byte: number) {
 // --------------------------------------------------------------------------
 /** Creates a FNV1A-64 non cryptographic hash of the given value */
 export function Hash(value: unknown) {
-  Accumulator = globalThis.BigInt('14695981039346656037')
+  Accumulator = BigInt('14695981039346656037')
   Visit(value)
   return Accumulator
 }

--- a/src/value/mutate.ts
+++ b/src/value/mutate.ts
@@ -47,12 +47,12 @@ export class ValueMutateInvalidRootMutationError extends Error {
 // Mutators
 // --------------------------------------------------------------------------
 export type Mutable = { [key: string]: unknown } | unknown[]
-function Object(root: Mutable, path: string, current: unknown, next: Record<string, unknown>) {
+function ObjectType(root: Mutable, path: string, current: unknown, next: Record<string, unknown>) {
   if (!ValueGuard.IsPlainObject(current)) {
     ValuePointer.Set(root, path, ValueClone.Clone(next))
   } else {
-    const currentKeys = globalThis.Object.keys(current)
-    const nextKeys = globalThis.Object.keys(next)
+    const currentKeys = Object.keys(current)
+    const nextKeys = Object.keys(next)
     for (const currentKey of currentKeys) {
       if (!nextKeys.includes(currentKey)) {
         delete current[currentKey]
@@ -68,7 +68,7 @@ function Object(root: Mutable, path: string, current: unknown, next: Record<stri
     }
   }
 }
-function Array(root: Mutable, path: string, current: unknown, next: unknown[]) {
+function ArrayType(root: Mutable, path: string, current: unknown, next: unknown[]) {
   if (!ValueGuard.IsArray(current)) {
     ValuePointer.Set(root, path, ValueClone.Clone(next))
   } else {
@@ -78,7 +78,7 @@ function Array(root: Mutable, path: string, current: unknown, next: unknown[]) {
     current.splice(next.length)
   }
 }
-function TypedArray(root: Mutable, path: string, current: unknown, next: ValueGuard.TypedArrayType) {
+function TypedArrayType(root: Mutable, path: string, current: unknown, next: ValueGuard.TypedArrayType) {
   if (ValueGuard.IsTypedArray(current) && current.length === next.length) {
     for (let i = 0; i < current.length; i++) {
       current[i] = next[i]
@@ -87,15 +87,15 @@ function TypedArray(root: Mutable, path: string, current: unknown, next: ValueGu
     ValuePointer.Set(root, path, ValueClone.Clone(next))
   }
 }
-function Value(root: Mutable, path: string, current: unknown, next: unknown) {
+function ValueType(root: Mutable, path: string, current: unknown, next: unknown) {
   if (current === next) return
   ValuePointer.Set(root, path, next)
 }
 function Visit(root: Mutable, path: string, current: unknown, next: unknown) {
-  if (ValueGuard.IsArray(next)) return Array(root, path, current, next)
-  if (ValueGuard.IsTypedArray(next)) return TypedArray(root, path, current, next)
-  if (ValueGuard.IsPlainObject(next)) return Object(root, path, current, next)
-  if (ValueGuard.IsValueType(next)) return Value(root, path, current, next)
+  if (ValueGuard.IsArray(next)) return ArrayType(root, path, current, next)
+  if (ValueGuard.IsTypedArray(next)) return TypedArrayType(root, path, current, next)
+  if (ValueGuard.IsPlainObject(next)) return ObjectType(root, path, current, next)
+  if (ValueGuard.IsValueType(next)) return ValueType(root, path, current, next)
 }
 // --------------------------------------------------------------------------
 // Mutate

--- a/src/value/pointer.ts
+++ b/src/value/pointer.ts
@@ -89,7 +89,7 @@ export namespace ValuePointer {
       next = next[component]
       key = component
     }
-    if (globalThis.Array.isArray(owner)) {
+    if (Array.isArray(owner)) {
       const index = parseInt(key)
       owner.splice(index, 1)
     } else {
@@ -106,7 +106,7 @@ export namespace ValuePointer {
       next = next[component]
       key = component
     }
-    return globalThis.Object.getOwnPropertyNames(owner).includes(key)
+    return Object.getOwnPropertyNames(owner).includes(key)
   }
   /** Gets the value at the given pointer */
   export function Get(value: any, pointer: string): any {


### PR DESCRIPTION
This PR implements a Transform codec example. This type may be embedded into the library in future, but is deferred for 0.30.0 until adequate review and testing has been carried out. 

Note: There are some considerations about the TransformUnwrap and design time performance impacts of having deeply recursive mapping handling the inference. 

Note: There are some issues with nested transform types which would be good to resolve. As the `Encode` and `Decode` operate similar to a typical `Parse`, and with the runtime checks on the decoded values not having associated schemas to check, there are issues with stacked transforms that need to be resolved.

Adding as example project for this release.