### PR TITLE
More strict type assertions

### DIFF
--- a/test/static/assert.ts
+++ b/test/static/assert.ts
@@ -1,6 +1,7 @@
 import { Static, StaticDecode, StaticEncode, TSchema } from '@sinclair/typebox'
 
 declare const unsatisfiable: unique symbol
+// Warning: `never` and `any` satisfy the constraint `extends Expected<...>`
 type Expected<_> = { [unsatisfiable]: never; }
 
 type ConstrainEqual<T, U> = (
@@ -13,9 +14,35 @@ type ConstrainEqual<T, U> = (
 type CircularHelper<T, U> = [T] extends U ? T : Expected<T>
 type ConstraintMutuallyExtend<T, U> = CircularHelper<T, [U]>
 
-// Comment one or the other to see the difference
+type If<T, Y, N> = T extends true ? Y : N
+type And<T, U> = If<T, U, false>
+type Or<T, U> = If<T, true, U>
+type Not<T> = If<T, false, true>
+
+type IsAny<a> = 0 extends 1 & a ? true : false
+type Extends<T, U> = [T] extends [U] ? true : false
+
+// If U is never, there's nothing we can do
+type ComplexConstraint<T, U> = If<
+  // If U is any, we can't use Expect<T> or it would satisfy the constraint
+  And<Not<IsAny<T>>, IsAny<U>>,
+  never,
+  If<
+    Or<
+      // If they are both any we are happy
+      And<IsAny<T>, IsAny<U>>,
+      // If T extends U, but not because it's any, we are happy
+      And<Extends<T, U>, Not<IsAny<T>>>
+    >,
+    T,
+    Expected<T>
+  >
+>
+
+// Uncomment one of the lines to see the difference
 // type Constraint<T, U> = ConstraintMutuallyExtend<T, U>
-type Constraint<T, U> = ConstrainEqual<T, U>
+// type Constraint<T, U> = ConstrainEqual<T, U>
+type Constraint<T, U> = ComplexConstraint<T, U>
 
 export function Expect<T extends TSchema>(schema: T) {
   return {

--- a/test/static/assert.ts
+++ b/test/static/assert.ts
@@ -20,8 +20,9 @@ type And<T, U> = If<T, U, false>
 type Or<T, U> = If<T, true, U>
 type Not<T> = If<T, false, true>
 
-type IsAny<a> = 0 extends 1 & a ? true : false
 type Extends<T, U> = [T] extends [U] ? true : false
+type IsAny<T> = 0 extends 1 & T ? true : false
+type IsNever<T> = Extends<T, never>
 
 // If U is never, there's nothing we can do
 type ComplexConstraint<T, U> = If<
@@ -45,10 +46,21 @@ type ComplexConstraint<T, U> = If<
 // type Constraint<T, U> = ConstrainEqual<T, U>
 type Constraint<T, U> = ComplexConstraint<T, U>
 
+type ExpectResult<T extends TSchema> = If<
+  IsNever<Static<T>>,
+  { ToStaticNever(): void },
+  {
+    ToStatic<U extends Constraint<Static<T>, U>>(): void,
+    ToStaticDecode<U extends Constraint<StaticDecode<T>, U>>(): void,
+    ToStaticEncode<U extends Constraint<StaticEncode<T>, U>>(): void,
+  }
+>
+
 export function Expect<T extends TSchema>(schema: T) {
   return {
-    ToStatic: <U extends Constraint<Static<T>, U>>() => {},
-    ToStaticDecode: <U extends Constraint<StaticDecode<T>, U>>() => {},
-    ToStaticEncode: <U extends Constraint<StaticEncode<T>, U>>() => {},
-  }
+    ToStatic() {},
+    ToStaticNever() {},
+    ToStaticDecode() {},
+    ToStaticEncode() {},
+  } as ExpectResult<T>;
 }

--- a/test/static/assert.ts
+++ b/test/static/assert.ts
@@ -1,13 +1,16 @@
 import { Static, StaticDecode, StaticEncode, TSchema } from '@sinclair/typebox'
 
+declare const unsatisfiable: unique symbol
+type Expected<_> = { [unsatisfiable]: never; }
+
 type ConstrainEqual<T, U> = (
   <V>() => V extends T ? 1 : 2
 ) extends <V>() => V extends U ? 1 : 2
   ? T
-  : never
+  : Expected<T>
 
 // See https://github.com/microsoft/TypeScript/issues/51011
-type CircularHelper<T, U> = [T] extends U ? T : never
+type CircularHelper<T, U> = [T] extends U ? T : Expected<T>
 type ConstraintMutuallyExtend<T, U> = CircularHelper<T, [U]>
 
 // Comment one or the other to see the difference

--- a/test/static/assert.ts
+++ b/test/static/assert.ts
@@ -1,9 +1,23 @@
 import { Static, StaticDecode, StaticEncode, TSchema } from '@sinclair/typebox'
 
+type ConstrainEqual<T, U> = (
+  <V>() => V extends T ? 1 : 2
+) extends <V>() => V extends U ? 1 : 2
+  ? T
+  : never
+
+// See https://github.com/microsoft/TypeScript/issues/51011
+type CircularHelper<T, U> = [T] extends U ? T : never
+type ConstraintMutuallyExtend<T, U> = CircularHelper<T, [U]>
+
+// Comment one or the other to see the difference
+// type Constraint<T, U> = ConstraintMutuallyExtend<T, U>
+type Constraint<T, U> = ConstrainEqual<T, U>
+
 export function Expect<T extends TSchema>(schema: T) {
   return {
-    ToStatic: <U extends Static<T>>() => {},
-    ToStaticDecode: <U extends StaticDecode<T>>() => {},
-    ToStaticEncode: <U extends StaticEncode<T>>() => {},
+    ToStatic: <U extends Constraint<Static<T>, U>>() => {},
+    ToStaticDecode: <U extends Constraint<StaticDecode<T>, U>>() => {},
+    ToStaticEncode: <U extends Constraint<StaticEncode<T>, U>>() => {},
   }
 }

--- a/test/static/assert.ts
+++ b/test/static/assert.ts
@@ -4,6 +4,7 @@ declare const unsatisfiable: unique symbol
 // Warning: `never` and `any` satisfy the constraint `extends Expected<...>`
 type Expected<_> = { [unsatisfiable]: never; }
 
+// See https://github.com/Microsoft/TypeScript/issues/27024
 type ConstrainEqual<T, U> = (
   <V>() => V extends T ? 1 : 2
 ) extends <V>() => V extends U ? 1 : 2

--- a/test/static/awaited.ts
+++ b/test/static/awaited.ts
@@ -11,10 +11,16 @@ Expect(Type.Awaited(Type.Promise(Type.Promise(Type.String())))).ToStatic<string>
 
 Expect(Type.Awaited(Type.Union([Type.Promise(Type.String()), Type.Number()]))).ToStatic<string | number>()
 
-Expect(Type.Awaited(Type.Intersect([Type.Promise(Type.String()), Type.Number()]))).ToStatic<string & number>()
+Expect(Type.Awaited(Type.Intersect([
+    Type.Promise(Type.Object({ a: Type.String() })),
+    Type.Object({ b: Type.Number() }),
+]))).ToStatic<{ a: string; } & { b: number; }>()
 
 // Two Levels
 
 Expect(Type.Awaited(Type.Union([Type.Promise(Type.Promise(Type.String())), Type.Number()]))).ToStatic<string | number>()
 
-Expect(Type.Awaited(Type.Intersect([Type.Promise(Type.Promise(Type.String())), Type.Number()]))).ToStatic<string & number>()
+Expect(Type.Awaited(Type.Intersect([
+    Type.Promise(Type.Promise(Type.Object({ a: Type.String() }))),
+    Type.Object({ b: Type.Number() }),
+]))).ToStatic<{ a: string; } & { b: number; }>()

--- a/test/static/composite.ts
+++ b/test/static/composite.ts
@@ -63,7 +63,7 @@ import { Type, TObject, TIntersect, TNumber, TBoolean } from '@sinclair/typebox'
   })
   const T = Type.Composite([A, B])
   Expect(T).ToStatic<{
-    A: number | undefined
+    A?: number | undefined
   }>()
 }
 {

--- a/test/static/exclude.ts
+++ b/test/static/exclude.ts
@@ -3,7 +3,7 @@ import { Expect } from './assert'
 
 {
   const T = Type.Exclude(Type.String(), Type.String())
-  Expect(T).ToStatic<never>()
+  Expect(T).ToStaticNever()
 }
 {
   const T = Type.Exclude(Type.String(), Type.Number())
@@ -21,7 +21,7 @@ import { Expect } from './assert'
   const B = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])])
 
   const T = Type.Exclude(A, B)
