### PR TITLE
Revision 0.32.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.13",
+  "version": "0.32.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.13",
+      "version": "0.32.14",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.13",
+  "version": "0.32.14",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,133 +29,78 @@ THE SOFTWARE.
 // ------------------------------------------------------------------
 // Infrastructure
 // ------------------------------------------------------------------
-export { Kind, Hint, ReadonlyKind, OptionalKind, TransformKind } from './type/symbols/index'
-export { PatternBoolean, PatternBooleanExact, PatternNumber, PatternNumberExact, PatternString, PatternStringExact } from './type/patterns/index'
-export { TypeRegistry, FormatRegistry } from './type/registry/index'
-export { TypeGuard, ValueGuard } from './type/guard/index'
-export { CloneType, CloneRest } from './type/clone/type'
-// ------------------------------------------------------------------
-// Error
-// ------------------------------------------------------------------
-export { TypeBoxError } from './type/error/index'
-// ------------------------------------------------------------------
-// Sets
-// ------------------------------------------------------------------
-export {
-  SetComplement,
-  SetDistinct,
-  SetIncludes,
-  SetIntersect,
-  SetIntersectMany,
-  SetIsSubset,
-  SetUnion,
-  SetUnionMany,
-  type TSetComplement,
-  type TSetDistinct,
-  type TSetIncludes,
-  type TSetIntersect,
-  type TSetIntersectMany,
-  type TSetIsSubset,
-  type TSetUnion,
-  type TSetUnionMany,
-} from './type/sets/index'
-// ------------------------------------------------------------------
-// Helpers
-// ------------------------------------------------------------------
-export { Increment, type TIncrement, type Assert, type AssertType, type AssertRest, type AssertProperties, type Ensure, type Evaluate, type TupleToIntersect, type TupleToUnion, type UnionToTuple } from './type/helpers/index'
+export * from './type/clone/index'
+export * from './type/error/index'
+export * from './type/guard/index'
+export * from './type/helpers/index'
+export * from './type/patterns/index'
+export * from './type/registry/index'
+export * from './type/sets/index'
+export * from './type/symbols/index'
 // ------------------------------------------------------------------
 // Types
 // ------------------------------------------------------------------
