### PR TITLE
Revision 0.32.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.3",
+  "version": "0.32.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.3",
+      "version": "0.32.4",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.3",
+  "version": "0.32.4",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -27,4 +27,4 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 export { Errors, ValueError, ValueErrorIterator, ValueErrorType, ValueErrorsUnknownTypeError } from './errors'
-export { DefaultErrorFunction, GetErrorFunction, SetErrorFunction, type ErrorFunction } from './function'
+export { DefaultErrorFunction, GetErrorFunction, SetErrorFunction, type ErrorFunction, type ErrorFunctionParameter } from './function'


### PR DESCRIPTION
This PR exports the ErrorFunctionParameter type. This type is passed to custom error functions and was added on 0.32.0, however the exporting of this type was missed.
