### PR TITLE
Revision 0.32.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.5",
+  "version": "0.32.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.5",
+      "version": "0.32.6",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.5",
+  "version": "0.32.6",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export { Pick, type TPick, type TPickFromMappedKey, type TPickFromMappedResult }
 export { Promise, type TPromise } from './type/promise/index'
 export { Readonly, ReadonlyFromMappedResult, type TReadonly, type TReadonlyWithFlag, type TReadonlyFromMappedResult } from './type/readonly/index'
 export { ReadonlyOptional, type TReadonlyOptional } from './type/readonly-optional/index'
-export { Record, type TRecord } from './type/record/index'
+export { Record, type TRecord, type TRecordOrObject } from './type/record/index'
 export { Recursive, type TRecursive, type TThis } from './type/recursive/index'
 export { Ref, type TRef } from './type/ref/index'
 export { RegExp, type TRegExp } from './type/regexp/index'

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export { TypeBoxError } from './type/error/index'
 export { Any, type TAny } from './type/any/index'
 export { Array, type TArray, type ArrayOptions } from './type/array/index'
 export { AsyncIterator, type TAsyncIterator } from './type/async-iterator/index'
-export { Awaited, type TAwaited } from './type/awaited/index'
+export { Awaited, type TAwaited, type TAwaitedResolve } from './type/awaited/index'
 export { BigInt, type TBigInt, type BigIntOptions } from './type/bigint/index'
 export { Boolean, type TBoolean } from './type/boolean/index'
 export { Composite, type TComposite } from './type/composite/index'
@@ -52,7 +52,7 @@ export { Date, type TDate, type DateOptions } from './type/date/index'
 export { Deref, type TDeref } from './type/deref/index'
 export { Enum, type TEnum } from './type/enum/index'
 export { Exclude, type TExclude, type TExcludeFromMappedResult } from './type/exclude/index'
-export { Extends, type TExtends, type ExtendsFromMappedResult, type ExtendsFromMappedKey, ExtendsCheck, ExtendsResult, ExtendsUndefinedCheck } from './type/extends/index'
+export { Extends, ExtendsCheck, ExtendsResult, ExtendsUndefinedCheck, type TExtends, type ExtendsFromMappedResult, type ExtendsFromMappedKey } from './type/extends/index'
 export { Extract, type TExtract, type TExtractFromMappedResult } from './type/extract/index'
 export { Function, type TFunction } from './type/function/index'
 export { Increment, type Assert, type AssertType, type AssertRest, type AssertProperties, type Ensure, type Evaluate, type TupleToIntersect, type TupleToUnion, type UnionToTuple } from './type/helpers/index'
@@ -62,29 +62,19 @@ export { Integer, type TInteger, type IntegerOptions } from './type/integer/inde
 export { Intersect, IntersectEvaluated, type TIntersect, type TIntersectEvaluated, type IntersectOptions } from './type/intersect/index'
 export { Iterator, type TIterator } from './type/iterator/index'
 export { Intrinsic, IntrinsicFromMappedKey, type TIntrinsic, Capitalize, type TCapitalize, Lowercase, type TLowercase, Uncapitalize, type TUncapitalize, Uppercase, type TUppercase } from './type/intrinsic/index'
-export {
-  KeyOf,
-  KeyOfPropertyKeys,
-  KeyOfPropertyKeysToRest as KeyOfFromPropertyKeys,
-  KeyOfFromMappedResult,
-  KeyOfPattern,
-  type TKeyOf,
-  type TKeyOfPropertyKeys,
-  type TKeyOfPropertyKeysToRest as TKeyOfFromPropertyKeys,
-  type TKeyOfFromMappedResult,
-} from './type/keyof/index'
+export { KeyOf, KeyOfPropertyKeys, KeyOfPropertyKeysToRest, KeyOfFromMappedResult, KeyOfPattern, type TKeyOf, type TKeyOfPropertyKeys, type TKeyOfPropertyKeysToRest, type TKeyOfFromMappedResult } from './type/keyof/index'
 export { Literal, type TLiteral, type TLiteralValue } from './type/literal/index'
-export { Mapped, MappedKey, MappedResult, type TMapped, type TMappedKey, type TMappedResult, type TMappedFunction } from './type/mapped/index'
+export { Mapped, MappedKey, MappedResult, MappedFunctionReturnType, type TMapped, type TMappedKey, type TMappedResult, type TMappedFunction, type TMappedFunctionReturnType } from './type/mapped/index'
 export { Never, type TNever } from './type/never/index'
 export { Not, type TNot } from './type/not/index'
 export { Null, type TNull } from './type/null/index'
 export { Number, type TNumber, type NumberOptions } from './type/number/index'
 export { Object, type TObject, type TProperties, type ObjectOptions } from './type/object/index'
