### PR TITLE
Return Object type from Record when using Enum keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.21",
+  "version": "0.31.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.31.21",
+      "version": "0.31.22",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.21",
+  "version": "0.31.22",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -650,7 +650,7 @@ export interface TPromise<T extends TSchema = TSchema> extends TSchema {
 export type TRecordFromUnionLiteralString<K extends TLiteralString, T extends TSchema> = { [_ in K['const']]: T }
 export type TRecordFromUnionLiteralNumber<K extends TLiteralNumber, T extends TSchema> = { [_ in K['const']]: T }
 // prettier-ignore
-export type TRecordFromEnumKey<K extends TEnum, T extends TSchema> = Ensure<TRecord<K, T>>
+export type TRecordFromEnumKey<K extends Record<string, string | number>, T extends TSchema> = Ensure<TObject<{ [_ in K[keyof K]]: T }>>
 // prettier-ignore
 export type TRecordFromUnionRest<K extends TSchema[], T extends TSchema> = K extends [infer L, ...infer R] ? (
   L extends TUnion<infer S> ? TRecordFromUnionRest<S, T> & TRecordFromUnionRest<AssertRest<R>, T> :
@@ -671,7 +671,7 @@ export type TRecordFromNumberKey<K extends TNumber, T extends TSchema> = Ensure<
 export type TRecordFromIntegerKey<K extends TInteger, T extends TSchema> = Ensure<TRecord<K, T>>
 // prettier-ignore
 export type TRecordResolve<K extends TSchema, T extends TSchema> = 
-  K extends TEnum<infer _> ? TRecordFromEnumKey<K, T> : // Enum before Union (intercept Hint)
+  K extends TEnum<infer S> ? TRecordFromEnumKey<S, T> : // Enum before Union (intercept Hint)
   K extends TUnion<infer S> ? TRecordFromUnion<S, T> :
   K extends TTemplateLiteral ? TRecordFromTemplateLiteralKey<K, T> :
   K extends TLiteralString ? TRecordFromLiteralStringKey<K, T> :

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -2915,6 +2915,7 @@ export class JsonTypeBuilder extends TypeBuilder {
   }
   /** `[Json]` Creates a Enum type */
   public Enum<V extends TEnumValue, T extends Record<TEnumKey, V>>(item: T, options: SchemaOptions = {}): TEnum<T> {
+    if (ValueGuard.IsUndefined(item)) return this.Throw('Enum undefined or empty')
     // prettier-ignore
     const values1 = Object.getOwnPropertyNames(item).filter((key) => isNaN(key as any)).map((key) => item[key]) as T[keyof T][]
     const values2 = [...new Set(values1)]

--- a/test/static/record.ts
+++ b/test/static/record.ts
@@ -128,3 +128,51 @@ import { Type, Static } from '@sinclair/typebox'
   const I = Type.Intersect([R, T])
   Expect(I).ToStatic<Record<`key${number}`, number> & { x: number; y: number }>()
 }
+{
+  // expect T as Object
+  enum E {
+    A,
+    B,
+    C,
+  }
+  const T = Type.Record(Type.Enum(E), Type.Number())
+  Expect(T).ToStatic<{
+    0: number
+    1: number
+    2: number
+  }>
+}
+{
+  // expect T as Partial Object
+  enum E {
+    A,
+    B,
+    C,
+  }
+  const T = Type.Partial(Type.Record(Type.Enum(E), Type.Number()))
+  Expect(T).ToStatic<{
+    0?: number
+    1?: number
+    2?: number
+  }>
+}
+{
+  // expect T to support named properties
+  enum E {
+    A = 'A',
+    B = 'B',
+    C = 'C',
+  }
+  const T = Type.Record(Type.Enum(E), Type.Number())
+  Expect(T).ToStatic<{
+    A: number
+    B: number
+    C: number
+  }>
+}
+{
+  // expect T to support named properties
+  enum E {}
+  const T = Type.Record(Type.Enum(E), Type.Number())
+  Expect(T).ToStatic<{}>
+}


### PR DESCRIPTION
This PR updates the return type of Record to give TObject when specifying keys of type TEnum. This is possible (and reasonable) as enums are fixed size.

Fixes https://github.com/sinclairzx81/typebox/issues/651