### PR TITLE
Improve Function and Constructor Inference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.23",
+  "version": "0.31.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.31.23",
+      "version": "0.31.24",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.23",
+  "version": "0.31.24",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -308,11 +308,12 @@ export type TComposite<T extends TObject[]> = TIntersect<T> extends TIntersect
 // --------------------------------------------------------------------------
 // TConstructor
 // --------------------------------------------------------------------------
-export type TConstructorReturnType<T extends TSchema, P extends unknown[]> = Static<T, P>
-export type TConstructorParameterArray<T extends TSchema[], P extends unknown[]> = T extends [infer L extends TSchema, ...infer R extends TSchema[]] ? [Static<L, P>, ...TFunctionParameters<R, P>] : []
+export type TConstructorReturnTypeResolve<T extends TSchema, P extends unknown[]> = Static<T, P>
+export type TConstructorParametersResolve<T extends TSchema[], P extends unknown[]> = T extends [infer L extends TSchema, ...infer R extends TSchema[]] ? [Static<L, P>, ...TFunctionParametersResolve<R, P>] : []
+export type TConstructorResolve<T extends TSchema[], U extends TSchema, P extends unknown[]> = Ensure<new (...param: TConstructorParametersResolve<T, P>) => TConstructorReturnTypeResolve<U, P>>
 export interface TConstructor<T extends TSchema[] = TSchema[], U extends TSchema = TSchema> extends TSchema {
   [Kind]: 'Constructor'
-  static: new (...param: TConstructorParameterArray<T, this['params']>) => TConstructorReturnType<U, this['params']>
+  static: TConstructorResolve<T, U, this['params']>
   type: 'Constructor'
   parameters: T
   returns: U
@@ -388,11 +389,12 @@ export type TExtract<T extends TSchema, U extends TSchema> =
 // --------------------------------------------------------------------------
 // TFunction
 // --------------------------------------------------------------------------
-export type TFunctionReturnType<T extends TSchema, P extends unknown[]> = Static<T, P>
-export type TFunctionParameters<T extends TSchema[], P extends unknown[]> = T extends [infer L extends TSchema, ...infer R extends TSchema[]] ? [Static<L, P>, ...TFunctionParameters<R, P>] : []
+export type TFunctionReturnTypeResolve<T extends TSchema, P extends unknown[]> = Static<T, P>
+export type TFunctionParametersResolve<T extends TSchema[], P extends unknown[]> = T extends [infer L extends TSchema, ...infer R extends TSchema[]] ? [Static<L, P>, ...TFunctionParametersResolve<R, P>] : []
+export type TFunctionResolve<T extends TSchema[], U extends TSchema, P extends unknown[]> = Ensure<(...param: TFunctionParametersResolve<T, P>) => TFunctionReturnTypeResolve<U, P>>
 export interface TFunction<T extends TSchema[] = TSchema[], U extends TSchema = TSchema> extends TSchema {
   [Kind]: 'Function'
-  static: (...param: TFunctionParameters<T, this['params']>) => TFunctionReturnType<U, this['params']>
+  static: TFunctionResolve<T, U, this['params']>
   type: 'Function'
   parameters: T
   returns: U

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -992,11 +992,11 @@ export interface TVoid extends TSchema {
 // --------------------------------------------------------------------------
 // Static<T>
 // --------------------------------------------------------------------------
-/** Creates the decoded static form for a TypeBox type */
+/** Creates an decoded static type from a TypeBox type */
 export type StaticDecode<T extends TSchema, P extends unknown[] = []> = Static<DecodeType<T>, P>
-/** Creates the encoded static form for a TypeBox type */
+/** Creates an encoded static type from a TypeBox type */
 export type StaticEncode<T extends TSchema, P extends unknown[] = []> = Static<T, P>
-/** Creates the static type for a TypeBox type */
+/** Creates a static type from a TypeBox type */
 export type Static<T extends TSchema, P extends unknown[] = []> = (T & { params: P })['static']
 // --------------------------------------------------------------------------
 // TypeRegistry

--- a/test/static/constructor.ts
+++ b/test/static/constructor.ts
@@ -1,11 +1,31 @@
 import { Expect } from './assert'
 import { Type } from '@sinclair/typebox'
-
-const C = Type.Constructor(
-  [Type.Number(), Type.String()],
-  Type.Object({
-    method: Type.Function([Type.Number(), Type.String()], Type.Boolean()),
-  }),
-)
-
-Expect(C).ToStatic<new (param_0: number, param_1: string) => { method: (param_0: number, param_1: string) => boolean }>()
+{
+  // simple
+  const T = Type.Constructor([Type.Number(), Type.Boolean()], Type.String())
+  Expect(T).ToStatic<new (param_0: number, param_1: boolean) => string>()
+}
+{
+  // nested
+  // prettier-ignore
+  const T = Type.Constructor([Type.Number(), Type.String()], Type.Object({
+    method: Type.Constructor([Type.Number(), Type.String()], Type.Boolean()),
+  }))
+  Expect(T).ToStatic<new (param_0: number, param_1: string) => { method: new (param_0: number, param_1: string) => boolean }>()
+}
+{
+  // decode 2
+  const S = Type.Transform(Type.Integer())
+    .Decode((value) => new Date(value))
+    .Encode((value) => value.getTime())
+  const T = Type.Constructor([S], Type.String())
+  Expect(T).ToStaticDecode<new (param_0: Date) => string>()
+}
+{
+  // decode 1
+  const S = Type.Transform(Type.Integer())
+    .Decode((value) => new Date(value))
+    .Encode((value) => value.getTime())
+  const T = Type.Constructor([Type.Number()], S)
+  Expect(T).ToStaticDecode<new (param_0: number) => Date>()
+}

--- a/test/static/function.ts
+++ b/test/static/function.ts
@@ -1,11 +1,32 @@
 import { Expect } from './assert'
 import { Type } from '@sinclair/typebox'
 
-const C = Type.Function(
-  [Type.Number(), Type.String()],
-  Type.Object({
+{
+  // simple
+  const T = Type.Function([Type.Number(), Type.Boolean()], Type.String())
+  Expect(T).ToStatic<(param_0: number, param_1: boolean) => string>()
+}
+{
+  // nested
+  // prettier-ignore
+  const T = Type.Function([Type.Number(), Type.String()], Type.Object({
     method: Type.Function([Type.Number(), Type.String()], Type.Boolean()),
-  }),
-)
-
-Expect(C).ToStatic<(param_0: number, param_1: string) => { method: (param_0: number, param_1: string) => boolean }>()
+  }))
+  Expect(T).ToStatic<(param_0: number, param_1: string) => { method: (param_0: number, param_1: string) => boolean }>()
+}
+{
+  // decode 2
+  const S = Type.Transform(Type.Integer())
+    .Decode((value) => new Date(value))
+    .Encode((value) => value.getTime())
+  const T = Type.Function([S], Type.String())
+  Expect(T).ToStaticDecode<(param_0: Date) => string>()
+}
+{
+  // decode 1
+  const S = Type.Transform(Type.Integer())
+    .Decode((value) => new Date(value))
+    .Encode((value) => value.getTime())
+  const T = Type.Function([Type.Number()], S)
+  Expect(T).ToStaticDecode<(param_0: number) => Date>()
+}

--- a/test/static/transform.ts
+++ b/test/static/transform.ts
@@ -291,3 +291,21 @@ import { Expect } from './assert'
   Expect(T).ToStaticDecode<1>()
   Expect(T).ToStaticEncode<E>()
 }
+{
+  // should transform functions
+  const S = Type.Transform(Type.Number())
+    .Decode((value) => new Date(value))
+    .Encode((value) => value.getTime())
+  const T = Type.Function([S], S)
+  Expect(T).ToStaticDecode<(x: Date) => Date>()
+  Expect(T).ToStaticEncode<(x: number) => number>()
+}
+{
+  // should transform constructors
+  const S = Type.Transform(Type.Number())
+    .Decode((value) => new Date(value))
+    .Encode((value) => value.getTime())
+  const T = Type.Constructor([S], S)
+  Expect(T).ToStaticDecode<new (x: Date) => Date>()
+  Expect(T).ToStaticEncode<new (x: number) => number>()
+}


### PR DESCRIPTION
This PR improves inference on Function and Constructor types, updating inference from tuple indexer mapping (a consequence of earlier versions of the compiler) to recursive rest resolve (as used by other types). This PR also updates the Transform decoding inference, ensuring Function and Constructor parameters are appropriately decoded.

This removes the need for `TFunction<any[], any>` signatures (which required latent inference checks to resolve to TSchema), Signatures are now always of the form `TFunction<TSchema[], TSchema>`. Other updates ensuring appropriate mapped inference for Constructor Parameters (retuning TTuple<[...]>), and ensuring Iterators resolve to `IterableIterator` and `AsyncIterableIterator` (and not the mapped type)