### PR TITLE
Support Infinite Template Literal Record Key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.15",
+  "version": "0.31.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.31.15",
+      "version": "0.31.16",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.15",
+  "version": "0.31.16",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -656,11 +656,11 @@ export type TRecordFromUnionRest<K extends TSchema[], T extends TSchema> = K ext
   L extends TLiteralNumber ? TRecordFromUnionLiteralNumber<L, T> & TRecordFromUnionRest<AssertRest<R>, T> :
 {}) : {}
 export type TRecordFromUnion<K extends TSchema[], T extends TSchema> = Ensure<TObject<AssertProperties<Evaluate<TRecordFromUnionRest<K, T>>>>>
-export type TRecordFromTemplateLiteralKeyInfinite<T extends TSchema> = Ensure<TRecord<TString, T>>
+export type TRecordFromTemplateLiteralKeyInfinite<K extends TTemplateLiteral, T extends TSchema> = Ensure<TRecord<K, T>>
 export type TRecordFromTemplateLiteralKeyFinite<K extends TTemplateLiteral, T extends TSchema, I = Static<K>> = Ensure<TObject<Evaluate<{ [_ in Assert<I, string>]: T }>>>
 // prettier-ignore
 export type TRecordFromTemplateLiteralKey<K extends TTemplateLiteral, T extends TSchema> = IsTemplateLiteralFinite<K> extends false 
-  ? TRecordFromTemplateLiteralKeyInfinite<T> 
+  ? TRecordFromTemplateLiteralKeyInfinite<K, T> 
   : TRecordFromTemplateLiteralKeyFinite<K, T>
 export type TRecordFromLiteralStringKey<K extends TLiteralString, T extends TSchema> = Ensure<TObject<{ [_ in K['const']]: T }>>
 export type TRecordFromLiteralNumberKey<K extends TLiteralNumber, T extends TSchema> = Ensure<TObject<{ [_ in K['const']]: T }>>

--- a/test/runtime/compiler-ajv/record.ts
+++ b/test/runtime/compiler-ajv/record.ts
@@ -175,4 +175,67 @@ describe('compiler-ajv/Record', () => {
     const T = Type.Record(Type.Number(), Type.String(), { additionalProperties: Type.Boolean() })
     Ok(T, { 1: '', 2: '', x: true })
   })
+  // ----------------------------------------------------------------
+  // TemplateLiteral
+  // ----------------------------------------------------------------
+  it('TemplateLiteral 1', () => {
+    const K = Type.TemplateLiteral('key${number}')
+    const R = Type.Record(K, Type.Number(), { additionalProperties: false })
+    Ok(R, {
+      key0: 1,
+      key1: 1,
+      key2: 1,
+    })
+  })
+  it('TemplateLiteral 2', () => {
+    const K = Type.TemplateLiteral('key${number}')
+    const R = Type.Record(K, Type.Number())
+    Ok(R, { keyA: 0 })
+  })
+  it('TemplateLiteral 3', () => {
+    const K = Type.TemplateLiteral('key${number}')
+    const R = Type.Record(K, Type.Number(), { additionalProperties: false })
+    Fail(R, { keyA: 0 })
+  })
+  it('TemplateLiteral 4', () => {
+    const K = Type.TemplateLiteral('key${number}')
+    const R = Type.Record(K, Type.Number())
+    const T = Type.Object({ x: Type.Number(), y: Type.Number() })
+    const I = Type.Intersect([R, T], { unevaluatedProperties: false })
+    Ok(I, {
+      x: 1,
+      y: 2,
+      key0: 1,
+      key1: 1,
+      key2: 1,
+    })
+  })
+  it('TemplateLiteral 5', () => {
+    const K = Type.TemplateLiteral('key${number}')
+    const R = Type.Record(K, Type.Number())
+    const T = Type.Object({ x: Type.Number(), y: Type.Number() })
+    const I = Type.Intersect([R, T])
+    Ok(I, {
+      x: 1,
+      y: 2,
+      z: 3,
+      key0: 1,
+      key1: 1,
+      key2: 1,
+    })
+  })
+  it('TemplateLiteral 6', () => {
+    const K = Type.TemplateLiteral('key${number}')
+    const R = Type.Record(K, Type.Number())
+    const T = Type.Object({ x: Type.Number(), y: Type.Number() })
+    const I = Type.Intersect([R, T], { unevaluatedProperties: false })
+    Fail(I, {
+      x: 1,
+      y: 2,
+      z: 3,
+      key0: 1,
+      key1: 1,
+      key2: 1,
+    })
+  })
 })

