### PR TITLE
Revision 0.32.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.10",
+  "version": "0.32.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.10",
+      "version": "0.32.11",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.10",
+  "version": "0.32.11",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,9 +79,9 @@ export { ConstructorParameters, type TConstructorParameters } from './type/const
 export { Date, type TDate, type DateOptions } from './type/date/index'
 export { Deref, type TDeref } from './type/deref/index'
 export { Enum, type TEnum } from './type/enum/index'
-export { Exclude, type TExclude, type TExcludeFromMappedResult } from './type/exclude/index'
+export { Exclude, type TExclude, type TExcludeFromMappedResult, type TExcludeFromTemplateLiteral } from './type/exclude/index'
 export { Extends, ExtendsCheck, ExtendsResult, ExtendsUndefinedCheck, type TExtends, type ExtendsFromMappedResult, type ExtendsFromMappedKey } from './type/extends/index'
-export { Extract, type TExtract, type TExtractFromMappedResult } from './type/extract/index'
+export { Extract, type TExtract, type TExtractFromMappedResult, type TExtractFromTemplateLiteral } from './type/extract/index'
 export { Function, type TFunction } from './type/function/index'
 export {
   Index,
@@ -136,6 +136,7 @@ export {
   TemplateLiteralGenerate,
   TemplateLiteralParse,
   TemplateLiteralParseExact,
+  TemplateLiteralToUnion,
   IsTemplateLiteralFinite,
   TemplateLiteralExpressionGenerate,
   IsTemplateLiteralExpressionFinite,
@@ -143,6 +144,7 @@ export {
   type TTemplateLiteralSyntax,
   type TTemplateLiteralGenerate,
   type TTemplateLiteralKind,
+  type TTemplateLiteralToUnion,
   type TIsTemplateLiteralFinite,
 } from './type/template-literal/index'
 export { Transform, TransformDecodeBuilder, TransformEncodeBuilder, type TTransform, type TransformOptions, type TransformFunction } from './type/transform/index'

--- a/src/type/exclude/exclude-from-mapped-result.ts
+++ b/src/type/exclude/exclude-from-mapped-result.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import type { TSchema, SchemaOptions } from '../schema/index'
+import type { TSchema } from '../schema/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult } from '../mapped/index'
 import { Exclude, type TExclude } from './exclude'
@@ -45,9 +45,9 @@ type TFromProperties<
 function FromProperties<
   P extends TProperties,
   T extends TSchema
->(P: P, U: T, options: SchemaOptions): TFromProperties<P, T> {
+>(P: P, U: T): TFromProperties<P, T> {
   return globalThis.Object.getOwnPropertyNames(P).reduce((Acc, K2) => {
-    return {...Acc, [K2]: Exclude(P[K2], U, options) }
+    return {...Acc, [K2]: Exclude(P[K2], U) }
   }, {}) as TFromProperties<P, T>
 }
 // ------------------------------------------------------------------
@@ -64,8 +64,8 @@ type TFromMappedResult<
 function FromMappedResult<
   R extends TMappedResult,
   T extends TSchema
->(R: R, T: T, options: SchemaOptions): TFromMappedResult<R, T> {
-  return FromProperties(R.properties, T, options) as TFromMappedResult<R, T>
+>(R: R, T: T): TFromMappedResult<R, T> {
+  return FromProperties(R.properties, T) as TFromMappedResult<R, T>
 }
 // ------------------------------------------------------------------
 // ExcludeFromMappedResult
@@ -83,7 +83,7 @@ export function ExcludeFromMappedResult<
   R extends TMappedResult,
   T extends TSchema,
   P extends TProperties = TFromMappedResult<R, T>
->(R: R, T: T, options: SchemaOptions): TMappedResult<P> {
-  const P = FromMappedResult(R, T, options) as unknown as P
+>(R: R, T: T): TMappedResult<P> {
+  const P = FromMappedResult(R, T) as unknown as P
   return MappedResult(P) 
 }

--- a/src/type/exclude/exclude-from-template-literal.ts
+++ b/src/type/exclude/exclude-from-template-literal.ts
@@ -26,6 +26,14 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-export * from './extract-from-mapped-result'
-export * from './extract-from-template-literal'
-export * from './extract'
+import type { TSchema } from '../schema/index'
+import { TExclude, Exclude } from './exclude'
+import { TemplateLiteralToUnion, type TTemplateLiteral, type TTemplateLiteralToUnion } from '../template-literal/index'
+
+// prettier-ignore
+export type TExcludeFromTemplateLiteral<L extends TTemplateLiteral, R extends TSchema> = (
+  TExclude<TTemplateLiteralToUnion<L>, R>
+)
+export function ExcludeFromTemplateLiteral<L extends TTemplateLiteral, R extends TSchema>(L: L, R: R): TExcludeFromTemplateLiteral<L, R> {
+  return Exclude(TemplateLiteralToUnion(L), R) as never
+}

--- a/src/type/exclude/index.ts
+++ b/src/type/exclude/index.ts
@@ -27,4 +27,5 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 export * from './exclude-from-mapped-result'
+export * from './exclude-from-template-literal'
 export * from './exclude'

--- a/src/type/extract/extract-from-mapped-result.ts
+++ b/src/type/extract/extract-from-mapped-result.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import type { TSchema, SchemaOptions } from '../schema/index'
+import type { TSchema } from '../schema/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult } from '../mapped/index'
 import { Extract, type TExtract } from './extract'
@@ -45,9 +45,9 @@ type TFromProperties<
 function FromProperties<
   P extends TProperties,
   T extends TSchema
->(P: P, T: T, options: SchemaOptions): TFromProperties<P, T> {
+>(P: P, T: T): TFromProperties<P, T> {
   return globalThis.Object.getOwnPropertyNames(P).reduce((Acc, K2) => {
-    return {...Acc, [K2]: Extract(P[K2], T, options) }
+    return {...Acc, [K2]: Extract(P[K2], T) }
   }, {}) as TFromProperties<P, T>
 }
 // ------------------------------------------------------------------
@@ -64,8 +64,8 @@ type TFromMappedResult<
 function FromMappedResult<
   R extends TMappedResult,
   T extends TSchema
->(R: R, T: T, options: SchemaOptions): TFromMappedResult<R, T> {
-  return FromProperties(R.properties, T, options) as TFromMappedResult<R, T>
+>(R: R, T: T): TFromMappedResult<R, T> {
+  return FromProperties(R.properties, T) as TFromMappedResult<R, T>
 }
 // ------------------------------------------------------------------
 // ExtractFromMappedResult
@@ -83,7 +83,7 @@ export function ExtractFromMappedResult<
   R extends TMappedResult,
   T extends TSchema,
   P extends TProperties = TFromMappedResult<R, T>
->(R: R, T: T, options: SchemaOptions): TMappedResult<P> {
-  const P = FromMappedResult(R, T, options) as unknown as P
+>(R: R, T: T): TMappedResult<P> {
+  const P = FromMappedResult(R, T) as unknown as P
   return MappedResult(P) 
 }

--- a/src/type/extract/extract-from-template-literal.ts
+++ b/src/type/extract/extract-from-template-literal.ts
@@ -26,6 +26,14 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-export * from './extract-from-mapped-result'
-export * from './extract-from-template-literal'
-export * from './extract'
+import type { TSchema } from '../schema/index'
+import { Extract, type TExtract } from './extract'
+import { TemplateLiteralToUnion, type TTemplateLiteral, type TTemplateLiteralToUnion } from '../template-literal/index'
+
+// prettier-ignore
+export type TExtractFromTemplateLiteral<L extends TTemplateLiteral, R extends TSchema> = (
+  TExtract<TTemplateLiteralToUnion<L>, R>
+)
+export function ExtractFromTemplateLiteral<L extends TTemplateLiteral, R extends TSchema>(L: L, R: R): TExtractFromTemplateLiteral<L, R> {
+  return Extract(TemplateLiteralToUnion(L), R) as never
+}

--- a/src/type/template-literal/union.ts
+++ b/src/type/template-literal/union.ts
@@ -26,19 +26,31 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import type { Static } from '../static/index'
 import type { TTemplateLiteral } from './template-literal'
-import { Union, type TUnion } from '../union/index'
+import type { UnionToTuple } from '../helpers/index'
+import { UnionEvaluated, type TUnionEvaluated } from '../union/index'
 import { Literal, type TLiteral } from '../literal/index'
-import { type TString } from '../string/index'
-import { type TNever } from '../never/index'
 import { TemplateLiteralGenerate } from './generate'
 
 // ------------------------------------------------------------------
 // TemplateLiteralToUnion
 // ------------------------------------------------------------------
+// prettier-ignore
+export type TTemplateLiteralToUnionLiteralArray<T extends string[], Acc extends TLiteral[] = []> = (
+  T extends [infer L extends string, ...infer R extends string[]]
+    ? TTemplateLiteralToUnionLiteralArray<R, [...Acc, TLiteral<L>]>
+    : Acc
+)
+// prettier-ignore
+export type TTemplateLiteralToUnion<
+  T extends TTemplateLiteral,
+  U extends string[] = UnionToTuple<Static<T>>
+> = TUnionEvaluated<TTemplateLiteralToUnionLiteralArray<U>>
+
 /** Returns a Union from the given TemplateLiteral */
-export function TemplateLiteralToUnion(schema: TTemplateLiteral): TNever | TString | TUnion<TLiteral[]> {
+export function TemplateLiteralToUnion<T extends TTemplateLiteral>(schema: TTemplateLiteral): TTemplateLiteralToUnion<T> {
   const R = TemplateLiteralGenerate(schema) as string[]
   const L = R.map((S) => Literal(S))
-  return Union(L)
+  return UnionEvaluated(L)
 }

--- a/src/type/type/json.ts
+++ b/src/type/type/json.ts
@@ -33,9 +33,9 @@ import { Composite, type TComposite } from '../composite/index'
 import { Const, type TConst } from '../const/index'
 import { Deref, type TDeref } from '../deref/index'
 import { Enum, type TEnum, type TEnumKey, type TEnumValue } from '../enum/index'
-import { Exclude, type TExclude, type TExcludeFromMappedResult } from '../exclude/index'
+import { Exclude, type TExclude, type TExcludeFromMappedResult, type TExcludeFromTemplateLiteral } from '../exclude/index'
 import { Extends, type TExtends, type TExtendsFromMappedKey, type TExtendsFromMappedResult } from '../extends/index'
-import { Extract, type TExtract, type TExtractFromMappedResult } from '../extract/index'
+import { Extract, type TExtract, type TExtractFromMappedResult, type TExtractFromTemplateLiteral } from '../extract/index'
 import { Index, TIndex, type TIndexPropertyKeys, type TIndexFromMappedKey, type TIndexFromMappedResult } from '../indexed/index'
 import { Integer, type IntegerOptions, type TInteger } from '../integer/index'
 import { Intersect, type IntersectOptions } from '../intersect/index'
@@ -148,6 +148,8 @@ export class JsonTypeBuilder {
   /** `[Json]` Constructs a type by excluding from unionType all union members that are assignable to excludedMembers */
   public Exclude<L extends TMappedResult, R extends TSchema>(unionType: L, excludedMembers: R, options?: SchemaOptions): TExcludeFromMappedResult<L, R>
   /** `[Json]` Constructs a type by excluding from unionType all union members that are assignable to excludedMembers */
+  public Exclude<L extends TTemplateLiteral, R extends TSchema>(unionType: L, excludedMembers: R, options?: SchemaOptions): TExcludeFromTemplateLiteral<L, R>
+  /** `[Json]` Constructs a type by excluding from unionType all union members that are assignable to excludedMembers */
   public Exclude<L extends TSchema, R extends TSchema>(unionType: L, excludedMembers: R, options?: SchemaOptions): TExclude<L, R>
   /** `[Json]` Constructs a type by excluding from unionType all union members that are assignable to excludedMembers */
   public Exclude(unionType: TSchema, excludedMembers: TSchema, options: SchemaOptions = {}): any {
@@ -165,6 +167,8 @@ export class JsonTypeBuilder {
   }
   /** `[Json]` Constructs a type by extracting from type all union members that are assignable to union */
   public Extract<L extends TMappedResult, R extends TSchema>(type: L, union: R, options?: SchemaOptions): TExtractFromMappedResult<L, R>
+  /** `[Json]` Constructs a type by extracting from type all union members that are assignable to union */
+  public Extract<L extends TTemplateLiteral, R extends TSchema>(type: L, union: R, options?: SchemaOptions): TExtractFromTemplateLiteral<L, R>
   /** `[Json]` Constructs a type by extracting from type all union members that are assignable to union */
   public Extract<L extends TSchema, R extends TSchema>(type: L, union: R, options?: SchemaOptions): TExtract<L, R>
   /** `[Json]` Constructs a type by extracting from type all union members that are assignable to union */

--- a/test/static/exclude.ts
+++ b/test/static/exclude.ts
@@ -82,3 +82,18 @@ import { Expect } from './assert'
   const T = Type.Exclude(A, B)
   Expect(T).ToStatic<'C' | 'B'>()
 }
+// https://github.com/sinclairzx81/typebox/issues/737
+{
+  const U = Type.Union([Type.Literal('A'), Type.Literal('B')])
+  const T = Type.Object({
+    type: Type.Exclude(U, Type.Literal('A')),
+  })
+  Expect(T).ToStatic<{ type: 'B' }>()
+}
+{
+  const U = Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])
+  const T = Type.Object({
+    type: Type.Exclude(U, Type.Literal('A')),
+  })
+  Expect(T).ToStatic<{ type: 'B' | 'C' }>()
+}

--- a/test/static/extract.ts
+++ b/test/static/extract.ts
@@ -81,3 +81,20 @@ import { Expect } from './assert'
   const T = Type.Extract(A, B)
   Expect(T).ToStatic<'A'>()
 }
+// ------------------------------------------------------------------------
+// Nested (Inference Test)
+// ------------------------------------------------------------------------
+{
+  const U = Type.Union([Type.Literal('A'), Type.Literal('B')])
+  const T = Type.Object({
+    type: Type.Extract(U, Type.Literal('A')),
+  })
+  Expect(T).ToStatic<{ type: 'A' }>()
+}
+{
+  const U = Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C')])
+  const T = Type.Object({
+    type: Type.Extract(U, Type.Union([Type.Literal('A'), Type.Literal('B')])),
+  })
+  Expect(T).ToStatic<{ type: 'A' | 'B' }>()
+}


### PR DESCRIPTION
This PR optmizes type inference for Extract and Exclude. This update adds additional overloads for TTemplateLiteral and TMappedResult and removes the resolution via the top level type. This approach resolves deep instantiation issues, but at a cost of moving further away from a unified resolver strategy for these types.

Reference https://github.com/sinclairzx81/typebox/issues/737