### PR TITLE
Github Code Renderer and Iterator Inference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.24",
+  "version": "0.31.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.31.24",
+      "version": "0.31.25",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.24",
+  "version": "0.31.25",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -857,15 +857,14 @@ export type TTemplateLiteralConst<T, Acc extends string> =
   T extends TBigInt ? `${bigint}` : 
   T extends TBoolean ? `${boolean}` :
   never
-export type TTemplateLiteralUnionInitial = '' // resolves github rendering bug
 // prettier-ignore
-export type TTemplateLiteralUnion<T extends TTemplateLiteralKind[], Acc extends string = TTemplateLiteralUnionInitial> = 
+export type TTemplateLiteralUnion<T extends TTemplateLiteralKind[], Acc extends string> = 
   T extends [infer L, ...infer R] ? `${TTemplateLiteralConst<L, Acc>}${TTemplateLiteralUnion<Assert<R, TTemplateLiteralKind[]>, Acc>}` :
   Acc
 export type TTemplateLiteralKeyRest<T extends TTemplateLiteral> = Assert<UnionToTuple<Static<T>>, TPropertyKey[]>
 export interface TTemplateLiteral<T extends TTemplateLiteralKind[] = TTemplateLiteralKind[]> extends TSchema {
   [Kind]: 'TemplateLiteral'
-  static: TTemplateLiteralUnion<T>
+  static: TTemplateLiteralUnion<T, ''>
   type: 'string'
   pattern: string // todo: it may be possible to infer this pattern
 }

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -857,8 +857,9 @@ export type TTemplateLiteralConst<T, Acc extends string> =
   T extends TBigInt ? `${bigint}` : 
   T extends TBoolean ? `${boolean}` :
   never
+export type TTemplateLiteralUnionInitial = '' // resolves github rendering bug
 // prettier-ignore
-export type TTemplateLiteralUnion<T extends TTemplateLiteralKind[], Acc extends string = ''> = 
+export type TTemplateLiteralUnion<T extends TTemplateLiteralKind[], Acc extends string = TTemplateLiteralUnionInitial> = 
   T extends [infer L, ...infer R] ? `${TTemplateLiteralConst<L, Acc>}${TTemplateLiteralUnion<Assert<R, TTemplateLiteralKind[]>, Acc>}` :
   Acc
 export type TTemplateLiteralKeyRest<T extends TTemplateLiteral> = Assert<UnionToTuple<Static<T>>, TPropertyKey[]>

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -242,7 +242,7 @@ export interface TArray<T extends TSchema = TSchema> extends TSchema, ArrayOptio
 // --------------------------------------------------------------------------
 // TAsyncIterator
 // --------------------------------------------------------------------------
-export type TAsyncIteratorResolve<T extends TSchema, P extends unknown[]> = Ensure<AsyncIterableIterator<Static<T, P>>>
+export type TAsyncIteratorResolve<T extends TSchema, P extends unknown[]> = AsyncIterableIterator<Ensure<Static<T, P>>>
 export interface TAsyncIterator<T extends TSchema = TSchema> extends TSchema {
   [Kind]: 'AsyncIterator'
   static: TAsyncIteratorResolve<T, this['params']>
@@ -477,7 +477,7 @@ export interface TIntersect<T extends TSchema[] = TSchema[]> extends TSchema, In
 // --------------------------------------------------------------------------
 // TIterator
 // --------------------------------------------------------------------------
-export type TIteratorResolve<T extends TSchema, P extends unknown[]> = Ensure<IterableIterator<Static<T, P>>>
+export type TIteratorResolve<T extends TSchema, P extends unknown[]> = IterableIterator<Ensure<Static<T, P>>>
 export interface TIterator<T extends TSchema = TSchema> extends TSchema {
   [Kind]: 'Iterator'
   static: TIteratorResolve<T, this['params']>


### PR DESCRIPTION
This PR applies a small update to ensure Github correctly previews / syntax highlights type inference code. This issue relates specifically to template literal types where empty quoted strings are used in type constraints. This update removes them from the constraints.

---

This PR also includes an additional fix on iterator inference to try and get the TSP correctly presenting resolved types.