### PR TITLE
Support Union Interior Transform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.17",
+  "version": "0.31.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.31.17",
+      "version": "0.31.18",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.17",
+  "version": "0.31.18",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/transform.ts
+++ b/src/value/transform.ts
@@ -403,12 +403,20 @@ export namespace EncodeTransform {
     return IsArray(schema.items) ? schema.items.map((schema, index) => Visit(schema, references, value1[index])) : []
   }
   function TUnion(schema: Types.TUnion, references: Types.TSchema[], value: any) {
+    const value1 = Default(schema, value)
+    // encoded union pass
     for (const subschema of schema.anyOf) {
-      if (!checkFunction(subschema, references, value)) continue
-      const value1 = Visit(subschema, references, value)
-      return Default(schema, value1)
+      if (!checkFunction(subschema, references, value1)) continue
+      const value2 = Visit(subschema, references, value)
+      return Default(schema, value2)
     }
-    return Default(schema, value)
+    // non-encoded union pass
+    for (const subschema of schema.anyOf) {
+      const value2 = Visit(subschema, references, value)
+      if (!checkFunction(schema, references, value2)) continue
+      return Default(schema, value2)
+    }
+    return value1
   }
   function Visit(schema: Types.TSchema, references: Types.TSchema[], value: any): any {
     const references_ = typeof schema.$id === 'string' ? [...references, schema] : references

--- a/src/value/transform.ts
+++ b/src/value/transform.ts
@@ -403,20 +403,19 @@ export namespace EncodeTransform {
     return IsArray(schema.items) ? schema.items.map((schema, index) => Visit(schema, references, value1[index])) : []
   }
   function TUnion(schema: Types.TUnion, references: Types.TSchema[], value: any) {
-    const value1 = Default(schema, value)
-    // encoded union pass
+    // test value against union variants
     for (const subschema of schema.anyOf) {
-      if (!checkFunction(subschema, references, value1)) continue
-      const value2 = Visit(subschema, references, value)
-      return Default(schema, value2)
+      if (!checkFunction(subschema, references, value)) continue
+      const value1 = Visit(subschema, references, value)
+      return Default(schema, value1)
     }
-    // non-encoded union pass
+    // test transformed value against union variants
     for (const subschema of schema.anyOf) {
-      const value2 = Visit(subschema, references, value)
-      if (!checkFunction(schema, references, value2)) continue
-      return Default(schema, value2)
+      const value1 = Visit(subschema, references, value)
+      if (!checkFunction(schema, references, value1)) continue
+      return Default(schema, value1)
     }
-    return value1
+    return Default(schema, value)
   }
   function Visit(schema: Types.TSchema, references: Types.TSchema[], value: any): any {
     const references_ = typeof schema.$id === 'string' ? [...references, schema] : references

--- a/test/runtime/value/transform/union.ts
+++ b/test/runtime/value/transform/union.ts
@@ -167,34 +167,35 @@ describe('value/transform/Union', () => {
     Assert.Throws(() => Value.Decode(T4, null))
   })
   // --------------------------------------------------------
-  // Generic Union Transform
+  // Interior Union Transform
   //
   // https://github.com/sinclairzx81/typebox/issues/631
   // --------------------------------------------------------
-  const Nullable = <T extends TSchema>(schema: T) => Type.Union([schema, Type.Null()])
-  // prettier-ignore
-  const DateType = () => Type.Transform(Type.String())
+  const T51 = Type.Transform(Type.String())
     .Decode((value) => new Date(value))
     .Encode((value) => value.toISOString())
-  it('Should decode generic union 1', () => {
-    const T = Nullable(DateType())
-    const R = Value.Decode(T, null)
+  const T52 = Type.Union([Type.Null(), T51])
+  it('Should decode interior union 1', () => {
+    const R = Value.Decode(T52, null)
     Assert.IsEqual(R, null)
   })
-  it('Should decode generic union 2', () => {
-    const T = Nullable(DateType())
-    const R = Value.Decode(T, new Date().toISOString())
+  it('Should decode interior union 2', () => {
+    const R = Value.Decode(T52, new Date().toISOString())
     Assert.IsInstanceOf(R, Date)
   })
-  it('Should encode generic union 1', () => {
-    const T = Nullable(DateType())
-    const R = Value.Encode(T, null)
+  it('Should encode interior union 1', () => {
+    const R = Value.Encode(T52, null)
     Assert.IsEqual(R, null)
   })
-  it('Should encode generic union 2', () => {
-    const T = Nullable(DateType())
+  it('Should encode interior union 2', () => {
     const D = new Date()
-    const R = Value.Encode(T, D)
+    const R = Value.Encode(T52, D)
     Assert.IsEqual(R, D.toISOString())
+  })
+  it('Should throw on interior union decode', () => {
+    Assert.Throws(() => Value.Decode(T52, {}))
+  })
+  it('Should throw on interior union encode', () => {
+    Assert.Throws(() => Value.Encode(T52, 1))
   })
 })


### PR DESCRIPTION
This PR applies a fix to Union transform encoding. The update ensures interior union variants are appropriately encoded by implementing two pass union encoding check. The first check attempts to encode against the direct value (if matching one of the union variants), the second check tests union variants against the transformed value.

The implementation supports the following case where the transform D is embedded within a union type.

```typescript
const D = Type.Transform(Type.String())
  .Decode(value => new Date())
  .Encode(value => value.toISOString())

const T = Type.Union([Type.Null(), D]) // transform interior to union


Value.Decode(T, new Date().toISOString()) // Date
Value.Decode(T, null)                     // null
Value.Encode(T, new Date())               // string (iso)
Value.Decode(T, null)                     // null
```