--- a/test/runtime/compiler/record.ts
+++ b/test/runtime/compiler/record.ts
@@ -206,4 +206,67 @@ describe('compiler/Record', () => {
     const T = Type.Record(Type.Number(), Type.String(), { additionalProperties: Type.Boolean() })
     Ok(T, { 1: '', 2: '', x: true })
   })
+  // ----------------------------------------------------------------
+  // TemplateLiteral
+  // ----------------------------------------------------------------
+  it('TemplateLiteral 1', () => {
+    const K = Type.TemplateLiteral('key${number}')
+    const R = Type.Record(K, Type.Number(), { additionalProperties: false })
+    Ok(R, {
+      key0: 1,
+      key1: 1,
+      key2: 1,
+    })
+  })
+  it('TemplateLiteral 2', () => {
+    const K = Type.TemplateLiteral('key${number}')
+    const R = Type.Record(K, Type.Number())
+    Ok(R, { keyA: 0 })
+  })
+  it('TemplateLiteral 3', () => {
+    const K = Type.TemplateLiteral('key${number}')
+    const R = Type.Record(K, Type.Number(), { additionalProperties: false })
+    Fail(R, { keyA: 0 })
+  })
+  it('TemplateLiteral 4', () => {
+    const K = Type.TemplateLiteral('key${number}')
+    const R = Type.Record(K, Type.Number())
+    const T = Type.Object({ x: Type.Number(), y: Type.Number() })
+    const I = Type.Intersect([R, T], { unevaluatedProperties: false })
+    Ok(I, {
+      x: 1,
+      y: 2,
+      key0: 1,
+      key1: 1,
+      key2: 1,
+    })
+  })
+  it('TemplateLiteral 5', () => {
+    const K = Type.TemplateLiteral('key${number}')
+    const R = Type.Record(K, Type.Number())
+    const T = Type.Object({ x: Type.Number(), y: Type.Number() })
+    const I = Type.Intersect([R, T])
+    Ok(I, {
+      x: 1,
+      y: 2,
+      z: 3,
+      key0: 1,
+      key1: 1,
+      key2: 1,
+    })
+  })
+  it('TemplateLiteral 6', () => {
+    const K = Type.TemplateLiteral('key${number}')
+    const R = Type.Record(K, Type.Number())
+    const T = Type.Object({ x: Type.Number(), y: Type.Number() })
+    const I = Type.Intersect([R, T], { unevaluatedProperties: false })
+    Fail(I, {
+      x: 1,
+      y: 2,
+      z: 3,
+      key0: 1,
+      key1: 1,
+      key2: 1,
+    })
+  })
 })

--- a/test/static/record.ts
+++ b/test/static/record.ts
@@ -70,7 +70,6 @@ import { Type, Static } from '@sinclair/typebox'
 
   Expect(T).ToStatic<Record<number, string>>()
 }
-
 {
   enum E {
     A = 'X',
@@ -79,4 +78,20 @@ import { Type, Static } from '@sinclair/typebox'
   }
   const T = Type.Record(Type.Enum(E), Type.Number())
   Expect(T).ToStatic<{}>()
+}
+{
+  // should support infinite record keys
+  // https://github.com/sinclairzx81/typebox/issues/604
+  const K = Type.TemplateLiteral('key${number}')
+  const R = Type.Record(K, Type.Number())
+  Expect(R).ToStatic<Record<`key${number}`, number>>()
+}
+{
+  // should support infinite record keys with intersect
+  // https://github.com/sinclairzx81/typebox/issues/604
+  const K = Type.TemplateLiteral('key${number}')
+  const R = Type.Record(K, Type.Number())
+  const T = Type.Object({ x: Type.Number(), y: Type.Number() })
+  const I = Type.Intersect([R, T])
+  Expect(I).ToStatic<Record<`key${number}`, number> & { x: number; y: number }>()
 }


### PR DESCRIPTION
This PR updates Record Template Literal inference to correctly infer infinitely expansive template literal keys. These are keys with either `${number}` or `${string}` encoded in the pattern.