### PR TITLE
Revision 0.32.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.6",
+  "version": "0.32.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.6",
+      "version": "0.32.7",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.6",
+  "version": "0.32.7",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/default/default.ts
+++ b/src/value/default/default.ts
@@ -27,6 +27,7 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import { Check } from '../check/index'
+import { Clone } from '../clone/index'
 import { Deref } from '../deref/index'
 import { Kind } from '../../type/symbols/index'
 
@@ -52,7 +53,7 @@ import { IsSchema } from '../../type/guard/type'
 // ValueOrDefault
 // ------------------------------------------------------------------
 function ValueOrDefault(schema: TSchema, value: unknown) {
-  return !(value === undefined) || !('default' in schema) ? value : schema.default
+  return value === undefined && 'default' in schema ? Clone(schema.default) : value
 }
 // ------------------------------------------------------------------
 // IsCheckable

--- a/test/runtime/value/default/object.ts
+++ b/test/runtime/value/default/object.ts
@@ -1,5 +1,5 @@
 import { Value } from '@sinclair/typebox/value'
-import { Type } from '@sinclair/typebox'
+import { Type, CloneType } from '@sinclair/typebox'
 import { Assert } from '../../assert/index'
 
 describe('value/default/Object', () => {
@@ -176,5 +176,37 @@ describe('value/default/Object', () => {
     )
     const R = Value.Default(T, { x: null, y: null, z: undefined })
     Assert.IsEqual(R, { x: null, y: null, z: undefined })
+  })
+  // ----------------------------------------------------------------
+  // Mutation
+  // ----------------------------------------------------------------
+  // https://github.com/sinclairzx81/typebox/issues/726
+  it('Should retain defaults on operation', () => {
+    const A = Type.Object({
+      a: Type.Object(
+        {
+          b: Type.Array(Type.String(), { default: [] }),
+        },
+        { default: {} },
+      ),
+    })
+    const value = Value.Default(A, {})
+    Assert.IsEqual(value, { a: { b: [] } })
+    Assert.IsEqual(A.properties.a.default, {})
+    Assert.IsEqual(A.properties.a.properties.b.default, [])
+  })
+  // https://github.com/sinclairzx81/typebox/issues/726
+  it('Should retain schematics on operation', () => {
+    const A = Type.Object({
+      a: Type.Object(
+        {
+          b: Type.Array(Type.String(), { default: [] }),
+        },
+        { default: {} },
+      ),
+    })
+    const B = CloneType(A)
+    Value.Default(A, {})
+    Assert.IsEqual(A, B)
   })
 })


### PR DESCRIPTION
This PR updates the `Default` Value function to ensure that the default annotation is cloned on assignment. Previously, the default annotation was assigned by reference, causing subsequent operations on the value to mutate the annotation.

Reference: https://github.com/sinclairzx81/typebox/issues/726