-export { Omit, type TOmit, type TOmitFromMappedKey, type TOmitFromMappedResult } from './type/omit/index'
+export { Omit, type TOmit, type TOmitResolve, type TOmitFromMappedKey, type TOmitFromMappedResult } from './type/omit/index'
 export { Optional, OptionalFromMappedResult, type TOptional, type TOptionalWithFlag, type TOptionalFromMappedResult } from './type/optional/index'
 export { Parameters, type TParameters } from './type/parameters/index'
 export { Partial, PartialFromMappedResult, type TPartial, type TPartialFromMappedResult } from './type/partial/index'
-export { Pick, type TPick, type TPickFromMappedKey, type TPickFromMappedResult } from './type/pick/index'
+export { Pick, type TPick, type TPickResolve, type TPickFromMappedKey, type TPickFromMappedResult } from './type/pick/index'
 export { Promise, type TPromise } from './type/promise/index'
 export { Readonly, ReadonlyFromMappedResult, type TReadonly, type TReadonlyWithFlag, type TReadonlyFromMappedResult } from './type/readonly/index'
 export { ReadonlyOptional, type TReadonlyOptional } from './type/readonly-optional/index'

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,17 @@ export { Integer, type TInteger, type IntegerOptions } from './type/integer/inde
 export { Intersect, IntersectEvaluated, type TIntersect, type TIntersectEvaluated, type IntersectOptions } from './type/intersect/index'
 export { Iterator, type TIterator } from './type/iterator/index'
 export { Intrinsic, IntrinsicFromMappedKey, type TIntrinsic, Capitalize, type TCapitalize, Lowercase, type TLowercase, Uncapitalize, type TUncapitalize, Uppercase, type TUppercase } from './type/intrinsic/index'
-export { KeyOf, type TKeyOf, type KeyOfFromMappedResult, KeyOfPropertyKeys, KeyOfPattern } from './type/keyof/index'
+export {
+  KeyOf,
+  KeyOfPropertyKeys,
+  KeyOfPropertyKeysToRest as KeyOfFromPropertyKeys,
+  KeyOfFromMappedResult,
+  KeyOfPattern,
+  type TKeyOf,
+  type TKeyOfPropertyKeys,
+  type TKeyOfPropertyKeysToRest as TKeyOfFromPropertyKeys,
+  type TKeyOfFromMappedResult,
+} from './type/keyof/index'
 export { Literal, type TLiteral, type TLiteralValue } from './type/literal/index'
 export { Mapped, MappedKey, MappedResult, type TMapped, type TMappedKey, type TMappedResult, type TMappedFunction } from './type/mapped/index'
 export { Never, type TNever } from './type/never/index'

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export { Required, type TRequired, type TRequiredFromMappedResult } from './type
 export { Rest, type TRest } from './type/rest/index'
 export { ReturnType, type TReturnType } from './type/return-type/index'
 export { type TSchema, type TKind, type SchemaOptions, type TAnySchema } from './type/schema/index'
