### PR TITLE
Support Enum Key Inference on Record

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.19",
+  "version": "0.31.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.31.19",
+      "version": "0.31.20",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.19",
+  "version": "0.31.20",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -650,7 +650,7 @@ export interface TPromise<T extends TSchema = TSchema> extends TSchema {
 export type TRecordFromUnionLiteralString<K extends TLiteralString, T extends TSchema> = { [_ in K['const']]: T }
 export type TRecordFromUnionLiteralNumber<K extends TLiteralNumber, T extends TSchema> = { [_ in K['const']]: T }
 // prettier-ignore
-export type TRecordFromEnumKey<K extends TSchema, T extends TSchema> = Ensure<TRecord<K, T>>
+export type TRecordFromEnumKey<K extends TEnum, T extends TSchema> = Ensure<TRecord<K, T>>
 // prettier-ignore
 export type TRecordFromUnionRest<K extends TSchema[], T extends TSchema> = K extends [infer L, ...infer R] ? (
   L extends TUnion<infer S> ? TRecordFromUnionRest<S, T> & TRecordFromUnionRest<AssertRest<R>, T> :

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -650,6 +650,8 @@ export interface TPromise<T extends TSchema = TSchema> extends TSchema {
 export type TRecordFromUnionLiteralString<K extends TLiteralString, T extends TSchema> = { [_ in K['const']]: T }
 export type TRecordFromUnionLiteralNumber<K extends TLiteralNumber, T extends TSchema> = { [_ in K['const']]: T }
 // prettier-ignore
+export type TRecordFromEnumKey<K extends TSchema, T extends TSchema> = Ensure<TRecord<K, T>>
+// prettier-ignore
 export type TRecordFromUnionRest<K extends TSchema[], T extends TSchema> = K extends [infer L, ...infer R] ? (
   L extends TUnion<infer S> ? TRecordFromUnionRest<S, T> & TRecordFromUnionRest<AssertRest<R>, T> :
   L extends TLiteralString ? TRecordFromUnionLiteralString<L, T> & TRecordFromUnionRest<AssertRest<R>, T> :
@@ -669,6 +671,7 @@ export type TRecordFromNumberKey<K extends TNumber, T extends TSchema> = Ensure<
 export type TRecordFromIntegerKey<K extends TInteger, T extends TSchema> = Ensure<TRecord<K, T>>
 // prettier-ignore
 export type TRecordResolve<K extends TSchema, T extends TSchema> = 
+  K extends TEnum<infer _> ? TRecordFromEnumKey<K, T> : // Enum before Union (intercept Hint)
   K extends TUnion<infer S> ? TRecordFromUnion<S, T> :
   K extends TTemplateLiteral ? TRecordFromTemplateLiteralKey<K, T> :
   K extends TLiteralString ? TRecordFromLiteralStringKey<K, T> :

--- a/test/static/record.ts
+++ b/test/static/record.ts
@@ -71,13 +71,46 @@ import { Type, Static } from '@sinclair/typebox'
   Expect(T).ToStatic<Record<number, string>>()
 }
 {
+  // Should support enum keys 1
   enum E {
     A = 'X',
     B = 'Y',
     C = 'Z',
   }
   const T = Type.Record(Type.Enum(E), Type.Number())
-  Expect(T).ToStatic<{}>()
+  Expect(T).ToStatic<{
+    X: number
+    Y: number
+    Z: number
+  }>()
+}
+{
+  // Should support enum keys 2
+  enum E {
+    A,
+    B,
+    C,
+  }
+  const T = Type.Record(Type.Enum(E), Type.Number())
+  Expect(T).ToStatic<{
+    0: number
+    1: number
+    2: number
+  }>()
+}
+{
+  // Should support enum keys 3
+  enum E {
+    A = 1,
+    B = '2',
+    C = 'Z',
+  }
+  const T = Type.Record(Type.Enum(E), Type.Number())
+  Expect(T).ToStatic<{
+    1: number
+    2: number
+    Z: number
+  }>()
 }
 {
   // should support infinite record keys


### PR DESCRIPTION
This PR adds an additional inference path for Record Keys of type Enum

```typescript
enum E { A, B, C }

const T = Type.Record(Type.Enum(E), Type.Number())

type T = Static<typeof T> // type T = {
                          //   0: number;
                          //   1: number;
                          //   2: number;
                          // }

console.log(T)            // {
                          //   type: 'object',
                          //   properties: {
                          //     '0': { type: 'number', [Symbol(TypeBox.Kind)]: 'Number' },
                          //     '1': { type: 'number', [Symbol(TypeBox.Kind)]: 'Number' },
                          //     '2': { type: 'number', [Symbol(TypeBox.Kind)]: 'Number' }
                          //   },
                          //   required: [ '0', '1', '2' ],
                          //   [Symbol(TypeBox.Hint)]: 'Record',
                          //   [Symbol(TypeBox.Kind)]: 'Object'
                          // }
```
Fixes https://github.com/sinclairzx81/typebox/issues/646