### PR TITLE
fix: respect Optional in Transform.Encode/Decode

### DIFF
--- a/src/value/transform/decode.ts
+++ b/src/value/transform/decode.ts
@@ -52,7 +52,7 @@ import { IsStandardObject, IsArray, IsValueType } from '../guard/index'
 // ------------------------------------------------------------------
 // TypeGuard
 // ------------------------------------------------------------------
-import { IsTransform, IsSchema } from '../../type/guard/type'
+import { IsTransform, IsSchema, IsOptional } from '../../type/guard/type'
 // ------------------------------------------------------------------
 // Errors
 // ------------------------------------------------------------------
@@ -73,7 +73,13 @@ export class TransformDecodeError extends TypeBoxError {
 // prettier-ignore
 function Default(schema: TSchema, value: any) {
   try {
-    return IsTransform(schema) ? schema[TransformKind].Decode(value) : value
+    if (IsTransform(schema)) {
+      if (IsOptional(schema) && value === undefined) {
+        return undefined
+      }
+      return schema[TransformKind].Decode(value)
+    }
+    return value
   } catch (error) {
     throw new TransformDecodeError(schema, value, error)
   }

--- a/src/value/transform/encode.ts
+++ b/src/value/transform/encode.ts
@@ -52,7 +52,7 @@ import { IsStandardObject, IsArray, IsValueType } from '../guard/index'
 // ------------------------------------------------------------------
 // TypeGuard
 // ------------------------------------------------------------------
-import { IsTransform, IsSchema } from '../../type/guard/type'
+import { IsTransform, IsSchema, IsOptional } from '../../type/guard/type'
 // ------------------------------------------------------------------
 // Errors
 // ------------------------------------------------------------------
@@ -72,7 +72,13 @@ export class TransformEncodeError extends TypeBoxError {
 // prettier-ignore
 function Default(schema: TSchema, value: any) {
   try {
-    return IsTransform(schema) ? schema[TransformKind].Encode(value) : value
+    if (IsTransform(schema)) {
+      if (IsOptional(schema) && value === undefined) {
+        return undefined
+      }
+      return schema[TransformKind].Encode(value)
+    }
+    return value
   } catch (error) {
     throw new TransformEncodeError(schema, value, error)
   }


### PR DESCRIPTION
When a Transform is optional and the value is undefined, let‘s avoid calling the Encode/Decode callbacks at all so they don‘t have to be responsible for how undefined values are handled (well, when Optional is used at least).