-export { type Static, type StaticDecode, type StaticEncode } from './type/static/index'
+export { type Static, type StaticDecode, type StaticEncode, type TDecodeType, type TDecodeRest, type TDecodeProperties } from './type/static/index'
 export { Strict } from './type/strict/index'
 export { String, type TString, type StringOptions, type StringFormatOption, type StringContentEncodingOption } from './type/string/index'
 export { Symbol, type TSymbol, type TSymbolValue as SymbolValue } from './type/symbol/index'

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,8 @@ export {
   TemplateLiteralParseExact,
   TemplateLiteralGenerate,
   TemplateLiteralExpressionGenerate,
+  TemplateLiteralSyntax,
+  type TTemplateLiteralSyntax,
   type TTemplateLiteral,
   type TIsTemplateLiteralFinite,
   type TTemplateLiteralGenerate,

--- a/src/type/indexed/indexed-from-mapped-key.ts
+++ b/src/type/indexed/indexed-from-mapped-key.ts
@@ -27,7 +27,7 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import type { TSchema, SchemaOptions } from '../schema/index'
-import type { Evaluate } from '../helpers/index'
+import type { Ensure, Evaluate } from '../helpers/index'
 import type { TProperties } from '../object/index'
 import { Index, type TIndex } from './indexed'
 import { MappedResult, type TMappedResult, type TMappedKey } from '../mapped/index'
@@ -90,7 +90,7 @@ export type TIndexFromMappedKey<
   K extends TMappedKey, 
   P extends TProperties = TMappedIndexProperties<T, K>
 > = (
-  TMappedResult<P>
+  Ensure<TMappedResult<P>>
 )
 // prettier-ignore
 export function IndexFromMappedKey<

--- a/src/type/keyof/keyof-from-mapped-result.ts
+++ b/src/type/keyof/keyof-from-mapped-result.ts
@@ -27,6 +27,7 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import type { SchemaOptions } from '../schema/index'
+import type { Ensure, Evaluate } from '../helpers/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult } from '../mapped/index'
 import { KeyOf, type TKeyOf } from './keyof'
@@ -55,7 +56,7 @@ function FromProperties<
 type TFromMappedResult<
   R extends TMappedResult
 > = (
-  TFromProperties<R['properties']>
+  Evaluate<TFromProperties<R['properties']>>
 )
 // prettier-ignore
 function FromMappedResult<
@@ -71,7 +72,7 @@ export type TKeyOfFromMappedResult<
   R extends TMappedResult,
   P extends TProperties = TFromMappedResult<R>
 > = (
-  TMappedResult<P>
+  Ensure<TMappedResult<P>>
 )
 // prettier-ignore
 export function KeyOfFromMappedResult<

--- a/src/type/keyof/keyof.ts
+++ b/src/type/keyof/keyof.ts
@@ -45,16 +45,16 @@ import { IsMappedResult } from '../guard/type'
 // FromPropertyKeys
 // ------------------------------------------------------------------
 // prettier-ignore
-type TFromPropertyKeys<T extends PropertyKey[], Acc extends TSchema[] = []> = (
+export type TKeyOfPropertyKeysToRest<T extends PropertyKey[], Acc extends TSchema[] = []> = (
   T extends [infer L extends PropertyKey, ...infer R extends PropertyKey[]]
     ? L extends '[number]'
-      ? TFromPropertyKeys<R, [...Acc, TNumber]>
-      : TFromPropertyKeys<R, [...Acc, TLiteral<Assert<L, TLiteralValue>>]>
+      ? TKeyOfPropertyKeysToRest<R, [...Acc, TNumber]>
+      : TKeyOfPropertyKeysToRest<R, [...Acc, TLiteral<Assert<L, TLiteralValue>>]>
     : Acc
 )
 // prettier-ignore
-function FromPropertyKeys<T extends PropertyKey[]>(T: [...T]): TFromPropertyKeys<T> {
-  return T.map(L => L === '[number]' ? Number() : Literal(L as TLiteralValue)) as TFromPropertyKeys<T>
+export function KeyOfPropertyKeysToRest<T extends PropertyKey[]>(T: [...T]): TKeyOfPropertyKeysToRest<T> {
+  return T.map(L => L === '[number]' ? Number() : Literal(L as TLiteralValue)) as TKeyOfPropertyKeysToRest<T>
 }
 // ------------------------------------------------------------------
 // KeyOfTypeResolve
@@ -63,7 +63,7 @@ function FromPropertyKeys<T extends PropertyKey[]>(T: [...T]): TFromPropertyKeys
 export type TKeyOf<
   T extends TSchema, 
   K extends PropertyKey[] = TKeyOfPropertyKeys<T>,
-  S extends TSchema[] = TFromPropertyKeys<K>,
+  S extends TSchema[] = TKeyOfPropertyKeysToRest<K>,
   U = TUnionEvaluated<S>
 > = (
   Ensure<U>
@@ -78,7 +78,7 @@ export function KeyOf(T: TSchema, options: SchemaOptions = {}): any {
     return KeyOfFromMappedResult(T, options)
   } else {
     const K = KeyOfPropertyKeys(T)
-    const S = FromPropertyKeys(K)
+    const S = KeyOfPropertyKeysToRest(K)
     const U = UnionEvaluated(S)
     return CloneType(U, options)
   }

--- a/src/type/mapped/mapped.ts
+++ b/src/type/mapped/mapped.ts
@@ -241,19 +241,19 @@ function FromSchemaType<K extends PropertyKey, T extends TSchema>(K: K, T: T): F
   ) as FromSchemaType<K, T>
 }
 // ------------------------------------------------------------------
-// FromMappedFunctionReturnType
+// MappedFunctionReturnType
 // ------------------------------------------------------------------
 // prettier-ignore
-type FromMappedFunctionReturnType<K extends PropertyKey[], T extends TSchema, Acc extends TProperties = {}> = (
+export type TMappedFunctionReturnType<K extends PropertyKey[], T extends TSchema, Acc extends TProperties = {}> = (
   K extends [infer L extends PropertyKey, ...infer R extends PropertyKey[]]
-    ? FromMappedFunctionReturnType<R, T, Acc & { [_ in L]: FromSchemaType<L, T> }>
+    ? TMappedFunctionReturnType<R, T, Acc & { [_ in L]: FromSchemaType<L, T> }>
     : Acc
 )
 // prettier-ignore
-function FromMappedFunctionReturnType<K extends PropertyKey[], T extends TSchema>(K: [...K], T: T, Acc: TProperties = {}): FromMappedFunctionReturnType<K, T> {
+export function MappedFunctionReturnType<K extends PropertyKey[], T extends TSchema>(K: [...K], T: T, Acc: TProperties = {}): TMappedFunctionReturnType<K, T> {
   return K.reduce((Acc, L) => {
     return { ...Acc, [L]: FromSchemaType(L, T) }
-  }, {} as TProperties) as FromMappedFunctionReturnType<K, T>
+  }, {} as TProperties) as TMappedFunctionReturnType<K, T>
 }
 // ------------------------------------------------------------------
 // TMappedFunction
@@ -267,7 +267,7 @@ export type TMappedFunction<K extends PropertyKey[], I = TMappedKey<K>> = (T: I)
 export type TMapped<
   K extends PropertyKey[], 
   F extends TMappedFunction<K>,
-  R extends TProperties = Evaluate<FromMappedFunctionReturnType<K, ReturnType<F>>>, 
+  R extends TProperties = Evaluate<TMappedFunctionReturnType<K, ReturnType<F>>>, 
 > = Ensure<TObject<R>>
 
 /** `[Json]` Creates a Mapped object type */
@@ -278,6 +278,6 @@ export function Mapped<K extends PropertyKey[], F extends TMappedFunction<K> = T
 export function Mapped(key: any, map: Function, options: ObjectOptions = {}) {
   const K = IsSchema(key) ? IndexPropertyKeys(key) : (key as PropertyKey[])
   const RT = map({ [Kind]: 'MappedKey', keys: K } as TMappedKey)
-  const R = FromMappedFunctionReturnType(K, RT)
+  const R = MappedFunctionReturnType(K, RT)
   return CloneType(Object(R), options)
 }

--- a/src/type/omit/omit-from-mapped-result.ts
+++ b/src/type/omit/omit-from-mapped-result.ts
@@ -27,6 +27,7 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import type { SchemaOptions } from '../schema/index'
+import type { Ensure, Evaluate } from '../helpers/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult } from '../mapped/index'
 import { Omit, type TOmit } from './omit'
@@ -58,7 +59,7 @@ type TFromMappedResult<
   R extends TMappedResult,
   K extends PropertyKey[],
 > = (
-  TFromProperties<R['properties'], K>
+  Evaluate<TFromProperties<R['properties'], K>>
 )
 // prettier-ignore
 function FromMappedResult<
@@ -76,7 +77,7 @@ export type TOmitFromMappedResult<
   K extends PropertyKey[],
   P extends TProperties = TFromMappedResult<T, K>
 > = (
-  TMappedResult<P>
+  Ensure<TMappedResult<P>>
 )
 // prettier-ignore
 export function OmitFromMappedResult<

--- a/src/type/partial/partial-from-mapped-result.ts
+++ b/src/type/partial/partial-from-mapped-result.ts
@@ -27,6 +27,7 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import type { SchemaOptions } from '../schema/index'
+import type { Ensure, Evaluate } from '../helpers/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult } from '../mapped/index'
 import { Partial, type TPartial } from './partial'
@@ -55,7 +56,7 @@ function FromProperties<
 type TFromMappedResult<
   R extends TMappedResult
 > = (
-  TFromProperties<R['properties']>
+  Evaluate<TFromProperties<R['properties']>>
 )
 // prettier-ignore
 function FromMappedResult<
@@ -71,7 +72,7 @@ export type TPartialFromMappedResult<
   R extends TMappedResult,
   P extends TProperties = TFromMappedResult<R>
 > = (
-  TMappedResult<P>
+  Ensure<TMappedResult<P>>
 )
 // prettier-ignore
 export function PartialFromMappedResult<

--- a/src/type/pick/pick-from-mapped-result.ts
+++ b/src/type/pick/pick-from-mapped-result.ts
@@ -27,6 +27,7 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import type { SchemaOptions } from '../schema/index'
+import type { Ensure, Evaluate } from '../helpers/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult } from '../mapped/index'
 import { Pick, type TPick } from './pick'
@@ -58,7 +59,7 @@ type TFromMappedResult<
   R extends TMappedResult,
   K extends PropertyKey[],
 > = (
-  TFromProperties<R['properties'], K>
+  Evaluate<TFromProperties<R['properties'], K>>
 )
 // prettier-ignore
 function FromMappedResult<
@@ -76,7 +77,7 @@ export type TPickFromMappedResult<
   K extends PropertyKey[],
   P extends TProperties = TFromMappedResult<T, K>
 > = (
-  TMappedResult<P>
+  Ensure<TMappedResult<P>>
 )
 // prettier-ignore
 export function PickFromMappedResult<

--- a/src/type/pick/pick.ts
+++ b/src/type/pick/pick.ts
@@ -50,7 +50,7 @@ import { IsMappedKey, IsMappedResult, IsIntersect, IsUnion, IsObject, IsSchema }
 // prettier-ignore
 type FromIntersect<T extends TSchema[], K extends PropertyKey[], Acc extends TSchema[] = []> = 
   T extends [infer L extends TSchema, ...infer R extends TSchema[]]
-    ? FromIntersect<R, K, [...Acc, PickResolve<L, K>]>
+    ? FromIntersect<R, K, [...Acc, TPickResolve<L, K>]>
     : Acc
 function FromIntersect<T extends TSchema[], K extends PropertyKey[]>(T: T, K: K) {
   return T.map((T) => PickResolve(T, K)) as FromIntersect<T, K>
@@ -61,7 +61,7 @@ function FromIntersect<T extends TSchema[], K extends PropertyKey[]>(T: T, K: K)
 // prettier-ignore
 type FromUnion<T extends TSchema[], K extends PropertyKey[], Acc extends TSchema[] = []> = 
   T extends [infer L extends TSchema, ...infer R extends TSchema[]]
-    ? FromUnion<R, K, [...Acc, PickResolve<L, K>]>
+    ? FromUnion<R, K, [...Acc, TPickResolve<L, K>]>
     : Acc
 // prettier-ignore
 function FromUnion<T extends TSchema[], K extends PropertyKey[]>(T: T, K: K) {
@@ -82,25 +82,25 @@ function FromProperties<T extends TProperties, K extends PropertyKey[]>(T: T, K:
 // PickResolve
 // ------------------------------------------------------------------
 // prettier-ignore
-export type PickResolve<T extends TProperties, K extends PropertyKey[]> = 
-  T extends TRecursive<infer S> ? TRecursive<PickResolve<S, K>> : 
+export type TPickResolve<T extends TProperties, K extends PropertyKey[]> = 
+  T extends TRecursive<infer S> ? TRecursive<TPickResolve<S, K>> : 
   T extends TIntersect<infer S> ? TIntersect<FromIntersect<S, K>> : 
   T extends TUnion<infer S> ? TUnion<FromUnion<S, K>> : 
   T extends TObject<infer S> ? TObject<FromProperties<S, K>> : 
   TObject<{}>
 // prettier-ignore
-export function PickResolve<T extends TSchema, K extends PropertyKey[]>(T: T, K: [...K]): PickResolve<T, K> {
+export function PickResolve<T extends TSchema, K extends PropertyKey[]>(T: T, K: [...K]): TPickResolve<T, K> {
   return (
     IsIntersect(T) ? Intersect(FromIntersect(T.allOf, K)) : 
     IsUnion(T) ? Union(FromUnion(T.anyOf, K)) : 
     IsObject(T) ? Object(FromProperties(T.properties, K)) : 
     Object({})
-  ) as PickResolve<T, K>
+  ) as TPickResolve<T, K>
 }
 // ------------------------------------------------------------------
 // TPick
 // ------------------------------------------------------------------
-export type TPick<T extends TSchema, K extends PropertyKey[]> = PickResolve<T, K>
+export type TPick<T extends TSchema, K extends PropertyKey[]> = TPickResolve<T, K>
 
 /** `[Json]` Constructs a type whose keys are picked from the given type */
 export function Pick<T extends TMappedResult, K extends PropertyKey[]>(T: T, K: [...K], options?: SchemaOptions): TPickFromMappedResult<T, K>

--- a/src/type/required/required-from-mapped-result.ts
+++ b/src/type/required/required-from-mapped-result.ts
@@ -27,6 +27,7 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import type { SchemaOptions } from '../schema/index'
+import type { Ensure, Evaluate } from '../helpers/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult } from '../mapped/index'
 import { Required, type TRequired } from './required'
@@ -55,7 +56,7 @@ function FromProperties<
 type TFromMappedResult<
   R extends TMappedResult
 > = (
-  TFromProperties<R['properties']>
+  Evaluate<TFromProperties<R['properties']>>
 )
 // prettier-ignore
 function FromMappedResult<
@@ -71,7 +72,7 @@ export type TRequiredFromMappedResult<
   R extends TMappedResult,
   P extends TProperties = TFromMappedResult<R>
 > = (
-  TMappedResult<P>
+  Ensure<TMappedResult<P>>
 )
 // prettier-ignore
 export function RequiredFromMappedResult<

--- a/src/type/static/static.ts
+++ b/src/type/static/static.ts
@@ -52,41 +52,41 @@ import type { TTransform } from '../transform/index'
 // DecodeType
 // ------------------------------------------------------------------
 // prettier-ignore
-export type DecodeProperties<T extends TProperties> = {
-  [K in keyof T]: DecodeType<T[K]>
+export type TDecodeProperties<T extends TProperties> = {
+  [K in keyof T]: TDecodeType<T[K]>
 }
 // prettier-ignore
-export type DecodeRest<T extends TSchema[], Acc extends TSchema[] = []> = 
+export type TDecodeRest<T extends TSchema[], Acc extends TSchema[] = []> = 
   T extends [infer L extends TSchema, ...infer R extends TSchema[]]
-    ? DecodeRest<R, [...Acc, DecodeType<L>]>
+    ? TDecodeRest<R, [...Acc, TDecodeType<L>]>
     : Acc
 // prettier-ignore
-export type DecodeType<T extends TSchema> = (
-  T extends TOptional<infer S extends TSchema> ? TOptional<DecodeType<S>> :
-  T extends TReadonly<infer S extends TSchema> ? TReadonly<DecodeType<S>> :
+export type TDecodeType<T extends TSchema> = (
+  T extends TOptional<infer S extends TSchema> ? TOptional<TDecodeType<S>> :
+  T extends TReadonly<infer S extends TSchema> ? TReadonly<TDecodeType<S>> :
   T extends TTransform<infer _, infer R> ? TUnsafe<R> :
-  T extends TArray<infer S extends TSchema> ? TArray<DecodeType<S>> :
-  T extends TAsyncIterator<infer S extends TSchema> ? TAsyncIterator<DecodeType<S>> :
-  T extends TConstructor<infer P extends TSchema[], infer R extends TSchema> ? TConstructor<DecodeRest<P>, DecodeType<R>> :
+  T extends TArray<infer S extends TSchema> ? TArray<TDecodeType<S>> :
+  T extends TAsyncIterator<infer S extends TSchema> ? TAsyncIterator<TDecodeType<S>> :
+  T extends TConstructor<infer P extends TSchema[], infer R extends TSchema> ? TConstructor<TDecodeRest<P>, TDecodeType<R>> :
   T extends TEnum<infer S> ? TEnum<S> : // intercept for union. interior non decodable
-  T extends TFunction<infer P extends TSchema[], infer R extends TSchema> ? TFunction<DecodeRest<P>, DecodeType<R>> :
-  T extends TIntersect<infer S extends TSchema[]> ? TIntersect<DecodeRest<S>> :
-  T extends TIterator<infer S extends TSchema> ? TIterator<DecodeType<S>> :
-  T extends TNot<infer S extends TSchema> ? TNot<DecodeType<S>> :
-  T extends TObject<infer S> ? TObject<Evaluate<DecodeProperties<S>>> :
-  T extends TPromise<infer S extends TSchema> ? TPromise<DecodeType<S>> :
-  T extends TRecord<infer K, infer S> ? TRecord<K, DecodeType<S>> :
-  T extends TRecursive<infer S extends TSchema> ? TRecursive<DecodeType<S>> :
-  T extends TRef<infer S extends TSchema> ? TRef<DecodeType<S>> :
-  T extends TTuple<infer S extends TSchema[]> ? TTuple<DecodeRest<S>> :
-  T extends TUnion<infer S extends TSchema[]> ? TUnion<DecodeRest<S>> :
+  T extends TFunction<infer P extends TSchema[], infer R extends TSchema> ? TFunction<TDecodeRest<P>, TDecodeType<R>> :
+  T extends TIntersect<infer S extends TSchema[]> ? TIntersect<TDecodeRest<S>> :
+  T extends TIterator<infer S extends TSchema> ? TIterator<TDecodeType<S>> :
+  T extends TNot<infer S extends TSchema> ? TNot<TDecodeType<S>> :
+  T extends TObject<infer S> ? TObject<Evaluate<TDecodeProperties<S>>> :
+  T extends TPromise<infer S extends TSchema> ? TPromise<TDecodeType<S>> :
+  T extends TRecord<infer K, infer S> ? TRecord<K, TDecodeType<S>> :
+  T extends TRecursive<infer S extends TSchema> ? TRecursive<TDecodeType<S>> :
+  T extends TRef<infer S extends TSchema> ? TRef<TDecodeType<S>> :
+  T extends TTuple<infer S extends TSchema[]> ? TTuple<TDecodeRest<S>> :
+  T extends TUnion<infer S extends TSchema[]> ? TUnion<TDecodeRest<S>> :
   T
 )
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
 /** Creates an decoded static type from a TypeBox type */
-export type StaticDecode<T extends TSchema, P extends unknown[] = []> = Static<DecodeType<T>, P>
+export type StaticDecode<T extends TSchema, P extends unknown[] = []> = Static<TDecodeType<T>, P>
 /** Creates an encoded static type from a TypeBox type */
 export type StaticEncode<T extends TSchema, P extends unknown[] = []> = Static<T, P>
 /** Creates a static type from a TypeBox type */

--- a/test/runtime/type/guard/exclude.ts
+++ b/test/runtime/type/guard/exclude.ts
@@ -3,40 +3,40 @@ import { Type } from '@sinclair/typebox'
 import { Assert } from '../../assert/index'
 
 describe('type/guard/TExclude', () => {
-  it('Should extract string from number', () => {
+  it('Should exclude string from number', () => {
     const T = Type.Exclude(Type.String(), Type.Number())
     Assert.IsTrue(TypeGuard.IsString(T))
   })
-  it('Should extract string from string', () => {
+  it('Should exclude string from string', () => {
     const T = Type.Exclude(Type.String(), Type.String())
     Assert.IsTrue(TypeGuard.IsNever(T))
   })
-  it('Should extract string | number | boolean from string', () => {
+  it('Should exclude string | number | boolean from string', () => {
     const T = Type.Exclude(Type.Union([Type.String(), Type.Number(), Type.Boolean()]), Type.String())
     Assert.IsTrue(TypeGuard.IsUnion(T))
     Assert.IsTrue(TypeGuard.IsNumber(T.anyOf[0]))
     Assert.IsTrue(TypeGuard.IsBoolean(T.anyOf[1]))
   })
-  it('Should extract string | number | boolean from string | boolean', () => {
+  it('Should exclude string | number | boolean from string | boolean', () => {
     const T = Type.Exclude(Type.Union([Type.String(), Type.Number(), Type.Boolean()]), Type.Union([Type.String(), Type.Boolean()]))
     Assert.IsTrue(TypeGuard.IsNumber(T))
   })
   // ------------------------------------------------------------------------
   // TemplateLiteral | TemplateLiteral
   // ------------------------------------------------------------------------
-  it('Should extract TemplateLiteral | TemplateLiteral 1', () => {
+  it('Should exclude TemplateLiteral | TemplateLiteral 1', () => {
     const A = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])])
     const B = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])])
     const T = Type.Exclude(A, B)
     Assert.IsTrue(TypeGuard.IsNever(T))
   })
-  it('Should extract TemplateLiteral | TemplateLiteral 1', () => {
+  it('Should exclude TemplateLiteral | TemplateLiteral 1', () => {
     const A = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])])
     const B = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B')])])
     const T = Type.Exclude(A, B)
     Assert.IsTrue(['C'].includes(T.const))
   })
-  it('Should extract TemplateLiteral | TemplateLiteral 1', () => {
+  it('Should exclude TemplateLiteral | TemplateLiteral 1', () => {
     const A = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])])
     const B = Type.TemplateLiteral([Type.Union([Type.Literal('A')])])
     const T = Type.Exclude(A, B)
@@ -46,19 +46,19 @@ describe('type/guard/TExclude', () => {
   // ------------------------------------------------------------------------
   // TemplateLiteral | Union 1
   // ------------------------------------------------------------------------
-  it('Should extract TemplateLiteral | Union 1', () => {
+  it('Should exclude TemplateLiteral | Union 1', () => {
     const A = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])])
     const B = Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])
     const T = Type.Exclude(A, B)
     Assert.IsTrue(TypeGuard.IsNever(T))
   })
-  it('Should extract TemplateLiteral | Union 1', () => {
+  it('Should exclude TemplateLiteral | Union 1', () => {
     const A = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])])
     const B = Type.Union([Type.Literal('A'), Type.Literal('B')])
     const T = Type.Exclude(A, B)
     Assert.IsTrue(['C'].includes(T.const))
   })
-  it('Should extract TemplateLiteral | Union 1', () => {
+  it('Should exclude TemplateLiteral | Union 1', () => {
     const A = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])])
     const B = Type.Union([Type.Literal('A')])
     const T = Type.Exclude(A, B)
@@ -68,23 +68,29 @@ describe('type/guard/TExclude', () => {
   // ------------------------------------------------------------------------
   // Union | TemplateLiteral 1
   // ------------------------------------------------------------------------
-  it('Should extract Union | TemplateLiteral 1', () => {
+  it('Should exclude Union | TemplateLiteral 1', () => {
     const A = Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])
     const B = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])])
     const T = Type.Exclude(A, B)
     Assert.IsTrue(TypeGuard.IsNever(T))
   })
-  it('Should extract Union | TemplateLiteral 1', () => {
+  it('Should exclude Union | TemplateLiteral 1', () => {
     const A = Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])
     const B = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B')])])
     const T = Type.Exclude(A, B)
     Assert.IsTrue(['C'].includes(T.const))
   })
-  it('Should extract Union | TemplateLiteral 1', () => {
+  it('Should exclude Union | TemplateLiteral 1', () => {
     const A = Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])
     const B = Type.TemplateLiteral([Type.Union([Type.Literal('A')])])
     const T = Type.Exclude(A, B)
     Assert.IsTrue(['C', 'B'].includes(T.anyOf[0].const))
     Assert.IsTrue(['C', 'B'].includes(T.anyOf[1].const))
+  })
+  it('Should exclude with options', () => {
+    const A = Type.String()
+    const B = Type.String()
+    const T = Type.Exclude(A, B, { foo: 'bar' })
+    Assert.IsEqual(T.foo, 'bar')
   })
 })

--- a/test/runtime/type/guard/extract.ts
+++ b/test/runtime/type/guard/extract.ts
@@ -93,4 +93,10 @@ describe('type/guard/TExtract', () => {
     const T = Type.Extract(A, B)
     Assert.IsTrue(['A'].includes(T.const))
   })
+  it('Should extract with options', () => {
+    const A = Type.String()
+    const B = Type.String()
+    const T = Type.Extract(A, B, { foo: 'bar' })
+    Assert.IsEqual(T.foo, 'bar')
+  })
 })

