### PR TITLE
Fix some infinite recursion with static types

### DIFF
--- a/src/type/array/array.ts
+++ b/src/type/array/array.ts
@@ -27,7 +27,7 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import { CloneType } from '../clone/type'
-import { Ensure } from '../helpers'
+import { Ensure } from '../helpers/index'
 import type { SchemaOptions, TSchema } from '../schema/index'
 import type { Static } from '../static/index'
 import { Kind } from '../symbols/index'

--- a/src/type/array/array.ts
+++ b/src/type/array/array.ts
@@ -26,10 +26,11 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import type { TSchema, SchemaOptions } from '../schema/index'
+import { CloneType } from '../clone/type'
+import { Ensure } from '../helpers'
+import type { SchemaOptions, TSchema } from '../schema/index'
 import type { Static } from '../static/index'
 import { Kind } from '../symbols/index'
-import { CloneType } from '../clone/type'
 
 export interface ArrayOptions extends SchemaOptions {
   /** The minimum number of items in this array */
@@ -45,9 +46,10 @@ export interface ArrayOptions extends SchemaOptions {
   /** A maximum number of contains schema matches */
   maxContains?: number
 }
+type ArrayStatic<T extends TSchema, P extends unknown[]> = Ensure<Static<T, P>[]>
 export interface TArray<T extends TSchema = TSchema> extends TSchema, ArrayOptions {
   [Kind]: 'Array'
-  static: Array<Static<T, this['params']>>
+  static: ArrayStatic<T, this['params']>
   type: 'array'
   items: T
 }

--- a/src/type/record/record.ts
+++ b/src/type/record/record.ts
@@ -181,7 +181,7 @@ function FromNumberKey<K extends TNumber, T extends TSchema>(_: K, T: T, options
 // ------------------------------------------------------------------
 // prettier-ignore
 type RecordStatic<K extends TSchema, T extends TSchema, P extends unknown[]> = (
-  Evaluate<{ [Key in Assert<Static<K>, PropertyKey>]: Static<T, P>; }>
+  Evaluate<{ [_ in Assert<Static<K>, PropertyKey>]: Static<T, P>; }>
 )
 // prettier-ignore
 export interface TRecord<K extends TSchema = TSchema, T extends TSchema = TSchema> extends TSchema {

--- a/src/type/record/record.ts
+++ b/src/type/record/record.ts
@@ -181,7 +181,7 @@ function FromNumberKey<K extends TNumber, T extends TSchema>(_: K, T: T, options
 // ------------------------------------------------------------------
 // prettier-ignore
 type RecordStatic<K extends TSchema, T extends TSchema, P extends unknown[]> = (
-  Evaluate<Record<Assert<Static<K>, PropertyKey>, Static<T, P>>>
+  Evaluate<{ [Key in Assert<Static<K>, PropertyKey>]: Static<T, P>; }>
 )
 // prettier-ignore
 export interface TRecord<K extends TSchema = TSchema, T extends TSchema = TSchema> extends TSchema {

--- a/test/static/recursive.ts
+++ b/test/static/recursive.ts
@@ -1,5 +1,5 @@
+import { Static, Type } from '@sinclair/typebox'
 import { Expect } from './assert'
-import { Type, Static } from '@sinclair/typebox'
 
 {
   // identity
@@ -77,4 +77,25 @@ import { Type, Static } from '@sinclair/typebox'
   Expect(T).ToStatic<{
     nodes: Static<typeof T>[]
   }>()
+}
+{
+  // issue: https://github.com/sinclairzx81/typebox/issues/336
+  type JSONValue =
+    | string
+    | number
+    | null
+    | boolean
+    | { [x: string]: JSONValue }
+    | JSONValue[]
+  const R = Type.Recursive((Node) =>
+    Type.Union([
+      Type.Null(),
+      Type.String(),
+      Type.Number(),
+      Type.Boolean(),
+      Type.Record(Type.String(), Node),
+      Type.Array(Node),
+    ]),
+  )
+  Expect(R).ToStatic<JSONValue>()
 }


### PR DESCRIPTION
This fixes the record type and the array type so that they are less likely to cause infinite recursion.

The `JSONValue` type in #336 is now usable without causing the `Type instantiation is excessively deep and possibly infinite` error.

The record fix was pretty straightforward, simply inlining the logic of `Record` directly in the `RecordStatic` type.
The array fix however is a bit weirder, I'm not quite sure why it works but it does somehow.

No tests were added, I took a brief look at [/test/static/recursive.ts](https://github.com/sinclairzx81/typebox/blob/0c0da45394e5ecb043a6fc6fee7d24a13bc9e4fa/test/static/recursive.ts) but wasn't quite sure how to add a test for this that made sense.