### PR TITLE
Revision 0.31.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.31.4",
+      "version": "0.31.5",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/readme.md
+++ b/readme.md
@@ -472,10 +472,10 @@ The following table lists the supported Json types. These types are fully compat
 ├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
 │ const A = Type.Tuple([         │ type A = [0, 1]             │ const T = {                    │
 │   Type.Literal(0),             │ type B = [2, 3]             │   type: 'array',               │
-│   Type.Literal(1)              │ type T = [...A, ...B]       │   items: [                     │
-│ ])                             │                             │     { const: 0 },              │
-│ const B = Type.Tuple([         │                             │     { const: 1 },              │
-|   Type.Literal(2),             │                             │     { const: 2 },              │
+│   Type.Literal(1)              │ type T = [                  │   items: [                     │
+│ ])                             │   ...A,                     │     { const: 0 },              │
+│ const B = Type.Tuple([         │   ...B                      │     { const: 1 },              │
+|   Type.Literal(2),             │ ]                           │     { const: 2 },              │
 |   Type.Literal(3)              │                             │     { const: 3 }               │
 │ ])                             │                             │   ],                           │
 │ const T = Type.Tuple([         │                             │   additionalItems: false,      │
@@ -485,26 +485,26 @@ The following table lists the supported Json types. These types are fully compat
 │                                │                             │                                │
 ├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
 │ const T = Type.Uncapitalize(   │ type T = Uncapitalize<      │ const T = {                    │
-│   Type.Literal('Hello')        │   'Hello'                   │    type: 'string',             │
-│ )                              │ >                           │    const: 'hello'              │
+│   Type.Literal('Hello')        │   'Hello'                   │   type: 'string',              │
+│ )                              │ >                           │   const: 'hello'               │
 │                                │                             │ }                              │
 │                                │                             │                                │
 ├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
 │ const T = Type.Capitalize(     │ type T = Capitalize<        │ const T = {                    │
-│   Type.Literal('hello')        │   'hello'                   │    type: 'string',             │
-│ )                              │ >                           │    const: 'Hello'              │
+│   Type.Literal('hello')        │   'hello'                   │   type: 'string',              │
+│ )                              │ >                           │   const: 'Hello'               │
 │                                │                             │ }                              │
 │                                │                             │                                │
 ├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
 │ const T = Type.Uppercase(      │ type T = Uppercase<         │ const T = {                    │
-│   Type.Literal('hello')        │   'hello'                   │    type: 'string',             │
-│ )                              │ >                           │    const: 'HELLO'              │
+│   Type.Literal('hello')        │   'hello'                   │   type: 'string',              │
+│ )                              │ >                           │   const: 'HELLO'               │
 │                                │                             │ }                              │
 │                                │                             │                                │
 ├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
 │ const T = Type.Lowercase(      │ type T = Lowercase<         │ const T = {                    │
-│   Type.Literal('HELLO')        │   'HELLO'                   │    type: 'string',             │
-│ )                              │ >                           │    const: 'hello'              │
+│   Type.Literal('HELLO')        │   'HELLO'                   │   type: 'string',              │
+│ )                              │ >                           │   const: 'hello'               │
 │                                │                             │ }                              │
 │                                │                             │                                │
 ├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
@@ -539,7 +539,7 @@ TypeBox provides an extended type set that can be used to create schematics for 
 │                                │                             │   }, {                         │
 │                                │                             │     type: 'number'             │
 │                                │                             │   }],                          │
-│                                │                             │   return: {                    │
+│                                │                             │   returns: {                   │
 │                                │                             │     type: 'boolean'            │
 │                                │                             │   }                            │
 │                                │                             │ }                              │
@@ -552,7 +552,7 @@ TypeBox provides an extended type set that can be used to create schematics for 
 │                                │                             │   }, {                         │
 │                                │                             │     type: 'number'             │
 │                                │                             │   }],                          │
-│                                │                             │   return: {                    │
+│                                │                             │   returns: {                   │
 │                                │                             │     type: 'boolean'            │
 │                                │                             │   }                            │
 │                                │                             │ }                              │