-export { Any, type TAny } from './type/any/index'
-export { Array, type TArray, type ArrayOptions } from './type/array/index'
-export { AsyncIterator, type TAsyncIterator } from './type/async-iterator/index'
-export { Awaited, type TAwaited } from './type/awaited/index'
-export { BigInt, type TBigInt, type BigIntOptions } from './type/bigint/index'
-export { Boolean, type TBoolean } from './type/boolean/index'
-export { Composite, type TComposite } from './type/composite/index'
-export { Const, type TConst } from './type/const/index'
-export { Constructor, type TConstructor } from './type/constructor/index'
-export { ConstructorParameters, type TConstructorParameters } from './type/constructor-parameters/index'
-export { Date, type TDate, type DateOptions } from './type/date/index'
-export { Deref, type TDeref } from './type/deref/index'
-export { Enum, type TEnum } from './type/enum/index'
-export { Exclude, type TExclude, type TExcludeFromMappedResult, type TExcludeFromTemplateLiteral } from './type/exclude/index'
-export { Extends, ExtendsCheck, ExtendsResult, ExtendsUndefinedCheck, type TExtends, type ExtendsFromMappedResult, type ExtendsFromMappedKey } from './type/extends/index'
-export { Extract, type TExtract, type TExtractFromMappedResult, type TExtractFromTemplateLiteral } from './type/extract/index'
-export { Function, type TFunction } from './type/function/index'
-export {
-  Index,
-  IndexPropertyKeys,
-  IndexFromPropertyKeys,
-  IndexFromPropertyKey,
-  IndexFromMappedKey,
-  IndexFromMappedResult,
-  type TIndex,
-  type TIndexPropertyKeys,
-  type TIndexFromPropertyKeys,
-  type TIndexFromPropertyKey,
-  type TIndexFromMappedKey,
-  type TIndexFromMappedResult,
-} from './type/indexed/index'
-export { InstanceType, type TInstanceType } from './type/instance-type/index'
-export { Integer, type TInteger, type IntegerOptions } from './type/integer/index'
-export { Intersect, IntersectEvaluated, type TIntersect, type TIntersectEvaluated, type IntersectOptions } from './type/intersect/index'
-export { Iterator, type TIterator } from './type/iterator/index'
-export { Intrinsic, IntrinsicFromMappedKey, type TIntrinsic, Capitalize, type TCapitalize, Lowercase, type TLowercase, Uncapitalize, type TUncapitalize, Uppercase, type TUppercase } from './type/intrinsic/index'
-export { KeyOf, KeyOfPropertyKeys, KeyOfPropertyKeysToRest, KeyOfFromMappedResult, KeyOfPattern, type TKeyOf, type TKeyOfPropertyKeys, type TKeyOfPropertyKeysToRest, type TKeyOfFromMappedResult } from './type/keyof/index'
-export { Literal, type TLiteral, type TLiteralValue } from './type/literal/index'
-export { Mapped, MappedKey, MappedResult, MappedFunctionReturnType, type TMapped, type TMappedKey, type TMappedResult, type TMappedFunction, type TMappedFunctionReturnType } from './type/mapped/index'
-export { Never, type TNever } from './type/never/index'
-export { Not, type TNot } from './type/not/index'
-export { Null, type TNull } from './type/null/index'
-export { Number, type TNumber, type NumberOptions } from './type/number/index'
-export { Object, type TObject, type TProperties, type ObjectOptions } from './type/object/index'
-export { Omit, type TOmit, type TOmitFromMappedKey, type TOmitFromMappedResult } from './type/omit/index'
-export { Optional, OptionalFromMappedResult, type TOptional, type TOptionalWithFlag, type TOptionalFromMappedResult } from './type/optional/index'
-export { Parameters, type TParameters } from './type/parameters/index'
-export { Partial, PartialFromMappedResult, type TPartial, type TPartialFromMappedResult } from './type/partial/index'
-export { Pick, type TPick, type TPickFromMappedKey, type TPickFromMappedResult } from './type/pick/index'
-export { Promise, type TPromise } from './type/promise/index'
-export { Readonly, ReadonlyFromMappedResult, type TReadonly, type TReadonlyWithFlag, type TReadonlyFromMappedResult } from './type/readonly/index'
-export { ReadonlyOptional, type TReadonlyOptional } from './type/readonly-optional/index'
-export { Record, type TRecord, type TRecordOrObject } from './type/record/index'
-export { Recursive, type TRecursive, type TThis } from './type/recursive/index'
-export { Ref, type TRef } from './type/ref/index'
-export { RegExp, type TRegExp, type RegExpOptions } from './type/regexp/index'
-export { Required, type TRequired, type TRequiredFromMappedResult } from './type/required/index'
-export { Rest, type TRest } from './type/rest/index'
-export { ReturnType, type TReturnType } from './type/return-type/index'
-export { type TSchema, type TKind, type SchemaOptions, type TAnySchema } from './type/schema/index'
-export { type Static, type StaticDecode, type StaticEncode, type TDecodeType, type TDecodeRest, type TDecodeProperties } from './type/static/index'
-export { Strict } from './type/strict/index'
-export { String, type TString, type StringOptions, type StringFormatOption, type StringContentEncodingOption } from './type/string/index'
-export { Symbol, type TSymbol, type TSymbolValue } from './type/symbol/index'
-export {
-  TemplateLiteral,
-  TemplateLiteralSyntax,
-  TemplateLiteralGenerate,
-  TemplateLiteralParse,
-  TemplateLiteralParseExact,
-  TemplateLiteralToUnion,
-  IsTemplateLiteralFinite,
-  TemplateLiteralExpressionGenerate,
-  IsTemplateLiteralExpressionFinite,
-  type TTemplateLiteral,
-  type TTemplateLiteralSyntax,
-  type TTemplateLiteralGenerate,
-  type TTemplateLiteralKind,
-  type TTemplateLiteralToUnion,
-  type TIsTemplateLiteralFinite,
-} from './type/template-literal/index'
-export { Transform, TransformDecodeBuilder, TransformEncodeBuilder, type TTransform, type TransformOptions, type TransformFunction } from './type/transform/index'
-export { Tuple, type TTuple } from './type/tuple/index'
-export { Uint8Array, type TUint8Array, type Uint8ArrayOptions } from './type/uint8array/index'
-export { Undefined, type TUndefined } from './type/undefined/index'
-export { Union, UnionEvaluated, type TUnion, type TUnionEvaluated } from './type/union/index'
-export { Unknown, type TUnknown } from './type/unknown/index'
-export { Unsafe, type TUnsafe } from './type/unsafe/index'
-export { Void, type TVoid } from './type/void/index'
+export * from './type/any/index'
+export * from './type/array/index'
+export * from './type/async-iterator/index'
+export * from './type/awaited/index'
+export * from './type/bigint/index'
+export * from './type/boolean/index'
+export * from './type/composite/index'
+export * from './type/const/index'
+export * from './type/constructor/index'
+export * from './type/constructor-parameters/index'
+export * from './type/date/index'
+export * from './type/deref/index'
+export * from './type/enum/index'
+export * from './type/exclude/index'
+export * from './type/extends/index'
+export * from './type/extract/index'
+export * from './type/function/index'
+export * from './type/indexed/index'
+export * from './type/instance-type/index'
+export * from './type/integer/index'
+export * from './type/intersect/index'
+export * from './type/iterator/index'
+export * from './type/intrinsic/index'
+export * from './type/keyof/index'
+export * from './type/literal/index'
+export * from './type/mapped/index'
+export * from './type/never/index'
+export * from './type/not/index'
+export * from './type/null/index'
+export * from './type/number/index'
+export * from './type/object/index'
+export * from './type/omit/index'
+export * from './type/optional/index'
+export * from './type/parameters/index'
+export * from './type/partial/index'
+export * from './type/pick/index'
+export * from './type/promise/index'
+export * from './type/readonly/index'
+export * from './type/readonly-optional/index'
+export * from './type/record/index'
+export * from './type/recursive/index'
+export * from './type/ref/index'
+export * from './type/regexp/index'
+export * from './type/required/index'
+export * from './type/rest/index'
+export * from './type/return-type/index'
+export * from './type/schema/index'
+export * from './type/static/index'
+export * from './type/strict/index'
+export * from './type/string/index'
+export * from './type/symbol/index'
+export * from './type/template-literal/index'
+export * from './type/transform/index'
+export * from './type/tuple/index'
+export * from './type/uint8array/index'
+export * from './type/undefined/index'
+export * from './type/union/index'
+export * from './type/unknown/index'
+export * from './type/unsafe/index'
+export * from './type/void/index'
 // ------------------------------------------------------------------
 // Namespace
 // ------------------------------------------------------------------
