### PR TITLE
Revision 0.32.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.14",
+  "version": "0.32.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.14",
+      "version": "0.32.15",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.14",
+  "version": "0.32.15",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -27,4 +27,4 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 export { ValueError, ValueErrorType, ValueErrorIterator } from '../errors/index'
-export { TypeCompiler, TypeCheck, type TypeCompilerCodegenOptions, type TypeCompilerLanguageOption, TypeCompilerTypeGuardError, TypeCompilerUnknownTypeError } from './compiler'
+export * from './compiler'

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -26,5 +26,5 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-export { Errors, ValueError, ValueErrorIterator, ValueErrorType, ValueErrorsUnknownTypeError } from './errors'
-export { DefaultErrorFunction, GetErrorFunction, SetErrorFunction, type ErrorFunction, type ErrorFunctionParameter } from './function'
+export * from './errors'
+export * from './function'

--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -26,5 +26,5 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-export { TypeSystemPolicy } from './policy'
-export { TypeSystem, TypeSystemDuplicateFormat, TypeSystemDuplicateTypeKind } from './system'
+export * from './policy'
+export * from './system'

--- a/src/value/cast/cast.ts
+++ b/src/value/cast/cast.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { IsPlainObject, IsArray, IsString, IsNumber, IsNull } from '../guard/index'
+import { IsStandardObject, IsArray, IsString, IsNumber, IsNull } from '../guard/index'
 import { TypeBoxError } from '../../type/error/index'
 import { Kind } from '../../type/symbols/index'
 import { Create } from '../create/index'