-  Expect(T).ToStatic<never>()
+  Expect(T).ToStaticNever()
 }
 {
   const A = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])])
@@ -44,7 +44,7 @@ import { Expect } from './assert'
   const B = Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])
 
   const T = Type.Exclude(A, B)
-  Expect(T).ToStatic<never>()
+  Expect(T).ToStaticNever()
 }
 {
   const A = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])])
@@ -67,7 +67,7 @@ import { Expect } from './assert'
   const B = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])])
 
   const T = Type.Exclude(A, B)
-  Expect(T).ToStatic<never>()
+  Expect(T).ToStaticNever()
 }
 {
   const A = Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])

--- a/test/static/indexed.ts
+++ b/test/static/indexed.ts
@@ -48,19 +48,19 @@ import { Type, Static } from '@sinclair/typebox'
   const A = Type.Tuple([])
   const R = Type.Index(A, Type.Number())
   type O = Static<typeof R>
-  Expect(R).ToStatic<never>()
+  Expect(R).ToStaticNever()
 }
 {
   const A = Type.Object({})
   const R = Type.Index(A, Type.BigInt()) // Support Overload
   type O = Static<typeof R>
-  Expect(R).ToStatic<never>()
+  Expect(R).ToStatic<unknown>()
 }
 {
   const A = Type.Array(Type.Number())
   const R = Type.Index(A, Type.BigInt()) // Support Overload
   type O = Static<typeof R>
-  Expect(R).ToStatic<never>()
+  Expect(R).ToStatic<unknown>()
 }
 // ------------------------------------------------------------------
 // Intersections
