### PR TITLE
Revision 0.31.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.5",
+  "version": "0.31.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.31.5",
+      "version": "0.31.6",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.5",
+  "version": "0.31.6",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/value.ts
+++ b/src/value/value.ts
@@ -78,9 +78,9 @@ export namespace Value {
     return ValueClone.Clone(value)
   }
   /** Decodes a value or throws if error */
-  export function Decode<T extends Types.TSchema>(schema: T, references: Types.TSchema[], value: unknown): Types.StaticDecode<T>
+  export function Decode<T extends Types.TSchema, D = Types.StaticDecode<T>>(schema: T, references: Types.TSchema[], value: unknown): D
   /** Decodes a value or throws if error */
-  export function Decode<T extends Types.TSchema>(schema: T, value: unknown): Types.StaticDecode<T>
+  export function Decode<T extends Types.TSchema, D = Types.StaticDecode<T>>(schema: T, value: unknown): D
   /** Decodes a value or throws if error */
   export function Decode(...args: any[]) {
     const [schema, references, value] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], [], args[1]]
@@ -88,9 +88,9 @@ export namespace Value {
     return ValueTransform.DecodeTransform.Decode(schema, references, value, ValueCheck.Check)
   }
   /** Encodes a value or throws if error */
-  export function Encode<T extends Types.TSchema>(schema: T, references: Types.TSchema[], value: unknown): Types.StaticEncode<T>
+  export function Encode<T extends Types.TSchema, E = Types.StaticEncode<T>>(schema: T, references: Types.TSchema[], value: unknown): E
   /** Encodes a value or throws if error */
-  export function Encode<T extends Types.TSchema>(schema: T, value: unknown): Types.StaticEncode<T>
+  export function Encode<T extends Types.TSchema, E = Types.StaticEncode<T>>(schema: T, value: unknown): E
   /** Encodes a value or throws if error */
   export function Encode(...args: any[]) {
     const [schema, references, value] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], [], args[1]]

--- a/test/static/readonly-optional.ts
+++ b/test/static/readonly-optional.ts
@@ -1,5 +1,5 @@
 import { Expect } from './assert'
-import { Type, TSchema } from '@sinclair/typebox'
+import { Type, TSchema, TReadonlyOptional } from '@sinclair/typebox'
 
 {
   const T = Type.Object({
@@ -8,4 +8,21 @@ import { Type, TSchema } from '@sinclair/typebox'
   Expect(T).ToStatic<{
     readonly A?: string
   }>()
+}
+{
+  const T = Type.ReadonlyOptional(Type.String())
+  function test(_: TReadonlyOptional<TSchema>) {}
+  test(T)
+}
+{
+  const T = Type.Readonly(Type.String())
+  function test(_: TReadonlyOptional<TSchema>) {}
+  // @ts-expect-error
+  test(T)
+}
+{
+  const T = Type.Optional(Type.String())
+  function test(_: TReadonlyOptional<TSchema>) {}
+  // @ts-expect-error
+  test(T)
 }


### PR DESCRIPTION
This PR updates the StaticDecode resolution strategy to use the recursive modifier unwrap as originally suggested in https://github.com/sinclairzx81/typebox/pull/544. This inference path does appear to be somewhat more optimal (and also tests ok against the generic union type submitted on https://github.com/sinclairzx81/typebox/issues/554).

Additional Updates:
- Remove Assertions from Decode Inference (use infer extends)
- Update Value Encode and Decode to forward infer the return type to mitigate function overloading pushing out type instantiations (this needs further review)
- Replace TModifier with TReadonlyOptional intersection type.



CC @HamishWHC