@@ -134,7 +134,7 @@ function FromConstructor(schema: TConstructor, references: TSchema[], value: any
 }
 function FromIntersect(schema: TIntersect, references: TSchema[], value: any): any {
   const created = Create(schema, references)
-  const mapped = IsPlainObject(created) && IsPlainObject(value) ? { ...(created as any), ...value } : value
+  const mapped = IsStandardObject(created) && IsStandardObject(value) ? { ...(created as any), ...value } : value
   return Check(schema, references, mapped) ? mapped : Create(schema, references)
 }
 function FromNever(schema: TNever, references: TSchema[], value: any): any {

--- a/src/value/clone/clone.ts
+++ b/src/value/clone/clone.ts
@@ -31,7 +31,7 @@ import type { ObjectType, ArrayType, TypedArrayType, ValueType } from '../guard/
 // ------------------------------------------------------------------
 // ValueGuard
 // ------------------------------------------------------------------
-import { IsArray, IsDate, IsPlainObject, IsTypedArray, IsValueType } from '../guard/index'
+import { IsArray, IsDate, IsStandardObject, IsTypedArray, IsValueType } from '../guard/index'
 // ------------------------------------------------------------------
 // Clonable
 // ------------------------------------------------------------------
@@ -58,7 +58,7 @@ function ValueType(value: ValueType): any {
 export function Clone<T extends unknown>(value: T): T {
   if (IsArray(value)) return ArrayType(value)
   if (IsDate(value)) return DateType(value)
-  if (IsPlainObject(value)) return ObjectType(value)
+  if (IsStandardObject(value)) return ObjectType(value)
   if (IsTypedArray(value)) return TypedArrayType(value)
   if (IsValueType(value)) return ValueType(value)
   throw new Error('ValueClone: Unable to clone value')

--- a/src/value/delta/delta.ts
+++ b/src/value/delta/delta.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { IsPlainObject, IsArray, IsTypedArray, IsValueType, IsSymbol, IsUndefined } from '../guard/index'
+import { IsStandardObject, IsArray, IsTypedArray, IsValueType, IsSymbol, IsUndefined } from '../guard/index'
 import type { ObjectType, ArrayType, TypedArrayType, ValueType } from '../guard/index'
 import type { Static } from '../../type/static/index'
 import { ValuePointer } from '../pointer/index'
@@ -90,7 +90,7 @@ function CreateDelete(path: string): Edit {
 // Diffing Generators
 // ------------------------------------------------------------------
 function* ObjectType(path: string, current: ObjectType, next: unknown): IterableIterator<Edit> {
-  if (!IsPlainObject(next)) return yield CreateUpdate(path, next)
+  if (!IsStandardObject(next)) return yield CreateUpdate(path, next)
   const currentKeys = [...globalThis.Object.keys(current), ...globalThis.Object.getOwnPropertySymbols(current)]
   const nextKeys = [...globalThis.Object.keys(next), ...globalThis.Object.getOwnPropertySymbols(next)]
   for (const key of currentKeys) {
@@ -136,7 +136,7 @@ function* ValueType(path: string, current: ValueType, next: unknown): IterableIt
   yield CreateUpdate(path, next)
 }
 function* Visit(path: string, current: unknown, next: unknown): IterableIterator<Edit> {
-  if (IsPlainObject(current)) return yield* ObjectType(path, current, next)
+  if (IsStandardObject(current)) return yield* ObjectType(path, current, next)
   if (IsArray(current)) return yield* ArrayType(path, current, next)
   if (IsTypedArray(current)) return yield* TypedArrayType(path, current, next)
   if (IsValueType(current)) return yield* ValueType(path, current, next)

--- a/src/value/equal/equal.ts
+++ b/src/value/equal/equal.ts
@@ -26,14 +26,14 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { IsPlainObject, IsDate, IsArray, IsTypedArray, IsValueType } from '../guard/index'
+import { IsStandardObject, IsDate, IsArray, IsTypedArray, IsValueType } from '../guard/index'
 import type { ObjectType, ArrayType, TypedArrayType, ValueType } from '../guard/index'
 
 // ------------------------------------------------------------------
 // Equality Checks
 // ------------------------------------------------------------------
 function ObjectType(left: ObjectType, right: unknown): boolean {
-  if (!IsPlainObject(right)) return false
+  if (!IsStandardObject(right)) return false
   const leftKeys = [...Object.keys(left), ...Object.getOwnPropertySymbols(left)]
   const rightKeys = [...Object.keys(right), ...Object.getOwnPropertySymbols(right)]
   if (leftKeys.length !== rightKeys.length) return false
@@ -58,7 +58,7 @@ function ValueType(left: ValueType, right: unknown): any {
 // ------------------------------------------------------------------
 /** Returns true if the left value deep-equals the right */
 export function Equal<T>(left: T, right: unknown): right is T {
-  if (IsPlainObject(left)) return ObjectType(left, right)
+  if (IsStandardObject(left)) return ObjectType(left, right)
   if (IsDate(left)) return DateType(left, right)
   if (IsTypedArray(left)) return TypedArrayType(left, right)
   if (IsArray(left)) return ArrayType(left, right)

--- a/src/value/guard/guard.ts
+++ b/src/value/guard/guard.ts
@@ -57,23 +57,86 @@ export function IsIterator(value: unknown): value is IterableIterator<any> {
   return IsObject(value) && Symbol.iterator in value
 }
 // --------------------------------------------------------------------------
-// Nominal
+// Object Instances
 // --------------------------------------------------------------------------
-/** Returns true if this value is a typed array */
-export function IsTypedArray(value: unknown): value is TypedArrayType {
-  return ArrayBuffer.isView(value)
+/** Returns true if this value is not an instance of a class */
+export function IsStandardObject(value: unknown): value is ObjectType {
+  return IsObject(value) && IsFunction(value.constructor) && value.constructor.name === 'Object'
 }
+/** Returns true if this value is an instance of a class */
+export function IsInstanceObject(value: unknown): value is ObjectType {
+  return IsObject(value) && IsFunction(value.constructor) && value.constructor.name !== 'Object'
+}
+// --------------------------------------------------------------------------
+// JavaScript
+// --------------------------------------------------------------------------
 /** Returns true if this value is a Promise */
 export function IsPromise(value: unknown): value is Promise<unknown> {
   return value instanceof Promise
 }
-/** Returns true if the value is a Uint8Array */
-export function IsUint8Array(value: unknown): value is Uint8Array {
-  return value instanceof Uint8Array
-}
 /** Returns true if this value is a Date */
 export function IsDate(value: unknown): value is Date {
   return value instanceof Date && Number.isFinite(value.getTime())
+}
+/** Returns true if this value is an instance of Map<K, T> */
+export function IsMap(value: unknown): value is Map<unknown, unknown> {
+  return value instanceof globalThis.Map
+}
+/** Returns true if this value is an instance of Set<T> */
+export function IsSet(value: unknown): value is Set<unknown> {
+  return value instanceof globalThis.Set
+}
+/** Returns true if this value is RegExp */
+export function IsRegExp(value: unknown): value is RegExp {
+  return value instanceof globalThis.RegExp
+}
+/** Returns true if this value is a typed array */
+export function IsTypedArray(value: unknown): value is TypedArrayType {
+  return ArrayBuffer.isView(value)
+}
+/** Returns true if the value is a Int8Array */
+export function IsInt8Array(value: unknown): value is Int8Array {
+  return value instanceof globalThis.Int8Array
+}
+/** Returns true if the value is a Uint8Array */
+export function IsUint8Array(value: unknown): value is Uint8Array {
+  return value instanceof globalThis.Uint8Array
+}
+/** Returns true if the value is a Uint8ClampedArray */
+export function IsUint8ClampedArray(value: unknown): value is Uint8ClampedArray {
+  return value instanceof globalThis.Uint8ClampedArray
+}
+/** Returns true if the value is a Int16Array */
+export function IsInt16Array(value: unknown): value is Int16Array {
+  return value instanceof globalThis.Int16Array
+}
+/** Returns true if the value is a Uint16Array */
+export function IsUint16Array(value: unknown): value is Uint16Array {
+  return value instanceof globalThis.Uint16Array
+}
+/** Returns true if the value is a Int32Array */
+export function IsInt32Array(value: unknown): value is Int32Array {
+  return value instanceof globalThis.Int32Array
+}
+/** Returns true if the value is a Uint32Array */
+export function IsUint32Array(value: unknown): value is Uint32Array {
+  return value instanceof globalThis.Uint32Array
+}
+/** Returns true if the value is a Float32Array */
+export function IsFloat32Array(value: unknown): value is Float32Array {
+  return value instanceof globalThis.Float32Array
+}
+/** Returns true if the value is a Float64Array */
+export function IsFloat64Array(value: unknown): value is Float64Array {
+  return value instanceof globalThis.Float64Array
+}
+/** Returns true if the value is a BigInt64Array */
+export function IsBigInt64Array(value: unknown): value is BigInt64Array {
+  return value instanceof globalThis.BigInt64Array
+}
+/** Returns true if the value is a BigUint64Array */
+export function IsBigUint64Array(value: unknown): value is BigUint64Array {
+  return value instanceof globalThis.BigUint64Array
 }
 // --------------------------------------------------------------------------
 // Standard
@@ -81,10 +144,6 @@ export function IsDate(value: unknown): value is Date {
 /** Returns true if this value has this property key */
 export function HasPropertyKey<K extends PropertyKey>(value: Record<any, unknown>, key: K): value is ObjectType & Record<K, unknown> {
   return key in value
-}
-/** Returns true if this object is not an instance of any other type */
-export function IsPlainObject(value: unknown): value is ObjectType {
-  return IsObject(value) && IsFunction(value.constructor) && value.constructor.name === 'Object'
 }
 /** Returns true of this value is an object type */
 export function IsObject(value: unknown): value is ObjectType {

--- a/src/value/guard/guard.ts
+++ b/src/value/guard/guard.ts
@@ -61,11 +61,11 @@ export function IsIterator(value: unknown): value is IterableIterator<any> {
 // --------------------------------------------------------------------------
 /** Returns true if this value is not an instance of a class */
 export function IsStandardObject(value: unknown): value is ObjectType {
-  return IsObject(value) && IsFunction(value.constructor) && value.constructor.name === 'Object'
+  return IsObject(value) && !IsArray(value) && IsFunction(value.constructor) && value.constructor.name === 'Object'
 }
 /** Returns true if this value is an instance of a class */
 export function IsInstanceObject(value: unknown): value is ObjectType {
-  return IsObject(value) && IsFunction(value.constructor) && value.constructor.name !== 'Object'
+  return IsObject(value) && !IsArray(value) && IsFunction(value.constructor) && value.constructor.name !== 'Object'
 }
 // --------------------------------------------------------------------------
 // JavaScript

--- a/src/value/hash/hash.ts
+++ b/src/value/hash/hash.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { IsArray, IsBoolean, IsBigInt, IsDate, IsNull, IsNumber, IsPlainObject, IsString, IsSymbol, IsUint8Array, IsUndefined } from '../guard/index'
+import { IsArray, IsBoolean, IsBigInt, IsDate, IsNull, IsNumber, IsStandardObject, IsString, IsSymbol, IsUint8Array, IsUndefined } from '../guard/index'
 import { TypeBoxError } from '../../type/error/index'
 
 // ------------------------------------------------------------------
@@ -140,7 +140,7 @@ function Visit(value: any) {
   if (IsDate(value)) return DateType(value)
   if (IsNull(value)) return NullType(value)
   if (IsNumber(value)) return NumberType(value)
-  if (IsPlainObject(value)) return ObjectType(value)
+  if (IsStandardObject(value)) return ObjectType(value)
   if (IsString(value)) return StringType(value)
   if (IsSymbol(value)) return SymbolType(value)
   if (IsUint8Array(value)) return Uint8ArrayType(value)

--- a/src/value/index.ts
+++ b/src/value/index.ts
@@ -27,55 +27,30 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 // ------------------------------------------------------------------
-// Value Errors (re-export)
+// Errors (re-export)
 // ------------------------------------------------------------------
 export { ValueError, ValueErrorType, ValueErrorIterator } from '../errors/index'
 // ------------------------------------------------------------------
-// Value Operators
+// Guards
 // ------------------------------------------------------------------
-export { Cast, ValueCastError } from './cast/index'
-export { Check } from './check/index'
-export { Clean } from './clean/index'
-export { Clone } from './clone/index'
-export { Convert } from './convert/index'
-export { Create, ValueCreateError } from './create/index'
-export { Default } from './default/index'
-export { Diff, Patch, Edit, Delete, Insert, Update, ValueDeltaError } from './delta/index'
-export { Equal } from './equal/index'
-export { Hash, ValueHashError } from './hash/index'
-export { Mutate, ValueMutateError, type Mutable } from './mutate/index'
-export { ValuePointer } from './pointer/index'
-export { TransformDecode, TransformEncode, HasTransform, TransformDecodeCheckError, TransformDecodeError, TransformEncodeCheckError, TransformEncodeError } from './transform/index'
+export * from './guard/index'
 // ------------------------------------------------------------------
-// Value Guards
+// Operators
 // ------------------------------------------------------------------
-export {
-  ArrayType,
-  HasPropertyKey,
-  IsArray,
-  IsAsyncIterator,
-  IsBigInt,
-  IsBoolean,
-  IsDate,
-  IsFunction,
-  IsInteger,
-  IsIterator,
-  IsNull,
-  IsNumber,
-  IsObject,
-  IsPlainObject,
-  IsPromise,
-  IsString,
-  IsSymbol,
-  IsTypedArray,
-  IsUint8Array,
-  IsUndefined,
-  IsValueType,
-  type ObjectType,
-  type TypedArrayType,
-  type ValueType,
-} from './guard/index'
+export * from './cast/index'
+export * from './check/index'
+export * from './clean/index'
+export * from './clone/index'
+export * from './convert/index'
+export * from './create/index'
+export * from './default/index'
+export * from './delta/index'
+export * from './equal/index'
+export * from './hash/index'
+export * from './mutate/index'
+export * from './pointer/index'
+export * from './transform/index'
 // ------------------------------------------------------------------
-// Value Namespace
+// Namespace
 // ------------------------------------------------------------------
 export { Value } from './value/index'

--- a/src/value/mutate/mutate.ts
+++ b/src/value/mutate/mutate.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { IsPlainObject, IsArray, IsTypedArray, IsValueType, type TypedArrayType } from '../guard/index'
+import { IsStandardObject, IsArray, IsTypedArray, IsValueType, type TypedArrayType } from '../guard/index'
 import { ValuePointer } from '../pointer/index'
 import { Clone } from '../clone/index'
 import { TypeBoxError } from '../../type/error/index'
@@ -44,7 +44,7 @@ export class ValueMutateError extends TypeBoxError {
 // ------------------------------------------------------------------
 export type Mutable = { [key: string]: unknown } | unknown[]
 function ObjectType(root: Mutable, path: string, current: unknown, next: Record<string, unknown>) {
-  if (!IsPlainObject(current)) {
+  if (!IsStandardObject(current)) {
     ValuePointer.Set(root, path, Clone(next))
   } else {
     const currentKeys = Object.keys(current)
@@ -90,7 +90,7 @@ function ValueType(root: Mutable, path: string, current: unknown, next: unknown)
 function Visit(root: Mutable, path: string, current: unknown, next: unknown) {
   if (IsArray(next)) return ArrayType(root, path, current, next)
   if (IsTypedArray(next)) return TypedArrayType(root, path, current, next)
-  if (IsPlainObject(next)) return ObjectType(root, path, current, next)
+  if (IsStandardObject(next)) return ObjectType(root, path, current, next)
   if (IsValueType(next)) return ValueType(root, path, current, next)
 }
 // ------------------------------------------------------------------
@@ -102,8 +102,8 @@ function IsNonMutableValue(value: unknown): value is Mutable {
 function IsMismatchedValue(current: unknown, next: unknown) {
   // prettier-ignore
   return (
-    (IsPlainObject(current) && IsArray(next)) || 
-    (IsArray(current) && IsPlainObject(next))
+    (IsStandardObject(current) && IsArray(next)) || 
+    (IsArray(current) && IsStandardObject(next))
   )
 }
 // ------------------------------------------------------------------

--- a/src/value/transform/decode.ts
+++ b/src/value/transform/decode.ts
@@ -48,7 +48,7 @@ import type { TUnion } from '../../type/union/index'
 // ------------------------------------------------------------------
 // ValueGuard
 // ------------------------------------------------------------------
-import { IsPlainObject, IsArray, IsValueType } from '../guard/index'
+import { IsStandardObject, IsArray, IsValueType } from '../guard/index'
 // ------------------------------------------------------------------
 // TypeGuard
 // ------------------------------------------------------------------
@@ -86,7 +86,7 @@ function FromArray(schema: TArray, references: TSchema[], value: any): any {
 }
 // prettier-ignore
 function FromIntersect(schema: TIntersect, references: TSchema[], value: any) {
-  if (!IsPlainObject(value) || IsValueType(value)) return Default(schema, value)
+  if (!IsStandardObject(value) || IsValueType(value)) return Default(schema, value)
   const knownKeys = KeyOfPropertyKeys(schema) as string[]
   const knownProperties = knownKeys.reduce((value, key) => {
     return (key in value)
@@ -110,7 +110,7 @@ function FromNot(schema: TNot, references: TSchema[], value: any) {
 }
 // prettier-ignore
 function FromObject(schema: TObject, references: TSchema[], value: any) {
-  if (!IsPlainObject(value)) return Default(schema, value)
+  if (!IsStandardObject(value)) return Default(schema, value)
   const knownKeys = KeyOfPropertyKeys(schema)
   const knownProperties = knownKeys.reduce((value, key) => {
     return (key in value) 
@@ -131,7 +131,7 @@ function FromObject(schema: TObject, references: TSchema[], value: any) {
 }
 // prettier-ignore
 function FromRecord(schema: TRecord, references: TSchema[], value: any) {
-  if (!IsPlainObject(value)) return Default(schema, value)
+  if (!IsStandardObject(value)) return Default(schema, value)
   const pattern = Object.getOwnPropertyNames(schema.patternProperties)[0]
   const knownKeys = new RegExp(pattern)
   const knownProperties = Object.getOwnPropertyNames(value).reduce((value, key) => {

--- a/src/value/transform/encode.ts
+++ b/src/value/transform/encode.ts
@@ -48,7 +48,7 @@ import type { TUnion } from '../../type/union/index'
 // ------------------------------------------------------------------
 // ValueGuard
 // ------------------------------------------------------------------
-import { IsPlainObject, IsArray, IsValueType } from '../guard/index'
+import { IsStandardObject, IsArray, IsValueType } from '../guard/index'
 // ------------------------------------------------------------------
 // TypeGuard
 // ------------------------------------------------------------------
@@ -87,7 +87,7 @@ function FromArray(schema: TArray, references: TSchema[], value: any): any {
 // prettier-ignore
 function FromIntersect(schema: TIntersect, references: TSchema[], value: any) {
   const defaulted = Default(schema, value)
-  if (!IsPlainObject(value) || IsValueType(value)) return defaulted
+  if (!IsStandardObject(value) || IsValueType(value)) return defaulted
   const knownKeys = KeyOfPropertyKeys(schema) as string[]
   const knownProperties = knownKeys.reduce((value, key) => {
     return key in defaulted 
@@ -112,7 +112,7 @@ function FromNot(schema: TNot, references: TSchema[], value: any) {
 // prettier-ignore
 function FromObject(schema: TObject, references: TSchema[], value: any) {
   const defaulted = Default(schema, value)
-  if (!IsPlainObject(value)) return defaulted
+  if (!IsStandardObject(value)) return defaulted
   const knownKeys = KeyOfPropertyKeys(schema) as string[]
   const knownProperties = knownKeys.reduce((value, key) => {
     return key in value 
@@ -133,7 +133,7 @@ function FromObject(schema: TObject, references: TSchema[], value: any) {
 // prettier-ignore
 function FromRecord(schema: TRecord, references: TSchema[], value: any) {
   const defaulted = Default(schema, value) as Record<PropertyKey, unknown>
-  if (!IsPlainObject(value)) return defaulted
+  if (!IsStandardObject(value)) return defaulted
   const pattern = Object.getOwnPropertyNames(schema.patternProperties)[0]
   const knownKeys = new RegExp(pattern)
   const knownProperties = Object.getOwnPropertyNames(value).reduce((value, key) => {

--- a/test/runtime/value/guard/guard.ts
+++ b/test/runtime/value/guard/guard.ts
@@ -179,13 +179,21 @@ describe('value/guard/ValueGuard', () => {
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
-  // IsNonInstanceObject
+  // IsStandardObject
   // -----------------------------------------------------
-  it('Should guard NonInstanceObject 1', () => {
+  it('Should guard StandardObject 1', () => {
     const R = ValueGuard.IsStandardObject({})
     Assert.IsTrue(R)
   })
-  it('Should guard NonInstanceObject 2', () => {
+  it('Should guard StandardObject 2', () => {
+    const R = ValueGuard.IsStandardObject(1)
+    Assert.IsFalse(R)
+  })
+  it('Should guard StandardObject 3', () => {
+    const R = ValueGuard.IsStandardObject([])
+    Assert.IsFalse(R)
+  })
+  it('Should guard StandardObject 4', () => {
     const R = ValueGuard.IsStandardObject(new (class {})())
     Assert.IsFalse(R)
   })
@@ -197,6 +205,14 @@ describe('value/guard/ValueGuard', () => {
     Assert.IsFalse(R)
   })
   it('Should guard InstanceObject 2', () => {
+    const R = ValueGuard.IsInstanceObject(1)
+    Assert.IsFalse(R)
+  })
+  it('Should guard InstanceObject 3', () => {
+    const R = ValueGuard.IsInstanceObject([])
+    Assert.IsFalse(R)
+  })
+  it('Should guard InstanceObject 4', () => {
     const R = ValueGuard.IsInstanceObject(new (class {})())
     Assert.IsTrue(R)
   })
@@ -405,6 +421,36 @@ describe('value/guard/ValueGuard', () => {
   })
   it('Should guard BigUint64Array 2', () => {
     const R = ValueGuard.IsBigUint64Array(1)
+    Assert.IsFalse(R)
+  })
+  // -----------------------------------------------------
+  // IsMap
+  // -----------------------------------------------------
+  it('Should guard Map 1', () => {
+    const R = ValueGuard.IsMap(new Map())
+    Assert.IsTrue(R)
+  })
+  it('Should guard Map 2', () => {
+    const R = ValueGuard.IsMap(new Float32Array(1))
+    Assert.IsFalse(R)
+  })
+  it('Should guard Map 2', () => {
+    const R = ValueGuard.IsMap(1)
+    Assert.IsFalse(R)
+  })
+  // -----------------------------------------------------
+  // IsSet
+  // -----------------------------------------------------
+  it('Should guard Set 1', () => {
+    const R = ValueGuard.IsSet(new Set())
+    Assert.IsTrue(R)
+  })
+  it('Should guard Set 2', () => {
+    const R = ValueGuard.IsSet(new Float32Array(1))
+    Assert.IsFalse(R)
+  })
+  it('Should guard Set 2', () => {
+    const R = ValueGuard.IsSet(1)
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------

--- a/test/runtime/value/guard/guard.ts
+++ b/test/runtime/value/guard/guard.ts
@@ -5,118 +5,115 @@ describe('value/guard/ValueGuard', () => {
   // -----------------------------------------------------
   // IsNull
   // -----------------------------------------------------
-  it('Should guard null 1', () => {
+  it('Should guard Null 1', () => {
     const R = ValueGuard.IsNull(null)
     Assert.IsTrue(R)
   })
-  it('Should guard null 2', () => {
+  it('Should guard Null 2', () => {
     const R = ValueGuard.IsNull({})
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
   // IsUndefined
   // -----------------------------------------------------
-  it('Should guard undefined 1', () => {
+  it('Should guard Undefined 1', () => {
     const R = ValueGuard.IsUndefined(undefined)
     Assert.IsTrue(R)
   })
-  it('Should guard undefined 2', () => {
+  it('Should guard Undefined 2', () => {
     const R = ValueGuard.IsUndefined({})
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
   // IsBigInt
   // -----------------------------------------------------
-  it('Should guard bigint 1', () => {
+  it('Should guard BigInt 1', () => {
     const R = ValueGuard.IsBigInt(1n)
     Assert.IsTrue(R)
   })
-  it('Should guard bigint 2', () => {
+  it('Should guard BigInt 2', () => {
     const R = ValueGuard.IsBigInt(1)
     Assert.IsFalse(R)
   })
-  it('Should guard bigint 3', () => {
+  it('Should guard BigInt 3', () => {
     const R = ValueGuard.IsBigInt('123')
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
   // IsNumber
   // -----------------------------------------------------
-  it('Should guard number 1', () => {
+  it('Should guard Number 1', () => {
     const R = ValueGuard.IsNumber(1)
     Assert.IsTrue(R)
   })
-  it('Should guard number 2', () => {
+  it('Should guard Number 2', () => {
     const R = ValueGuard.IsNumber(3.14)
     Assert.IsTrue(R)
   })
-  it('Should guard number 3', () => {
+  it('Should guard Number 3', () => {
     const R = ValueGuard.IsNumber('')
     Assert.IsFalse(R)
   })
-  it('Should guard number 4', () => {
+  it('Should guard Number 4', () => {
     const R = ValueGuard.IsNumber(NaN)
     Assert.IsTrue(R)
   })
   // -----------------------------------------------------
   // IsString
   // -----------------------------------------------------
-  it('Should guard string 1', () => {
+  it('Should guard String 1', () => {
     const R = ValueGuard.IsString('')
     Assert.IsTrue(R)
   })
-  it('Should guard string 2', () => {
+  it('Should guard String 2', () => {
     const R = ValueGuard.IsString(true)
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
   // IsBoolean
   // -----------------------------------------------------
-  it('Should guard boolean 1', () => {
+  it('Should guard Boolean 1', () => {
     const R = ValueGuard.IsBoolean(true)
     Assert.IsTrue(R)
   })
-  it('Should guard boolean 2', () => {
+  it('Should guard Boolean 2', () => {
     const R = ValueGuard.IsBoolean(1)
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
   // IsObject
   // -----------------------------------------------------
-  it('Should guard object 1', () => {
+  it('Should guard Object 1', () => {
     const R = ValueGuard.IsObject({})
     Assert.IsTrue(R)
   })
-  it('Should guard object 2', () => {
+  it('Should guard Object 2', () => {
     const R = ValueGuard.IsObject(1)
     Assert.IsFalse(R)
   })
-  it('Should guard object 3', () => {
+  it('Should guard Object 3', () => {
     const R = ValueGuard.IsObject([])
     Assert.IsTrue(R)
   })
   // -----------------------------------------------------
   // IsArray
   // -----------------------------------------------------
-  it('Should guard array 1', () => {
+  it('Should guard Array 1', () => {
     const R = ValueGuard.IsArray([])
     Assert.IsTrue(R)
   })
-  it('Should guard array 2', () => {
+  it('Should guard Array 2', () => {
     const R = ValueGuard.IsArray({})
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
-  // Specialized (Values Only)
-  // -----------------------------------------------------
-  // -----------------------------------------------------
   // IsAsyncIterator
   // -----------------------------------------------------
-  it('Should guard async iterator 1', () => {
+  it('Should guard AsyncIterator 1', () => {
     const R = ValueGuard.IsAsyncIterator((async function* (): any {})())
     Assert.IsTrue(R)
   })
-  it('Should guard async iterator 2', () => {
+  it('Should guard AsyncIterator 2', () => {
     const R = ValueGuard.IsAsyncIterator((function* (): any {})())
     Assert.IsFalse(R)
   })
@@ -136,116 +133,278 @@ describe('value/guard/ValueGuard', () => {
   // -----------------------------------------------------
   // IsDate
   // -----------------------------------------------------
-  it('Should guard date 1', () => {
+  it('Should guard Date 1', () => {
     const R = ValueGuard.IsDate(new Date())
     Assert.IsTrue(R)
   })
-  it('Should guard date 2', () => {
+  it('Should guard Date 2', () => {
     const R = ValueGuard.IsDate({})
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
   // IsFunction
   // -----------------------------------------------------
-  it('Should guard function 1', () => {
+  it('Should guard Function 1', () => {
     const R = ValueGuard.IsFunction(function () {})
     Assert.IsTrue(R)
   })
-  it('Should guard function 2', () => {
+  it('Should guard Function 2', () => {
     const R = ValueGuard.IsFunction({})
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
   // IsInteger
   // -----------------------------------------------------
-  it('Should guard integer 1', () => {
+  it('Should guard Integer 1', () => {
     const R = ValueGuard.IsInteger(1)
     Assert.IsTrue(R)
   })
-  it('Should guard integer 2', () => {
+  it('Should guard Integer 2', () => {
     const R = ValueGuard.IsInteger(3.14)
     Assert.IsFalse(R)
   })
-  it('Should guard integer 3', () => {
+  it('Should guard Integer 3', () => {
     const R = ValueGuard.IsInteger(NaN)
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
   // IsIterator
   // -----------------------------------------------------
-  it('Should guard iterator 1', () => {
+  it('Should guard Iterator 1', () => {
     const R = ValueGuard.IsIterator((function* () {})())
     Assert.IsTrue(R)
   })
-  it('Should guard iterator 2', () => {
+  it('Should guard Iterator 2', () => {
     const R = ValueGuard.IsIterator({})
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
-  // IsPlainObject
+  // IsNonInstanceObject
   // -----------------------------------------------------
-  it('Should guard plain object 1', () => {
-    const R = ValueGuard.IsPlainObject({})
+  it('Should guard NonInstanceObject 1', () => {
+    const R = ValueGuard.IsStandardObject({})
     Assert.IsTrue(R)
   })
-  it('Should guard plain object 2', () => {
-    const R = ValueGuard.IsPlainObject(new (class {})())
+  it('Should guard NonInstanceObject 2', () => {
+    const R = ValueGuard.IsStandardObject(new (class {})())
     Assert.IsFalse(R)
+  })
+  // -----------------------------------------------------
+  // IsInstanceObject
+  // -----------------------------------------------------
+  it('Should guard InstanceObject 1', () => {
+    const R = ValueGuard.IsInstanceObject({})
+    Assert.IsFalse(R)
+  })
+  it('Should guard InstanceObject 2', () => {
+    const R = ValueGuard.IsInstanceObject(new (class {})())
+    Assert.IsTrue(R)
   })
   // -----------------------------------------------------
   // IsPromise
   // -----------------------------------------------------
-  it('Should guard promise 1', () => {
+  it('Should guard Promise 1', () => {
     const R = ValueGuard.IsPromise(Promise.resolve(1))
     Assert.IsTrue(R)
   })
-  it('Should guard promise 2', () => {
+  it('Should guard Promise 2', () => {
     const R = ValueGuard.IsPromise(new (class {})())
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
   // IsSymbol
   // -----------------------------------------------------
-  it('Should guard symbol 1', () => {
+  it('Should guard Symbol 1', () => {
     const R = ValueGuard.IsSymbol(Symbol(1))
     Assert.IsTrue(R)
   })
-  it('Should guard symbol 2', () => {
+  it('Should guard Symbol 2', () => {
     const R = ValueGuard.IsSymbol(1)
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
   // IsTypedArray
   // -----------------------------------------------------
-  it('Should guard typed array 1', () => {
+  it('Should guard TypedArray 1', () => {
     const R = ValueGuard.IsTypedArray(new Uint8Array(1))
     Assert.IsTrue(R)
   })
-  it('Should guard typed array 2', () => {
+  it('Should guard TypedArray 2', () => {
     const R = ValueGuard.IsTypedArray(new Float32Array(1))
     Assert.IsTrue(R)
   })
-  it('Should guard typed array 3', () => {
+  it('Should guard TypedArray 3', () => {
     const R = ValueGuard.IsTypedArray(new ArrayBuffer(1))
     Assert.IsFalse(R)
   })
-  it('Should guard typed array 4', () => {
+  it('Should guard TypedArray 4', () => {
     const R = ValueGuard.IsTypedArray(1)
+    Assert.IsFalse(R)
+  })
+  // -----------------------------------------------------
+  // IsInt8Array
+  // -----------------------------------------------------
+  it('Should guard Int8Array 1', () => {
+    const R = ValueGuard.IsInt8Array(new Int8Array(1))
+    Assert.IsTrue(R)
+  })
+  it('Should guard Int8Array 2', () => {
+    const R = ValueGuard.IsInt8Array(new Float32Array(1))
+    Assert.IsFalse(R)
+  })
+  it('Should guard Int8Array 2', () => {
+    const R = ValueGuard.IsInt8Array(1)
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------
   // IsUint8Array
   // -----------------------------------------------------
-  it('Should guard uint8array 1', () => {
+  it('Should guard Uint8Array 1', () => {
     const R = ValueGuard.IsUint8Array(new Uint8Array(1))
     Assert.IsTrue(R)
   })
-  it('Should guard uint8array 2', () => {
+  it('Should guard Uint8Array 2', () => {
     const R = ValueGuard.IsUint8Array(new Float32Array(1))
     Assert.IsFalse(R)
   })
-  it('Should guard uint8array 2', () => {
+  it('Should guard Uint8Array 2', () => {
     const R = ValueGuard.IsUint8Array(1)
+    Assert.IsFalse(R)
+  })
+  // -----------------------------------------------------
+  // IsUint8ClampedArray
+  // -----------------------------------------------------
+  it('Should guard Uint8ClampedArray 1', () => {
+    const R = ValueGuard.IsUint8ClampedArray(new Uint8ClampedArray(1))
+    Assert.IsTrue(R)
+  })
+  it('Should guard Uint8ClampedArray 2', () => {
+    const R = ValueGuard.IsUint8ClampedArray(new Float32Array(1))
+    Assert.IsFalse(R)
+  })
+  it('Should guard Uint8ClampedArray 2', () => {
+    const R = ValueGuard.IsUint8ClampedArray(1)
+    Assert.IsFalse(R)
+  })
+
+  // -----------------------------------------------------
+  // IsInt16Array
+  // -----------------------------------------------------
+  it('Should guard Int16Array 1', () => {
+    const R = ValueGuard.IsInt16Array(new Int16Array(1))
+    Assert.IsTrue(R)
+  })
+  it('Should guard Int16Array 2', () => {
+    const R = ValueGuard.IsInt16Array(new Float32Array(1))
+    Assert.IsFalse(R)
+  })
+  it('Should guard Int16Array 2', () => {
+    const R = ValueGuard.IsInt16Array(1)
+    Assert.IsFalse(R)
+  })
+  // -----------------------------------------------------
+  // IsUint16Array
+  // -----------------------------------------------------
+  it('Should guard Uint16Array 1', () => {
+    const R = ValueGuard.IsUint16Array(new Uint16Array(1))
+    Assert.IsTrue(R)
+  })
+  it('Should guard Uint16Array 2', () => {
+    const R = ValueGuard.IsUint16Array(new Float32Array(1))
+    Assert.IsFalse(R)
+  })
+  it('Should guard Uint16Array 2', () => {
+    const R = ValueGuard.IsUint16Array(1)
+    Assert.IsFalse(R)
+  })
+  // -----------------------------------------------------
+  // IsInt32Array
+  // -----------------------------------------------------
+  it('Should guard Int32Array 1', () => {
+    const R = ValueGuard.IsInt32Array(new Int32Array(1))
+    Assert.IsTrue(R)
+  })
+  it('Should guard Int32Array 2', () => {
+    const R = ValueGuard.IsInt32Array(new Float32Array(1))
+    Assert.IsFalse(R)
+  })
+  it('Should guard Int32Array 2', () => {
+    const R = ValueGuard.IsInt32Array(1)
+    Assert.IsFalse(R)
+  })
+  // -----------------------------------------------------
+  // IsUint32Array
+  // -----------------------------------------------------
+  it('Should guard Uint32Array 1', () => {
+    const R = ValueGuard.IsUint32Array(new Uint32Array(1))
+    Assert.IsTrue(R)
+  })
+  it('Should guard Uint32Array 2', () => {
+    const R = ValueGuard.IsUint32Array(new Float32Array(1))
+    Assert.IsFalse(R)
+  })
+  it('Should guard Uint32Array 2', () => {
+    const R = ValueGuard.IsUint32Array(1)
+    Assert.IsFalse(R)
+  })
+  // -----------------------------------------------------
+  // IsFloat32Array
+  // -----------------------------------------------------
+  it('Should guard Float32Array 1', () => {
+    const R = ValueGuard.IsFloat32Array(new Float32Array(1))
+    Assert.IsTrue(R)
+  })
+  it('Should guard Float32Array 2', () => {
+    const R = ValueGuard.IsFloat32Array(new Float64Array(1))
+    Assert.IsFalse(R)
+  })
+  it('Should guard Float32Array 2', () => {
+    const R = ValueGuard.IsFloat32Array(1)
+    Assert.IsFalse(R)
+  })
+  // -----------------------------------------------------
+  // IsFloat64Array
+  // -----------------------------------------------------
+  it('Should guard Float64Array 1', () => {
+    const R = ValueGuard.IsFloat64Array(new Float64Array(1))
+    Assert.IsTrue(R)
+  })
+  it('Should guard Float64Array 2', () => {
+    const R = ValueGuard.IsFloat64Array(new Float32Array(1))
+    Assert.IsFalse(R)
+  })
+  it('Should guard Float64Array 2', () => {
+    const R = ValueGuard.IsFloat64Array(1)
+    Assert.IsFalse(R)
+  })
+  // -----------------------------------------------------
+  // IsBigInt64Array
+  // -----------------------------------------------------
+  it('Should guard BigInt64Array 1', () => {
+    const R = ValueGuard.IsBigInt64Array(new BigInt64Array(1))
+    Assert.IsTrue(R)
+  })
+  it('Should guard BigInt64Array 2', () => {
+    const R = ValueGuard.IsBigInt64Array(new Float32Array(1))
+    Assert.IsFalse(R)
+  })
+  it('Should guard BigInt64Array 2', () => {
+    const R = ValueGuard.IsBigInt64Array(1)
+    Assert.IsFalse(R)
+  })
+  // -----------------------------------------------------
+  // IsBigUint64Array
+  // -----------------------------------------------------
+  it('Should guard BigUint64Array 1', () => {
+    const R = ValueGuard.IsBigUint64Array(new BigUint64Array(1))
+    Assert.IsTrue(R)
+  })
+  it('Should guard BigUint64Array 2', () => {
+    const R = ValueGuard.IsBigUint64Array(new Float32Array(1))
+    Assert.IsFalse(R)
+  })
+  it('Should guard BigUint64Array 2', () => {
+    const R = ValueGuard.IsBigUint64Array(1)
     Assert.IsFalse(R)
   })
   // -----------------------------------------------------


### PR DESCRIPTION
This PR adds additional value guards for all built in Typed Arrays as well as for Map and Set. Additional updates include guard narrowing for instance types (defined as objects that appear to be instanced from class definitions)

Additional updates include simplifying value exports (inline with simplified type exports)