### PR TITLE
Fix (#754) - Allow decimal values in multipleOf option for Number types

### DIFF
--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -366,7 +366,7 @@ function* FromNumber(schema: TNumber, references: TSchema[], path: string, value
   if (IsDefined<number>(schema.minimum) && !(value >= schema.minimum)) {
     yield Create(ValueErrorType.NumberMinimum, schema, path, value)
   }
-  if (IsDefined<number>(schema.multipleOf) && !(value % schema.multipleOf === 0)) {
+  if (IsDefined<number>(schema.multipleOf) && !Number.isInteger(value / schema.multipleOf)) {
     yield Create(ValueErrorType.NumberMultipleOf, schema, path, value)
   }
 }

--- a/test/runtime/errors/types/number-multiple-of.ts
+++ b/test/runtime/errors/types/number-multiple-of.ts
@@ -14,4 +14,22 @@ describe('errors/type/NumberMultipleOf', () => {
     Assert.IsEqual(R.length, 1)
     Assert.IsEqual(R[0].type, ValueErrorType.NumberMultipleOf)
   })
+  const T2 = Type.Number({ multipleOf: 0.1 })
+  it('Should pass 2', () => {
+    const R = Resolve(T2, 0)
+    Assert.IsEqual(R.length, 0)
+  })
+  it('Should pass 3', () => {
+    const R = Resolve(T2, 1)
+    Assert.IsEqual(R.length, 0)
+  })
+  it('Should pass 4', () => {
+    const R = Resolve(T2, 1.1)
+    Assert.IsEqual(R.length, 0)
+  })
+  it('Should pass 5', () => {
+    const R = Resolve(T2, 1.15)
+    Assert.IsEqual(R.length, 1)
+    Assert.IsEqual(R[0].type, ValueErrorType.NumberMultipleOf)
+  })
 })

--- a/test/runtime/errors/types/number-multiple-of.ts
+++ b/test/runtime/errors/types/number-multiple-of.ts
@@ -32,4 +32,8 @@ describe('errors/type/NumberMultipleOf', () => {
     Assert.IsEqual(R.length, 1)
     Assert.IsEqual(R[0].type, ValueErrorType.NumberMultipleOf)
   })
+  it('Should pass 6', () => {
+    const R = Resolve(T2, 1.4)
+    Assert.IsEqual(R.length, 0)
+  })
 })


### PR DESCRIPTION
Allow `Number` types to be configured with a decimal `multipleOf` value (fixes #754).

Validation for `BigInt`, `Integer` and `Date` types were unmodified as these should only ever be dealing with modulus-safe integers.