### PR TITLE
feat: Export TLiteralValue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export { Intersect, IntersectEvaluated, type TIntersect, type TIntersectEvaluate
 export { Iterator, type TIterator } from './type/iterator/index'
 export { Intrinsic, IntrinsicFromMappedKey, type TIntrinsic, Capitalize, type TCapitalize, Lowercase, type TLowercase, Uncapitalize, type TUncapitalize, Uppercase, type TUppercase } from './type/intrinsic/index'
 export { KeyOf, type TKeyOf, type KeyOfFromMappedResult, KeyOfPropertyKeys, KeyOfPattern } from './type/keyof/index'
-export { Literal, type TLiteral } from './type/literal/index'
+export { Literal, type TLiteral, type TLiteralValue } from './type/literal/index'
 export { Mapped, MappedKey, MappedResult, type TMapped, type TMappedKey, type TMappedResult, type TMappedFunction } from './type/mapped/index'
 export { Never, type TNever } from './type/never/index'
 export { Not, type TNot } from './type/not/index'


### PR DESCRIPTION
Exporting `TLiteralValue` to allow for code blocks like the one described below. Type was "unexported" in [v0.32.0](https://github.com/sinclairzx81/typebox/compare/0.31.28...0.32.0).

```ts
const createLiteralArraySchema = <T extends TLiteralValue>(array: T[]) => {
  return Type.Union(array.map(a => Type.Literal<T>(a)));
};
```