### PR TITLE
fix: check if Union type is optional during Encode

### DIFF
--- a/src/value/transform/encode.ts
+++ b/src/value/transform/encode.ts
@@ -171,6 +171,9 @@ function FromTuple(schema: TTuple, references: TSchema[], value: any) {
 }
 // prettier-ignore
 function FromUnion(schema: TUnion, references: TSchema[], value: any) {
+  if (IsOptional(schema) && value === undefined) {
+    return undefined
+  }
   // test value against union variants
   for (const subschema of schema.anyOf) {
     if (!Check(subschema, references, value)) continue


### PR DESCRIPTION
Since the “optionality” of a Union type is not inherited by its anyOf types, we need to bail out on `undefined` values when the Union is optional.