### PR TITLE
Fix/check array with unique items/non latin characters

### DIFF
--- a/src/value/hash.ts
+++ b/src/value/hash.ts
@@ -57,7 +57,7 @@ export enum ByteMarker {
 // --------------------------------------------------------------------------
 let Accumulator = BigInt('14695981039346656037')
 const [Prime, Size] = [BigInt('1099511628211'), BigInt('2') ** BigInt('64')]
-const Bytes = Array.from({ length: 256 }).map((_, i) => BigInt(i))
+const Bytes = Array.from({ length: 2 ** 16 }).map((_, i) => BigInt(i)) // 2 ** 16 is max for charCodeAt() https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt
 const F64 = new Float64Array(1)
 const F64In = new DataView(F64.buffer)
 const F64Out = new Uint8Array(F64.buffer)

--- a/test/runtime/compiler/array.ts
+++ b/test/runtime/compiler/array.ts
@@ -98,7 +98,7 @@ describe('compiler/Array', () => {
   it('Should validate for an array with objects when items are distinct objects', () => {
     const T = Type.Array(
       Type.Object({ a: Type.String(), b: Type.String() }),
-      { uniqueItems: true, },
+      { uniqueItems: true },
     )
     Ok(T, [
       { a: '1', b: 'hieróglyphos' },

--- a/test/runtime/compiler/array.ts
+++ b/test/runtime/compiler/array.ts
@@ -95,6 +95,17 @@ describe('compiler/Array', () => {
     const T = Type.Array(Type.Number(), { uniqueItems: true })
     Fail(T, [0, 0])
   })
+  it('Should validate for an array with objects when items are distinct objects', () => {
+    const T = Type.Array(
+      Type.Object({ a: Type.String(), b: Type.String() }),
+      { uniqueItems: true, },
+    )
+    Ok(T, [
+      { a: '1', b: 'hieróglyphos' },
+      { a: '2', b: 'γράμματα' },
+      { a: '3', b: 'абвгд' },
+    ])
+  })
   // ---------------------------------------------------------
   // Contains
   // ---------------------------------------------------------


### PR DESCRIPTION
Previous version works only for latin characters(exact for first 256 charCodes) and when u check array with objects (!NB with option { uniqueItems: true }) 

with **non latin** strings u got exception on Value.Check() 

TypeError: Cannot mix BigInt and other types, use explicit conversions
      at FNV1A64 (target\test\runtime\index.js:1786:29)
      at StringType (target\test\runtime\index.js:1744:5)
      at Visit (target\test\runtime\index.js:1776:12)
      at ObjectType (target\test\runtime\index.js:1738:5)
      at Visit (target\test\runtime\index.js:1774:12)
      at Hash (target\test\runtime\index.js:1791:3)
      at hashFunction (target\test\runtime\index.js:3291:14)
      at eval (eval at Compile (target\test\runtime\index.js:3275:41), <anonymous>:7:87)
      at TypeCheck.check [as checkFunc] (eval at Compile (target\test\runtime\index.js:3275:41), <anonymous>:7:181)
      at TypeCheck.Check (target\test\runtime\index.js:2773:17)
      at Ok (target\test\runtime\index.js:5089:20)
      at Context.<anonymous> (target\test\runtime\index.js:5289:5)
      at process.processImmediate (node:internal/timers:476:21)

finally fixed them and added test