### PR TITLE
Update string.ts

### DIFF
--- a/src/type/string/string.ts
+++ b/src/type/string/string.ts
@@ -66,7 +66,7 @@ export interface StringOptions extends SchemaOptions {
   /** The minimum string length */
   minLength?: number
   /** A regular expression pattern this string should match */
-  pattern?: string
+  pattern?: RegExp
   /** A format this string should match */
   format?: StringFormatOption
   /** The content encoding for this string */


### PR DESCRIPTION
Migrate to regexp or string type
In case it is a string - the developer should add additional escape characters and also can not pass regexp flags

```
const regex = /^\w(?:[\w-]{0,61}\w)?$/igm;
const regex = new RegExp('^\\w(?:[\\w-]{0,61}\\w)?$', 'igm')

```
![image](https://github.com/sinclairzx81/typebox/assets/468006/ed27014a-56ef-4b77-ad13-cbaa0b11d0b7)

But if we change this to RegeXp instead of string - tools will act as it should
![image](https://github.com/sinclairzx81/typebox/assets/468006/da1e2be1-2f51-4b3f-8575-0926f414ffbb)
