### PR TITLE
fix: avoid Errors call for nested Encode/Decode

### DIFF
--- a/src/value/transform/decode.ts
+++ b/src/value/transform/decode.ts
@@ -63,7 +63,7 @@ export class TransformDecodeCheckError extends TypeBoxError {
   }
 }
 export class TransformDecodeError extends TypeBoxError {
-  constructor(public readonly schema: TSchema, public readonly value: unknown, error: any) {
+  constructor(public readonly schema: TSchema, public readonly value: unknown, error?: any) {
     super(`${error instanceof Error ? error.message : 'Unknown error'}`)
   }
 }

--- a/src/value/transform/encode.ts
+++ b/src/value/transform/encode.ts
@@ -62,7 +62,7 @@ export class TransformEncodeCheckError extends TypeBoxError {
   }
 }
 export class TransformEncodeError extends TypeBoxError {
-  constructor(public readonly schema: TSchema, public readonly value: unknown, error: any) {
+  constructor(public readonly schema: TSchema, public readonly value: unknown, error?: any) {
     super(`${error instanceof Error ? error.message : 'Unknown error'}`)
   }
 }


### PR DESCRIPTION
Use a stack for Encode/Decode to detect when it‘s a nested call. If nested, the `Errors` function is **not** called, since the produced error would only be a fraction of the full JSON path. This change is beneficial for certain `Transform` usage, as described in #780.

Closes #780
