### PR TITLE
Intersect Transform Update

### DIFF
--- a/examples/index.ts
+++ b/examples/index.ts
@@ -1,40 +1,40 @@
 import { TypeSystem } from '@sinclair/typebox/system'
 import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
-import { Type, TypeGuard, Kind, Static, TSchema } from '@sinclair/typebox'
+import { Type, StaticDecode, StaticEncode, Static } from '@sinclair/typebox'
 
-// -----------------------------------------------------------
-// Create: Type
-// -----------------------------------------------------------
+const TBItem = Type.Transform(
+  Type.Object({
+    isHybrid: Type.Boolean(),
+  }),
+)
+  .Decode((value) => ({ isHybrid: value.isHybrid ? 1 : 0 }))
+  .Encode((value) => ({ isHybrid: value.isHybrid === 1 ? true : false }))
 
-const T = Type.Object({
-  x: Type.Number(),
-  y: Type.Number(),
-  z: Type.Number(),
+let decoded = Value.Decode(TBItem, { isHybrid: true })
+let encoded = Value.Encode(TBItem, { isHybrid: 1 })
+console.log('decoded', decoded)
+console.log('encoded', encoded)
+
+const TBIntersect = Type.Intersect([
+  Type.Object({
+    model: Type.String(),
+  }),
+  Type.Object({
+    features: Type.Array(TBItem),
+  }),
+])
+
+const aencoded = Value.Encode(TBIntersect, {
+  model: 'Prius',
+  features: [
+    {
+      isHybrid: 1,
+    },
+    {
+      isHybrid: 1,
+    },
+  ],
 })
 
-type T = Static<typeof T>
-
-console.log(T)
-
-// -----------------------------------------------------------
-// Create: Value
-// -----------------------------------------------------------
-
-const V = Value.Create(T)
-
-console.log(V)
-
-// -----------------------------------------------------------
-// Compile: Type
-// -----------------------------------------------------------
-
-const C = TypeCompiler.Compile(T)
-
-console.log(C.Code())
-
-// -----------------------------------------------------------
-// Check: Value
-// -----------------------------------------------------------
-
-console.log(C.Check(V))
+console.log(aencoded)

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -1,40 +1,40 @@
 import { TypeSystem } from '@sinclair/typebox/system'
 import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Value, ValuePointer } from '@sinclair/typebox/value'
-import { Type, StaticDecode, StaticEncode, Static } from '@sinclair/typebox'
+import { Type, TypeGuard, Kind, Static, TSchema } from '@sinclair/typebox'
 
-const TBItem = Type.Transform(
-  Type.Object({
-    isHybrid: Type.Boolean(),
-  }),
-)
-  .Decode((value) => ({ isHybrid: value.isHybrid ? 1 : 0 }))
-  .Encode((value) => ({ isHybrid: value.isHybrid === 1 ? true : false }))
+// -----------------------------------------------------------
+// Create: Type
+// -----------------------------------------------------------
 
-let decoded = Value.Decode(TBItem, { isHybrid: true })
-let encoded = Value.Encode(TBItem, { isHybrid: 1 })
-console.log('decoded', decoded)
-console.log('encoded', encoded)
-
-const TBIntersect = Type.Intersect([
-  Type.Object({
-    model: Type.String(),
-  }),
-  Type.Object({
-    features: Type.Array(TBItem),
-  }),
-])
-
-const aencoded = Value.Encode(TBIntersect, {
-  model: 'Prius',
-  features: [
-    {
-      isHybrid: 1,
-    },
-    {
-      isHybrid: 1,
-    },
-  ],
+const T = Type.Object({
+  x: Type.Number(),
+  y: Type.Number(),
+  z: Type.Number(),
 })
 
-console.log(aencoded)
+type T = Static<typeof T>
+
+console.log(T)
+
+// -----------------------------------------------------------
+// Create: Value
+// -----------------------------------------------------------
+
+const V = Value.Create(T)
+
+console.log(V)
+
+// -----------------------------------------------------------
+// Compile: Type
+// -----------------------------------------------------------
+
+const C = TypeCompiler.Compile(T)
+
+console.log(C.Code())
+
+// -----------------------------------------------------------
+// Check: Value
+// -----------------------------------------------------------
+
+console.log(C.Check(V))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.27",
+  "version": "0.31.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.31.27",
+      "version": "0.31.28",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/hammer": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.31.27",
+  "version": "0.31.28",
   "description": "JSONSchema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/readme.md
+++ b/readme.md
@@ -1719,11 +1719,11 @@ The following table lists esbuild compiled and minified sizes for each TypeBox m
 ┌──────────────────────┬────────────┬────────────┬─────────────┐
 │       (index)        │  Compiled  │  Minified  │ Compression │
 ├──────────────────────┼────────────┼────────────┼─────────────┤
-│ typebox/compiler     │ '148.9 kb' │ ' 65.8 kb' │  '2.26 x'   │
-│ typebox/errors       │ '111.5 kb' │ ' 49.1 kb' │  '2.27 x'   │
-│ typebox/system       │ ' 82.6 kb' │ ' 36.8 kb' │  '2.24 x'   │
-│ typebox/value        │ '190.5 kb' │ ' 82.4 kb' │  '2.31 x'   │
-│ typebox              │ ' 72.4 kb' │ ' 31.6 kb' │  '2.29 x'   │
+│ typebox/compiler     │ '163.6 kb' │ ' 71.6 kb' │  '2.28 x'   │
+│ typebox/errors       │ '113.3 kb' │ ' 50.1 kb' │  '2.26 x'   │
+│ typebox/system       │ ' 83.9 kb' │ ' 37.5 kb' │  '2.24 x'   │
+│ typebox/value        │ '191.1 kb' │ ' 82.3 kb' │  '2.32 x'   │
+│ typebox              │ ' 73.8 kb' │ ' 32.3 kb' │  '2.29 x'   │
 └──────────────────────┴────────────┴────────────┴─────────────┘
 ```
 

--- a/test/runtime/value/transform/intersect.ts
+++ b/test/runtime/value/transform/intersect.ts
@@ -120,4 +120,61 @@ describe('value/transform/Intersect', () => {
   it('Should throw on exterior value type decode', () => {
     Assert.Throws(() => Encoder.Decode(T4, null))
   })
+  // --------------------------------------------------------
+  // https://github.com/sinclairzx81/typebox/discussions/672
+  // --------------------------------------------------------
+  // prettier-ignore
+  {
+    const A = Type.Object({ isHybrid: Type.Boolean() })
+    const T = Type.Transform(A)
+      .Decode((value) => ({ isHybrid: value.isHybrid ? 1 : 0 }))
+      .Encode((value) => ({ isHybrid: value.isHybrid === 1 ? true : false }))
+    const I = Type.Intersect([
+      Type.Object({ model: Type.String() }),
+      Type.Object({ features: Type.Array(T) }),
+    ])
+    it('Should decode nested 1', () => {
+      const value = Value.Decode(T, { isHybrid: true })
+      Assert.IsEqual(value, { isHybrid: 1 })
+    })
+    // prettier-ignore
+    it('Should decode nested 2', () => {
+      const value = Value.Decode(I, {
+        model: 'Prius',
+        features: [
+          { isHybrid: true },
+          { isHybrid: false }
+        ],
+      })
+      Assert.IsEqual(value, {
+        model: 'Prius',
+        features: [
+          { isHybrid: 1 },
+          { isHybrid: 0 }
+        ],
+      })
+    })
+    it('should encode nested 1', () => {
+      let value = Value.Encode(T, { isHybrid: 1 })
+      Assert.IsEqual(value, { isHybrid: true })
+    })
+    // prettier-ignore
+    it('Should encode nested 2', () => {
+      const value = Value.Encode(I, {
+        model: 'Prius',
+        features: [
+          { isHybrid: 1 },
+          { isHybrid: 0 }
+        ],
+      })
+      Assert.IsEqual(value, {
+        model: 'Prius',
+        features: [
+          { isHybrid: true },
+          { isHybrid: false }
+
+        ],
+      })
+    })
+  }
 })


### PR DESCRIPTION
This PR implements new transform logic for intersection. The update works through the `KeyResolver` and `IndexedAccessor` utilities in `Type` to enumerate keys and resolve intersect property types. This PR also updates the logic for encoding and decoding across all object types. It also removes `UnknownType` checks (allowing Unsafe Types to be default transformed, but not internally enumerated)

Related: https://github.com/sinclairzx81/typebox/discussions/672