-export { Type, JsonTypeBuilder, JavaScriptTypeBuilder } from './type/type/index'
+export * from './type/type/index'

--- a/src/type/clone/index.ts
+++ b/src/type/clone/index.ts
@@ -26,5 +26,5 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-export * as TypeClone from './type'
-export * as ValueClone from './value'
+export * from './type'
+export * from './value'

--- a/src/type/const/const.ts
+++ b/src/type/const/const.ts
@@ -44,7 +44,7 @@ import { Readonly, type TReadonly } from '../readonly/index'
 import { Undefined, type TUndefined } from '../undefined/index'
 import { Uint8Array, type TUint8Array } from '../uint8array/index'
 import { Unknown, type TUnknown } from '../unknown/index'
-import { TypeClone } from '../clone/index'
+import { CloneType } from '../clone/index'
 
 // ------------------------------------------------------------------
 // ValueGuard
@@ -131,5 +131,5 @@ export type TConst<T> = FromValue<T, true>
 
 /** `[JavaScript]` Creates a readonly const type from the given value. */
 export function Const</* const (not supported in 4.0) */ T>(T: T, options: SchemaOptions = {}): TConst<T> {
-  return TypeClone.CloneType(FromValue(T, true), options) as TConst<T>
+  return CloneType(FromValue(T, true), options) as TConst<T>
 }

--- a/src/type/object/object.ts
+++ b/src/type/object/object.ts
@@ -84,7 +84,7 @@ export interface TObject<T extends TProperties = TProperties> extends TSchema, O
   required?: string[]
 }
 /** `[Json]` Creates an Object type */
-export function _Object<T extends TProperties>(properties: T, options: ObjectOptions = {}): TObject<T> {
+function _Object<T extends TProperties>(properties: T, options: ObjectOptions = {}): TObject<T> {
   const propertyKeys = globalThis.Object.getOwnPropertyNames(properties)
   const optionalKeys = propertyKeys.filter((key) => IsOptional(properties[key]))
   const requiredKeys = propertyKeys.filter((name) => !optionalKeys.includes(name))


### PR DESCRIPTION
This PR simplifies the top level exports by switching over the barrel exports (using `*`). It's noted that bundlers (specifically WebPack) are able to correctly shake these exports for ESM. Internal type modules should only export the type factory function.