### PR TITLE
Revision 0.32.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.7",
+  "version": "0.32.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.7",
+      "version": "0.32.8",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.7",
+  "version": "0.32.8",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/cast/cast.ts
+++ b/src/value/cast/cast.ts
@@ -92,7 +92,7 @@ function SelectUnion(union: TUnion, references: TSchema[], value: any): TSchema 
 }
 function CastUnion(union: TUnion, references: TSchema[], value: any) {
   if ('default' in union) {
-    return union.default
+    return typeof value === 'function' ? union.default : Clone(union.default)
   } else {
     const schema = SelectUnion(union, references, value)
     return Cast(schema, references, value)

--- a/test/runtime/value/create/object.ts
+++ b/test/runtime/value/create/object.ts
@@ -68,4 +68,19 @@ describe('value/create/Object', () => {
       z: 3,
     })
   })
+  // ----------------------------------------------------------------
+  // Mutation
+  // ----------------------------------------------------------------
+  // https://github.com/sinclairzx81/typebox/issues/726
+  it('Should clone defaults on assignment - no mutation', () => {
+    const T = Type.Object(
+      {
+        x: Type.Number(),
+      },
+      { default: { x: 1 } },
+    )
+    const V = Value.Create(T)
+    V.x = 123
+    Assert.IsEqual(T.default, { x: 1 })
+  })
 })


### PR DESCRIPTION
This PR ensures the default annotation in cloned on Create. Prior to this PR, Create could assign default values by reference. This could result in unintended mutation of the annotation with downstream handling of the value, cloning the value mitigates this.

Reference: https://github.com/sinclairzx81/typebox/issues/726