--- a/test/static/extract.ts
+++ b/test/static/extract.ts
@@ -7,7 +7,7 @@ import { Expect } from './assert'
 }
 {
   const T = Type.Extract(Type.String(), Type.Number())
-  Expect(T).ToStatic<string>()
+  Expect(T).ToStaticNever()
 }
 {
   const T = Type.Extract(Type.Union([Type.Number(), Type.String(), Type.Boolean()]), Type.Number())


### PR DESCRIPTION
This PR exports additional type infrastructure. It's been noted that TypeScript will report errors when users configure for `declaration: true` when exporting certain TB types. It's also been noted that TypeScript may have varying behavior depending on TS implementation, noting that TypeScript may attempt to fully expand the interior type infrastructure for certain signatures (requiring any interior type infrastructure to also be exported)

Related https://github.com/sinclairzx81/typebox/issues/722

This PR exports the following additional types.

- TTemplateLiteralSyntax
- TemplateLiteralSyntax
- TDecodeType
- TDecodeRest
- TDecodePropertes
- TRecordOrObject
- TAwaitedResolve
- TPickResolve
- TOmitResolve
- TKeyOf (Infrastructure)
- TMappedFunctionReturnType

Additional: 

Updated Extract and Exclude to remove MappedType overloads. This needs to be done for all types in subsequent revisions.