@@ -115,7 +115,7 @@ import { Type, Static } from '@sinclair/typebox'
   const C = Type.Intersect([A, B])
   const R = Type.Index(C, ['x'])
   type O = Static<typeof R>
-  Expect(R).ToStatic<never>()
+  Expect(R).ToStaticNever()
 }
 {
   type A = { x: string; y: number }

--- a/test/static/intersect.ts
+++ b/test/static/intersect.ts
@@ -1,5 +1,5 @@
 import { Expect } from './assert'
-import { Type, TOptional, TString, Static } from '@sinclair/typebox'
+import { Type, Static } from '@sinclair/typebox'
 
 {
   const A = Type.Object({
@@ -32,8 +32,7 @@ import { Type, TOptional, TString, Static } from '@sinclair/typebox'
   })
   const T = Type.Intersect([A, B])
 
-  Expect(T.properties.A).ToStatic<TOptional<TString>>()
-  Expect(T.properties.B).ToStatic<TString>()
+  Expect(T).ToStatic<{ A?: string | undefined } & { B: string }>()
 }
 
 // https://github.com/sinclairzx81/typebox/issues/113

--- a/test/static/never.ts
+++ b/test/static/never.ts
@@ -3,5 +3,5 @@ import { Type } from '@sinclair/typebox'
 
 {
   const T = Type.Never()
-  Expect(T).ToStatic<never>()
+  Expect(T).ToStaticNever()
 }

--- a/test/static/record.ts
+++ b/test/static/record.ts
@@ -73,10 +73,14 @@ import { Type, Static } from '@sinclair/typebox'
 
 {
   enum E {
-    A = 'A',
-    B = 'B',
-    C = 'C',
+    A = 'X',
+    B = 'Y',
+    C = 'Z',
   };
   const T = Type.Record(Type.Enum(E), Type.Number());
-  Expect(T).ToStatic<Record<E, string>>();
+  Expect(T).ToStatic<{
+    X: number;
+    Y: number;
+    Z: number;
+  }>();
 }

--- a/test/static/record.ts
+++ b/test/static/record.ts
@@ -70,3 +70,13 @@ import { Type, Static } from '@sinclair/typebox'
 
   Expect(T).ToStatic<Record<number, string>>()
 }
