### PR TITLE
AOT compile regexp for records

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -330,7 +330,7 @@ export namespace TypeCompiler {
     if (IsNumber(schema.minProperties)) yield `Object.getOwnPropertyNames(${value}).length >= ${schema.minProperties}`
     if (IsNumber(schema.maxProperties)) yield `Object.getOwnPropertyNames(${value}).length <= ${schema.maxProperties}`
     const [patternKey, patternSchema] = Object.entries(schema.patternProperties)[0]
-    const variable = CreateVariable(`new RegExp(/${patternKey}/)`)
+    const variable = CreateVariable(`${new RegExp(patternKey)}`)
     const check1 = CreateExpression(patternSchema, references, 'value')
     const check2 = Types.TypeGuard.TSchema(schema.additionalProperties) ? CreateExpression(schema.additionalProperties, references, value) : schema.additionalProperties === false ? 'false' : 'true'
     const expression = `(${variable}.test(key) ? ${check1} : ${check2})`


### PR DESCRIPTION
```typescript
TypeCompiler.Compile(Type.Record(Type.String(), Type.Any())).Code()
``` 
Gives
```typescript
const local_0 = new RegExp(/^(.*)$/)
// ...
``` 
But I belive that literal notoation would be better. Thus
```typescript
const local_0 = /^(.*)$/
``` 