### PR TITLE
Revision 0.32.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ajv-formats": "^2.1.1",
         "mocha": "^9.2.2",
         "prettier": "^2.7.1",
-        "typescript": "^5.4.2"
+        "typescript": "^5.4.3"
       }
     },
     "node_modules/@andrewbranch/untar.js": {
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2874,9 +2874,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "dev": true
     },
     "undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.19",
+  "version": "0.32.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.19",
+      "version": "0.32.20",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.19",
+  "version": "0.32.20",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "ajv-formats": "^2.1.1",
     "mocha": "^9.2.2",
     "prettier": "^2.7.1",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.3"
   }
 }

--- a/src/value/delta/delta.ts
+++ b/src/value/delta/delta.ts
@@ -33,34 +33,55 @@ import { ValuePointer } from '../pointer/index'
 import { Clone } from '../clone/index'
 import { TypeBoxError } from '../../type/error/index'
 
-import { Literal as CreateLiteral } from '../../type/literal/index'
-import { Object as CreateObject } from '../../type/object/index'
-import { String as CreateString } from '../../type/string/index'
-import { Unknown as CreateUnknown } from '../../type/unknown/index'
-import { Union as CreateUnion } from '../../type/union/index'
+import { Literal, type TLiteral } from '../../type/literal/index'
+import { Object, type TObject } from '../../type/object/index'
+import { String, type TString } from '../../type/string/index'
+import { Unknown, type TUnknown } from '../../type/unknown/index'
+import { Union, type TUnion } from '../../type/union/index'
 
 // ------------------------------------------------------------------
 // Commands
 // ------------------------------------------------------------------
+
+// Note: A TypeScript 5.4.2 compiler regression resulted in the type
+// import paths being generated incorrectly. We can resolve this by
+// explicitly importing the correct TSchema types above. Note also
+// that the left-side annotations are optional, but since the types
+// are imported we might as well use them. We should check this
+// regression in future. The regression occured between TypeScript
+// versions 5.3.3 -> 5.4.2.
+
 export type Insert = Static<typeof Insert>
-export const Insert = CreateObject({
-  type: CreateLiteral('insert'),
-  path: CreateString(),
-  value: CreateUnknown(),
+export const Insert: TObject<{
+  type: TLiteral<'insert'>
+  path: TString
+  value: TUnknown
+}> = Object({
+  type: Literal('insert'),
+  path: String(),
+  value: Unknown(),
 })
 export type Update = Static<typeof Update>
-export const Update = CreateObject({
-  type: CreateLiteral('update'),
-  path: CreateString(),
-  value: CreateUnknown(),
+export const Update: TObject<{
+  type: TLiteral<'update'>
+  path: TString
+  value: TUnknown
+}> = Object({
+  type: Literal('update'),
+  path: String(),
+  value: Unknown(),
 })
 export type Delete = Static<typeof Delete>
-export const Delete = CreateObject({
-  type: CreateLiteral('delete'),
-  path: CreateString(),
+export const Delete: TObject<{
+  type: TLiteral<'delete'>
+  path: TString
+}> = Object({
+  type: Literal('delete'),
+  path: String(),
 })
 export type Edit = Static<typeof Edit>
-export const Edit = CreateUnion([Insert, Update, Delete])
+export const Edit: TUnion<[typeof Insert, typeof Update, typeof Delete]> = Union([Insert, Update, Delete])
+
 // ------------------------------------------------------------------
 // Errors
 // ------------------------------------------------------------------


### PR DESCRIPTION
This PR resolves a TypeScript compiler regression that occurred in between TS 5.3.3 -> 5.4.2. The issue seems isolated to the `value/delta/...` modules where the inferred TSchema types were emitting with basePath relative `src/...` paths, and not the relative module path. 

```typescript
// TS 5.3.3 - correct
export type Update = Static<typeof Update>;
export declare const Update: import("../../type/object/object.mjs").TObject<{
    type: import("../../type/literal/literal.mjs").TLiteral<"update">;
    path: import("../../type/string/string.mjs").TString;
    value: import("../../type/unknown/unknown.mjs").TUnknown;
}>;

// TS 5.4.2 - incorrect
export type Update = Static<typeof Update>;
export declare const Update: import("src/type/object/object.mjs").TObject<{
    type: import("src/type/literal/literal.mjs").TLiteral<"update">;
    path: import("src/type/string/string.mjs").TString;
    value: import("src/type/unknown/unknown.mjs").TUnknown;
}>;
```
This PR resolves the problem by explicitly importing the types using the correct path. Comments have been left to review the compiler behavior in subsequent revisions. It may also be worth introducing post build type assertions on top of the ESM module asserts (for consideration), but would prefer to trust compiler emit.

Fixes https://github.com/sinclairzx81/typebox/issues/808