+
+{
+  enum E {
+    A = 'A',
+    B = 'B',
+    C = 'C',
+  };
+  const T = Type.Record(Type.Enum(E), Type.Number());
+  Expect(T).ToStatic<Record<E, string>>();
+}

--- a/test/static/recursive.ts
+++ b/test/static/recursive.ts
@@ -33,8 +33,8 @@ import { Type, Static } from '@sinclair/typebox'
   )
   const T = Type.Partial(R)
   Expect(T).ToStatic<{
-    id: string | undefined
-    nodes: Static<typeof T>[] | undefined
+    id?: string | undefined
+    nodes?: Static<typeof T>[] | undefined
   }>()
 }
 {

--- a/test/static/rest.ts
+++ b/test/static/rest.ts
@@ -4,13 +4,13 @@ import { Type, Static } from '@sinclair/typebox'
   // union never
   const A = Type.String()
   const B = Type.Union(Type.Rest(A))
-  Expect(B).ToStatic<never>()
+  Expect(B).ToStaticNever()
 }
 {
   // intersect never
   const A = Type.String()
   const B = Type.Intersect(Type.Rest(A))
-  Expect(B).ToStatic<never>()
+  Expect(B).ToStaticNever()
 }
 {
   // tuple

--- a/test/static/transform.ts
+++ b/test/static/transform.ts
@@ -84,7 +84,7 @@ import { Expect } from './assert'
     .Encode((value) => ({
       id: 'A',
       nodes: [
-        { id: 'B', nodes: [] }, 
+        { id: 'B', nodes: [] },
         { id: 'C', nodes: [] }
       ]
     }))
@@ -112,7 +112,7 @@ import { Expect } from './assert'
     .Encode((value) => ({
       id: 'A',
       nodes: [
-        { id: 'B', nodes: [] }, 
+        { id: 'B', nodes: [] },
         { id: 'C', nodes: [] }
       ]
     }))
@@ -160,8 +160,8 @@ import { Expect } from './assert'
   // null to typebox type
   // prettier-ignore
   const T = Type.Transform(Type.Null())
-    .Decode(value => Type.Object({ 
-      x: Type.Number(), 
+    .Decode(value => Type.Object({
+      x: Type.Number(),
       y: Type.Number(),
       z: Type.Number()
     }))
@@ -189,8 +189,7 @@ import { Expect } from './assert'
     x: Type.Optional(Type.Number()),
     y: Type.Optional(Type.Number())
   })
-  Expect(T).ToStaticDecode<{ x: undefined; y: undefined }>()
-  Expect(T).ToStaticDecode<{ x: 1; y: 1 }>()
+  Expect(T).ToStaticDecode<{ x?: number | undefined; y?: number | undefined; }>()
 }
 {
   // ensure decode as readonly
@@ -199,7 +198,7 @@ import { Expect } from './assert'
     x: Type.Readonly(Type.Number()),
     y: Type.Readonly(Type.Number())
   })
