### PR TITLE
Retain Registry Kinds on Compile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.30.3",
+      "version": "0.30.4",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -545,9 +545,10 @@ export namespace TypeCompiler {
   export function Compile<T extends Types.TSchema>(schema: T, references: Types.TSchema[] = []): TypeCheck<T> {
     const generatedCode = Code(schema, references, { language: 'javascript' })
     const compiledFunction = globalThis.Function('kind', 'format', 'hash', generatedCode)
+    const instances = new Map(state.instances)
     function typeRegistryFunction(kind: string, instance: number, value: unknown) {
-      if (!Types.TypeRegistry.Has(kind) || !state.instances.has(instance)) return false
-      const schema = state.instances.get(instance)
+      if (!Types.TypeRegistry.Has(kind) || !instances.has(instance)) return false
+      const schema = instances.get(instance)
       const checkFunc = Types.TypeRegistry.Get(kind)!
       return checkFunc(schema, value)
     }

--- a/test/runtime/compiler/kind.ts
+++ b/test/runtime/compiler/kind.ts
@@ -69,4 +69,55 @@ describe('type/compiler/Kind', () => {
     Assert.IsEqual(stack[1], 'B')
     TypeRegistry.Delete('Kind')
   })
+  // ------------------------------------------------------------
+  // Instances Retain
+  // ------------------------------------------------------------
+  it('Should retain kind instances on subsequent compile', () => {
+    let stack: string[] = []
+    TypeRegistry.Set('Kind', (schema: unknown) => {
+      // prettier-ignore
+      return (typeof schema === 'object' && schema !== null && Kind in schema && schema[Kind] === 'Kind' && '$id' in schema && typeof schema.$id === 'string') 
+        ? (() => { stack.push(schema.$id); return true })()
+        : false
+    })
+    const A = { [Kind]: 'Kind', $id: 'A' } as TSchema
+    const B = { [Kind]: 'Kind', $id: 'B' } as TSchema
+    const C = { [Kind]: 'Kind', $id: 'C' } as TSchema
+    const D = { [Kind]: 'Kind', $id: 'D' } as TSchema
+    const T1 = Type.Object({ a: A, b: B })
+    const T2 = Type.Object({ a: C, b: D })
+
+    // Compile T1 and run check, expect A and B
+    const C1 = TypeCompiler.Compile(T1)
+    const R1 = C1.Check({ a: null, b: null })
+    Assert.IsTrue(R1)
+    Assert.IsEqual(stack.length, 2)
+    Assert.IsEqual(stack[0], 'A')
+    Assert.IsEqual(stack[1], 'B')
+    stack = []
+    // compile T2 and force instance.clear()
+    const C2 = TypeCompiler.Compile(T2)
+    // run T1 check
+    const R2 = C1.Check({ a: null, b: null })
+    Assert.IsTrue(R2)
+    Assert.IsEqual(stack.length, 2)
+    Assert.IsEqual(stack[0], 'A')
+    Assert.IsEqual(stack[1], 'B')
+    stack = []
+    // run T2 check
+    const R3 = C2.Check({ a: null, b: null })
+    Assert.IsTrue(R3)
+    Assert.IsEqual(stack.length, 2)
+    Assert.IsEqual(stack[0], 'C')
+    Assert.IsEqual(stack[1], 'D')
+    stack = []
+    // run T1 check
+    const R4 = C1.Check({ a: null, b: null })
+    Assert.IsTrue(R4)
+    Assert.IsEqual(stack.length, 2)
+    Assert.IsEqual(stack[0], 'A')
+    Assert.IsEqual(stack[1], 'B')
+    stack = []
+    TypeRegistry.Delete('Kind')
+  })
 })


### PR DESCRIPTION
This PR is a subsequent fix for #522 dereferencing type registry kinds. The previous PR missed caching the collected kinds causing subsequent compilation to loose track of them. This PR includes the fix for this (same caching as in 0.29.0) and tests.