### PR TITLE
Revision 0.32.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.18",
+  "version": "0.32.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.18",
+      "version": "0.32.19",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.18",
+  "version": "0.32.19",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/convert/convert.ts
+++ b/src/value/convert/convert.ts
@@ -240,7 +240,12 @@ function FromUndefined(schema: TUndefined, references: TSchema[], value: any): u
   return TryConvertUndefined(value)
 }
 function FromUnion(schema: TUnion, references: TSchema[], value: any): unknown {
-  return schema.anyOf.reduce((value, schema) => Visit(schema, references, value), value)
+  for (const subschema of schema.anyOf) {
+    const converted = Visit(subschema, references, value)
+    if (!Check(subschema, references, converted)) continue
+    return converted
+  }
+  return value
 }
 function Visit(schema: TSchema, references: TSchema[], value: any): unknown {
   const references_ = IsString(schema.$id) ? [...references, schema] : references

--- a/test/runtime/value/convert/union.ts
+++ b/test/runtime/value/convert/union.ts
@@ -14,12 +14,12 @@ describe('value/convert/Union', () => {
     Assert.IsEqual(V2, { x: null })
     Assert.IsEqual(V3, { x: 'hello' })
   })
-  it('Should convert last variant in ambiguous conversion', () => {
+  it('Should convert first variant in ambiguous conversion', () => {
     const T = Type.Object({
       x: Type.Union([Type.Boolean(), Type.Number()]),
     })
     const V1 = Value.Convert(T, { x: '1' })
-    Assert.IsEqual(V1, { x: 1 })
+    Assert.IsEqual(V1, { x: true })
   })
   // ----------------------------------------------------------------
   // https://github.com/sinclairzx81/typebox/issues/787
@@ -38,6 +38,6 @@ describe('value/convert/Union', () => {
     const C = Convert(T, { a: '1', b: '2', c: '3' })
     Assert.IsEqual(A, { a: 1, c: 2 })
     Assert.IsEqual(B, { b: 1, c: 2 })
-    Assert.IsEqual(C, { a: 1, b: 2, c: 3 })
+    Assert.IsEqual(C, { a: 1, b: '2', c: 3 }) // note: matching on first
   })
 })


### PR DESCRIPTION
This PR reverts the Union conversion logic applied on Revision 0.32.16 which matched on the "first" union variant (where 0.32.16 matched on the last). The PR retains the Intersect conversion logic in support of distributive type conversions when mixing union and intersection together.