### PR TITLE
Revision 0.32.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.16",
+  "version": "0.32.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.16",
+      "version": "0.32.17",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.16",
+  "version": "0.32.17",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/type/static/static.ts
+++ b/src/type/static/static.ts
@@ -85,8 +85,9 @@ export type TDecodeType<T extends TSchema> = (
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
+export type StaticDecodeIsAny<T> = boolean extends (T extends TSchema ? true : false) ? true : false
 /** Creates an decoded static type from a TypeBox type */
-export type StaticDecode<T extends TSchema, P extends unknown[] = []> = Static<TDecodeType<T>, P>
+export type StaticDecode<T extends TSchema, P extends unknown[] = []> = StaticDecodeIsAny<T> extends true ? unknown : Static<TDecodeType<T>, P>
 /** Creates an encoded static type from a TypeBox type */
 export type StaticEncode<T extends TSchema, P extends unknown[] = []> = Static<T, P>
 /** Creates a static type from a TypeBox type */

--- a/test/static/transform.ts
+++ b/test/static/transform.ts
@@ -1,4 +1,7 @@
 import { Type, TSchema, Static, StaticDecode, TObject, TNumber } from '@sinclair/typebox'
+import { TypeCheck } from '@sinclair/typebox/compiler'
+import { Value } from '@sinclair/typebox/value'
+
 import { Expect } from './assert'
 {
   // string > number
@@ -308,4 +311,12 @@ import { Expect } from './assert'
   const T = Type.Constructor([S], S)
   Expect(T).ToStaticDecode<new (x: Date) => Date>()
   Expect(T).ToStaticEncode<new (x: number) => number>()
+}
+// -------------------------------------------------------------
+// https://github.com/sinclairzx81/typebox/issues/798
+// -------------------------------------------------------------
+{
+  const c1: TypeCheck<any> = {} as any
+  const x1 = c1.Decode({})
+  const x2 = Value.Decode({} as any, {})
 }


### PR DESCRIPTION
This PR adds a `any` type detection path for `StaticDecode`. 

It is noted that even though the `StaticDecode` type is constrained to generic parameters of type `TSchema`; passing `any` for a parameter is still permissible as `any` does loosely satisfy this constraint. However in the context of StaticDecode, passing `any` does result in TS2589 instantiation issues due this type producing union results when used as a left-side operand (classic example below)

```typescript
type T = any extends string ? 1 : 2 // T = 1 | 2
```
This PR attempts to catch `any` for StaticDecode specifically, principally because this type makes heavy use of conditional mapping, and where union results for `any` cause ambiguous resolution of the decode static type.