### PR TITLE
fix: rethrow TypeBoxError instead of creating a new one

### DIFF
--- a/src/value/transform/decode.ts
+++ b/src/value/transform/decode.ts
@@ -75,6 +75,7 @@ function Default(schema: TSchema, value: any) {
   try {
     return IsTransform(schema) ? schema[TransformKind].Decode(value) : value
   } catch (error) {
+    if (error instanceof TypeBoxError) throw error
     throw new TransformDecodeError(schema, value, error)
   }
 }

--- a/src/value/transform/encode.ts
+++ b/src/value/transform/encode.ts
@@ -74,6 +74,7 @@ function Default(schema: TSchema, value: any) {
   try {
     return IsTransform(schema) ? schema[TransformKind].Encode(value) : value
   } catch (error) {
+    if (error instanceof TypeBoxError) throw error
     throw new TransformEncodeError(schema, value, error)
   }
 }


### PR DESCRIPTION
Valuable information is lost by creating a TransformEncodeError/TransformDecodeError instead of rethrowing the error when it‘s a TypeBoxError, because that error may be a TransformEncodeCheckError/TransformDecodeCheckError, which have an `error` property that tells the caller which property path is the cause.
