### PR TITLE
Revision 0.32.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.0",
+      "version": "0.32.1",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ajv-formats": "^2.1.1",
         "mocha": "^9.2.2",
         "prettier": "^2.7.1",
-        "typescript": "^5.3.2"
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@andrewbranch/untar.js": {
@@ -61,6 +61,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@arethetypeswrong/core/node_modules/typescript": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@colors/colors": {
@@ -1631,9 +1644,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1826,6 +1839,14 @@
         "semver": "^7.5.4",
         "typescript": "5.3.2",
         "validate-npm-package-name": "^5.0.0"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+          "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+          "dev": true
+        }
       }
     },
     "@colors/colors": {
@@ -2853,9 +2874,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "ajv-formats": "^2.1.1",
     "mocha": "^9.2.2",
     "prettier": "^2.7.1",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/task/build/redirect/create-package-json.ts
+++ b/task/build/redirect/create-package-json.ts
@@ -48,12 +48,13 @@ function resolvePackageJson(submodules: string[]) {
 function resolveSubmoduleExports(submodule: string) {
   return {
     require: {
+      types: `./build/require/${submodule}/index.d.ts`,
       default: `./build/require/${submodule}/index.js`,
-      types: `./build/require/${submodule}/index.d.ts`
     },
     import: {
-      default: `./build/import/${submodule}/index.mjs`,
       types: `./build/import/${submodule}/index.d.mts`,
+      default: `./build/import/${submodule}/index.mjs`,
+      
     }
   }
 }
@@ -65,12 +66,13 @@ function resolveExports(submodules: string[]) {
     // ... and root module
     ".": {
       "require": {
+        "types": "./build/require/index.d.ts",
         "default": "./build/require/index.js",
-        "types": "./build/require/index.d.ts"
+        
       },
       "import": {
+        "types": "./build/import/index.d.mts",
         "default": "./build/import/index.mjs",
-        "types": "./build/import/index.d.mts"
       }
     }
   })
@@ -89,8 +91,8 @@ function resolveMetadata() {
     license: packageJson.license,
     repository: packageJson.repository,
     scripts: { test: 'echo test' }, // flagged by socket.dev
-    module: "./build/import/index.mjs",
     types: "./build/require/index.d.ts",
-    main: "./build/require/index.js"
+    main: "./build/require/index.js",
+    module: "./build/import/index.mjs",
   }
 }


### PR DESCRIPTION
This PR updates the `package.json` key order to ensure the `default` import target is specified last. This PR is prompted by WebPack mandating the `default` target be specified last (which is very surprising behavior)

### WebPack Assertion

https://github.com/webpack/enhanced-resolve/blob/58464fc7cb56673c9aa849e68e6300239601e615/lib/util/entrypoints.js#L475

### Related

https://github.com/sinclairzx81/typebox/issues/699