-  Expect(T).ToStaticDecode<{ readonly x: 1; readonly y: 1 }>()
+  Expect(T).ToStaticDecode<{ readonly x: number; readonly y: number }>()
 }
 {
   // ensure decode as optional union
@@ -210,9 +209,7 @@ import { Expect } from './assert'
       Type.Number()
     ]))
   })
-  Expect(T).ToStaticDecode<{ x: 1 }>()
-  Expect(T).ToStaticDecode<{ x: '1' }>()
-  Expect(T).ToStaticDecode<{ x: undefined }>()
+  Expect(T).ToStaticDecode<{ x?: string | number | undefined }>()
 }
 {
   // should decode within generic function context

--- a/test/static/union.ts
+++ b/test/static/union.ts
@@ -69,5 +69,5 @@ import { Type, Static } from '@sinclair/typebox'
 
 {
   const T = Type.Union([])
-  Expect(T).ToStatic<never>()
+  Expect(T).ToStaticNever()
 }


### PR DESCRIPTION
# Alternatives

In the PR there are three possible implementations of constraints:
1. Strict equality
2. Mutually assignable
3. A complex set of conditions

# The good news

All of them fix the original issue to write a regression test for a record with an enum as key.
The following assertions fails on master and succeeds on the enum branch:

https://github.com/sinclairzx81/typebox/blob/23baf023d0d708bf6fc2d706a9796d91e6eb306c/test/static/record.ts#L81

# The bad news

A common shortcoming to all the alternatives (including the current implementation) is that `.ToStatic<never>()` always succeeds, because `never` is assignable to any type, and I don't think there is a way around it unless we change completely the `Expect(x).ToStatic<Y>()` pattern.

E.g. this assertion is completely useless:

https://github.com/sinclairzx81/typebox/blob/18d1cf7ac57c8b5f0292cb02ddbd1707e86c8c4c/test/static/exclude.ts#L5-L6

If this is a deal breaker you can stop reading here and we should brainstorm some way to rewrite static tests.

# The issue with strict equality

I like strict equality because catches even subtle changes, however the following case gives error even though it shouldn't and I can't make it work:

https://github.com/sinclairzx81/typebox/blob/18d1cf7ac57c8b5f0292cb02ddbd1707e86c8c4c/test/static/omit.ts#L89-L94

`Static<typeof P>` is exactly as specified in `.ToStatic<...>`, but somehow they are considered different, because the type literal is simplified to `{ x: number, y: number }` while `Static<typeof P>` somehow preserves `({} | {} | {})` as is.

See also:
- https://github.com/microsoft/TypeScript/issues/51019
- https://dev.to/tylim88/typescript-caveat-6-non-collapsing-object-unions-2i87

The only workaround I can't think of is to treat this test as a special case and just check for assignability.

# The issue with mutual assignability

Strict equality showed that `T.properties` is `any` and these assertions passed even though it is likely not what they were meant to be:

https://github.com/sinclairzx81/typebox/blob/18d1cf7ac57c8b5f0292cb02ddbd1707e86c8c4c/test/static/intersect.ts#L35-L36

Unfortunately `any` is mutually assignable to every type except for `never`, so this issue would go undetected.

# The issue with the complex set of conditions

With this last attempt I tried to cover some corner cases of mutual assignability. It detects when the inferred type is `any` unless explicitly expected to be so.

However the following case is caught only by strict equality:

https://github.com/sinclairzx81/typebox/blob/23baf023d0d708bf6fc2d706a9796d91e6eb306c/test/static/record.ts#L20-L23

I can't tell if there could be other common cases that would go undetected.

# Final considerations

I'd go for strict equality, if we find acceptable to have a special case for the problematic test. Otherwise I think the third option strikes the best balance, but the implementation is way more complex and I'm not sure it's justified.