### PR TITLE
Escape for Single Quote Literals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.0",
+  "version": "0.31.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.31.0",
+      "version": "0.31.2",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -129,6 +129,14 @@ namespace Identifier {
   }
 }
 // -------------------------------------------------------------------
+// LiteralString
+// -------------------------------------------------------------------
+namespace LiteralString {
+  export function Escape(content: string) {
+    return content.replace(/'/g, "\\'")
+  }
+}
+// -------------------------------------------------------------------
 // Errors
 // -------------------------------------------------------------------
 export class TypeCompilerUnknownTypeError extends Types.TypeBoxError {
@@ -263,7 +271,7 @@ export namespace TypeCompiler {
     if (typeof schema.const === 'number' || typeof schema.const === 'boolean') {
       yield `(${value} === ${schema.const})`
     } else {
-      yield `(${value} === '${schema.const}')`
+      yield `(${value} === '${LiteralString.Escape(schema.const)}')`
     }
   }
   function* TNever(schema: Types.TNever, references: Types.TSchema[], value: string): IterableIterator<string> {

--- a/test/runtime/compiler/literal.ts
+++ b/test/runtime/compiler/literal.ts
@@ -36,6 +36,7 @@ describe('compiler/Literal', () => {
     Fail(T, 43)
     Fail(T, 'world')
   })
+  // reference: https://github.com/sinclairzx81/typebox/issues/539
   it('Should escape single quote literals', () => {
     const T = Type.Literal("it's")
     Ok(T, "it's")

--- a/test/runtime/compiler/literal.ts
+++ b/test/runtime/compiler/literal.ts
@@ -36,4 +36,14 @@ describe('compiler/Literal', () => {
     Fail(T, 43)
     Fail(T, 'world')
   })
+  it('Should escape single quote literals', () => {
+    const T = Type.Literal("it's")
+    Ok(T, "it's")
+    Fail(T, "it''s")
+  })
+  it('Should escape multiple single quote literals', () => {
+    const T = Type.Literal("'''''''''")
+    Ok(T, "'''''''''")
+    Fail(T, "''''''''") // minus 1
+  })
 })

--- a/test/runtime/schema/literal.ts
+++ b/test/runtime/schema/literal.ts
@@ -36,6 +36,7 @@ describe('type/schema/Literal', () => {
     Fail(T, 43)
     Fail(T, 'world')
   })
+  // reference: https://github.com/sinclairzx81/typebox/issues/539
   it('Should escape single quote literals', () => {
     const T = Type.Literal("it's")
     Ok(T, "it's")

--- a/test/runtime/schema/literal.ts
+++ b/test/runtime/schema/literal.ts
@@ -36,4 +36,14 @@ describe('type/schema/Literal', () => {
     Fail(T, 43)
     Fail(T, 'world')
   })
+  it('Should escape single quote literals', () => {
+    const T = Type.Literal("it's")
+    Ok(T, "it's")
+    Fail(T, "it''s")
+  })
+  it('Should escape multiple single quote literals', () => {
+    const T = Type.Literal("'''''''''")
+    Ok(T, "'''''''''")
+    Fail(T, "''''''''") // minus 1
+  })
 })


### PR DESCRIPTION
This PR implements a fix for string literal values that include single quotes. These would cause non-closing strings in the generated output. This fix ensures these quotes are appropriately escaped.

```typescript
const C = TypeCompiler.Compile(Type.Literal("it's")) // fixed: eval error due to non-escaped single quote

return function check(value) {
  return (
    (value === 'it\'s')
  )
}
```
Related Issue https://github.com/sinclairzx81/typebox/issues/539