### PR TITLE
Revision 0.32.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.2",
+      "version": "0.32.3",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/type/record/record.ts
+++ b/src/type/record/record.ts
@@ -181,7 +181,7 @@ function FromNumberKey<K extends TNumber, T extends TSchema>(_: K, T: T, options
 // ------------------------------------------------------------------
 // prettier-ignore
 type RecordStatic<K extends TSchema, T extends TSchema, P extends unknown[]> = (
-  Record<Assert<Static<K>, PropertyKey>, Static<T, P>>
+  Evaluate<Record<Assert<Static<K>, PropertyKey>, Static<T, P>>>
 )
 // prettier-ignore
 export interface TRecord<K extends TSchema = TSchema, T extends TSchema = TSchema> extends TSchema {


### PR DESCRIPTION
This PR adds an `Evaluate<T>` inference call to Record inference. This to ensure the inferred type presents with the simple TS type, and not the TB type infrastructure.