### PR TITLE
Revision 0.32.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.9",
+  "version": "0.32.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.9",
+      "version": "0.32.10",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.9",
+  "version": "0.32.10",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/type/required/required.ts
+++ b/src/type/required/required.ts
@@ -53,7 +53,7 @@ import { IsMappedResult, IsIntersect, IsUnion, IsObject } from '../guard/type'
 // prettier-ignore
 type TFromRest<T extends TSchema[], Acc extends TSchema[] = []> = (
   T extends [infer L extends TSchema, ...infer R extends TSchema[]]
-    ? TFromRest<R, [...Acc, TRequiredResolve<L>]>
+    ? TFromRest<R, [...Acc, TRequired<L>]>
     : Acc
 )
 // prettier-ignore
@@ -80,28 +80,27 @@ function FromProperties<T extends TProperties>(T: T) {
 // ------------------------------------------------------------------
 // RequiredResolve
 // ------------------------------------------------------------------
+
 // prettier-ignore
-type TRequiredResolve<T extends TSchema> = (
-  T extends TRecursive<infer S> ? TRecursive<TRequiredResolve<S>> :
-  T extends TIntersect<infer S> ? TIntersect<TFromRest<S>> :
-  T extends TUnion<infer S> ? TUnion<TFromRest<S>> :
-  T extends TObject<infer S> ? TObject<TFromProperties<S>> :
-  TObject<{}>
-)
-// prettier-ignore
-function RequiredResolve<T extends TSchema>(T: T): TRequiredResolve<T> {
+function RequiredResolve<T extends TSchema>(T: T): TRequired<T> {
   return (
     IsIntersect(T) ? Intersect(FromRest(T.allOf)) :
     IsUnion(T) ?  Union(FromRest(T.anyOf)) :
     IsObject(T) ? Object(FromProperties(T.properties)) :
     Object({})
-  ) as TRequiredResolve<T>
+  ) as TRequired<T>
 }
 // ------------------------------------------------------------------
 // TRequired
 // ------------------------------------------------------------------
-export type TRequired<T extends TSchema> = TRequiredResolve<T>
-
+// prettier-ignore
+export type TRequired<T extends TSchema> = (
+  T extends TRecursive<infer S> ? TRecursive<TRequired<S>> :
+  T extends TIntersect<infer S> ? TIntersect<TFromRest<S>> :
+  T extends TUnion<infer S> ? TUnion<TFromRest<S>> :
+  T extends TObject<infer S> ? TObject<TFromProperties<S>> :
+  TObject<{}>
+)
 /** `[Json]` Constructs a type where all properties are required */
 export function Required<T extends TMappedResult>(T: T, options?: SchemaOptions): TRequiredFromMappedResult<T>
 /** `[Json]` Constructs a type where all properties are required */


### PR DESCRIPTION
This PR exports additional type infrastructure for Partial and Required. This update is prompted by "The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed." errors being observed on the TSP due to it being unable to resolve internal infrastructure (so TS appears to try and synthesize it)