--- a/readme.md
+++ b/readme.md
@@ -533,7 +533,7 @@ TypeBox provides an extended type set that can be used to create schematics for 
 │                                │                             │                                │
 ├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
 │ const T = Type.Constructor([   │ type T = new (              │ const T = {                    │
-│   Type.String(),               │  arg0: string,              │   type: 'constructor',         │
+│   Type.String(),               │  arg0: string,              │   type: 'Constructor',         │
 │   Type.Number()                │  arg0: number               │   parameters: [{               │
 │ ], Type.Boolean())             │ ) => boolean                │     type: 'string'             │
 │                                │                             │   }, {                         │
@@ -546,7 +546,7 @@ TypeBox provides an extended type set that can be used to create schematics for 
 │                                │                             │                                │
 ├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
 │ const T = Type.Function([      │ type T = (                  │ const T = {                    │
-|   Type.String(),               │  arg0: string,              │   type: 'function',            │
+|   Type.String(),               │  arg0: string,              │   type: 'Function',            │
 │   Type.Number()                │  arg1: number               │   parameters: [{               │
 │ ], Type.Boolean())             │ ) => boolean                │     type: 'string'             │
 │                                │                             │   }, {                         │

--- a/readme.md
+++ b/readme.md
@@ -277,7 +277,7 @@ The following table lists the supported Json types. These types are fully compat
 │ const T = Type.Tuple([         │ type T = [number, number]   │ const T = {                    │
 │   Type.Number(),               │                             │   type: 'array',               │
 │   Type.Number()                │                             │   items: [{                    │
-│ ])                             │                             │      type: 'number'            │
+│ ])                             │                             │     type: 'number'             │
 │                                │                             │   }, {                         │
 │                                │                             │     type: 'number'             │
 │                                │                             │   }],                          │
@@ -312,9 +312,9 @@ The following table lists the supported Json types. These types are fully compat
 ├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
 │ const T = Type.Union([         │ type T = string | number    │ const T = {                    │
 │   Type.String(),               │                             │   anyOf: [{                    │
-│   Type.Number()                │                             │      type: 'string'            │
+│   Type.Number()                │                             │     type: 'string'             │
 │ ])                             │                             │   }, {                         │
-│                                │                             │      type: 'number'            │
+│                                │                             │     type: 'number'             │
 │                                │                             │   }]                           │
 │                                │                             │ }                              │
 │                                │                             │                                │

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -1204,7 +1204,7 @@ export namespace TypeGuard {
     // prettier-ignore
     return (
       TKindOf(schema, 'Constructor') && 
-      schema.type === 'constructor' &&
+      schema.type === 'Constructor' &&
       IsOptionalString(schema.$id) && 
       ValueGuard.IsArray(schema.parameters) &&
       schema.parameters.every(schema => TSchema(schema)) &&
@@ -1229,7 +1229,7 @@ export namespace TypeGuard {
     // prettier-ignore
     return (
       TKindOf(schema, 'Function') &&
-      schema.type === 'function' &&
+      schema.type === 'Function' &&
       IsOptionalString(schema.$id) && 
       ValueGuard.IsArray(schema.parameters) && 
       schema.parameters.every(schema => TSchema(schema)) &&
@@ -3300,7 +3300,7 @@ export class JavaScriptTypeBuilder extends JsonTypeBuilder {
   /** `[JavaScript]` Creates a Constructor type */
   public Constructor<T extends TSchema[], U extends TSchema>(parameters: [...T], returns: U, options?: SchemaOptions): TConstructor<T, U> {
     const [clonedParameters, clonedReturns] = [TypeClone.Rest(parameters), TypeClone.Type(returns)]
-    return this.Create({ ...options, [Kind]: 'Constructor', type: 'constructor', parameters: clonedParameters, returns: clonedReturns })
+    return this.Create({ ...options, [Kind]: 'Constructor', type: 'Constructor', parameters: clonedParameters, returns: clonedReturns })
   }
   /** `[JavaScript]` Creates a Date type */
   public Date(options: DateOptions = {}): TDate {
@@ -3309,7 +3309,7 @@ export class JavaScriptTypeBuilder extends JsonTypeBuilder {
   /** `[JavaScript]` Creates a Function type */
   public Function<T extends TSchema[], U extends TSchema>(parameters: [...T], returns: U, options?: SchemaOptions): TFunction<T, U> {
     const [clonedParameters, clonedReturns] = [TypeClone.Rest(parameters), TypeClone.Type(returns)]
-    return this.Create({ ...options, [Kind]: 'Function', type: 'function', parameters: clonedParameters, returns: clonedReturns })
+    return this.Create({ ...options, [Kind]: 'Function', type: 'Function', parameters: clonedParameters, returns: clonedReturns })
   }
   /** `[JavaScript]` Extracts the InstanceType from the given Constructor type */
   public InstanceType<T extends TConstructor<any[], any>>(schema: T, options: SchemaOptions = {}): TInstanceType<T> {

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -641,7 +641,7 @@ export type TPick<T extends TSchema = TSchema, K extends keyof any = keyof any> 
 export interface TPromise<T extends TSchema = TSchema> extends TSchema {
   [Kind]: 'Promise'
   static: Promise<Static<T, this['params']>>
-  type: 'promise'
+  type: 'Promise'
   item: TSchema
 }
 // --------------------------------------------------------------------------

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -311,7 +311,7 @@ export type TConstructorParameterArray<T extends readonly TSchema[], P extends u
 export interface TConstructor<T extends TSchema[] = TSchema[], U extends TSchema = TSchema> extends TSchema {
   [Kind]: 'Constructor'
   static: new (...param: TConstructorParameterArray<T, this['params']>) => Static<U, this['params']>
-  type: 'constructor'
+  type: 'Constructor'
   parameters: T
   returns: U
 }
@@ -390,7 +390,7 @@ export type TFunctionParameters<T extends TSchema[], P extends unknown[]> = [...
 export interface TFunction<T extends TSchema[] = TSchema[], U extends TSchema = TSchema> extends TSchema {
   [Kind]: 'Function'
   static: (...param: TFunctionParameters<T, this['params']>) => Static<U, this['params']>
-  type: 'function'
+  type: 'Function'
   parameters: T
   returns: U
 }


### PR DESCRIPTION
This PR corrects the static types representing Promise, Constructor and Function. This PR updates the `type` field to use uppercase type descriptors. Other updates include fixing documentation for Function and Constructor return type field (using `returns` over `return`)