### PR TITLE
Revision 0.32.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.20",
+  "version": "0.32.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.20",
+      "version": "0.32.21",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.20",
+  "version": "0.32.21",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/type/composite/composite.ts
+++ b/src/type/composite/composite.ts
@@ -45,14 +45,14 @@ import { IsNever } from '../guard/type'
 // prettier-ignore
 type TCompositeKeys<T extends TSchema[], Acc extends PropertyKey[] = []> = (
   T extends [infer L extends TSchema, ...infer R extends TSchema[]]
-    ? TCompositeKeys<R, TSetDistinct<[...Acc, ...TKeyOfPropertyKeys<L>]>>
-    : Acc
+    ? TCompositeKeys<R, [...Acc, ...TKeyOfPropertyKeys<L>]>
+    : TSetDistinct<Acc>
 )
 // prettier-ignore
 function CompositeKeys<T extends TSchema[]>(T: [...T]): TCompositeKeys<T> {
-  return T.reduce((Acc, L) => {
-    return SetDistinct([...Acc, ...KeyOfPropertyKeys(L)]) as never
-  }, []) as never
+  return SetDistinct(T.reduce((Acc, L) => {
+    return ([...Acc, ...KeyOfPropertyKeys(L)]) as never
+  }, [])) as never
 }
 // ------------------------------------------------------------------
 // FilterNever
@@ -61,7 +61,7 @@ function CompositeKeys<T extends TSchema[]>(T: [...T]): TCompositeKeys<T> {
 type TFilterNever<T extends TSchema[], Acc extends TSchema[] = []> = (
   T extends [infer L extends TSchema, ...infer R extends TSchema[]]
     ? L extends TNever 
-      ? Acc 
+      ? TFilterNever<R, [...Acc]> 
       : TFilterNever<R, [...Acc, L]>
     : Acc
 )
@@ -75,14 +75,14 @@ function FilterNever<T extends TSchema[]>(T: [...T]): TFilterNever<T> {
 // prettier-ignore
 type TCompositeProperty<T extends TSchema[], K extends PropertyKey, Acc extends TSchema[] = []> = (
   T extends [infer L extends TSchema, ...infer R extends TSchema[]]
-   ? TCompositeProperty<R, K, TFilterNever<[...Acc, ...TIndexFromPropertyKeys<L, [K]>]>>
-   : Acc
+   ? TCompositeProperty<R, K, [...Acc, ...TIndexFromPropertyKeys<L, [K]>]>
+   : TFilterNever<Acc>
 )
 // prettier-ignore
 function CompositeProperty<T extends TSchema[], K extends PropertyKey>(T: [...T], K: K): TCompositeProperty<T, K> {
-  return T.reduce((Acc, L) => {
-    return FilterNever([...Acc, ...IndexFromPropertyKeys(L, [K])])
-  }, []) as never
+  return FilterNever(T.reduce((Acc, L) => {
+    return [...Acc, ...IndexFromPropertyKeys(L, [K])] as never
+  }, [])) as never
 }
 // ------------------------------------------------------------------
 // CompositeProperties

--- a/src/value/convert/convert.ts
+++ b/src/value/convert/convert.ts
@@ -29,10 +29,7 @@ THE SOFTWARE.
 import { Clone } from '../clone/index'
 import { Check } from '../check/index'
 import { Deref } from '../deref/index'
-
-import { IsObject as IsObjectType } from '../../type/guard/type'
 import { Kind } from '../../type/symbols/index'
-import { Composite } from '../../type/composite/index'
 
 import type { TSchema } from '../../type/schema/index'
 import type { TArray } from '../../type/array/index'
@@ -166,10 +163,8 @@ function Default(value: any) {
 // Convert
 // ------------------------------------------------------------------
 function FromArray(schema: TArray, references: TSchema[], value: any): any {
-  if (IsArray(value)) {
-    return value.map((value) => Visit(schema.items, references, value))
-  }
-  return value
+  const elements = IsArray(value) ? value : [value]
+  return elements.map((element) => Visit(schema.items, references, element))
 }
 function FromBigInt(schema: TBigInt, references: TSchema[], value: any): unknown {
   return TryConvertBigInt(value)

--- a/test/runtime/value/convert/array.ts
+++ b/test/runtime/value/convert/array.ts
@@ -29,4 +29,28 @@ describe('value/convert/Array', () => {
     Assert.IsEqual(R[5].getTime(), 0)
     Assert.IsEqual(R[6], 'hello')
   })
+  // ----------------------------------------------------------------
+  // Array Coercion
+  // ----------------------------------------------------------------
+  it('Should convert into array (convert interior)', () => {
+    const T = Type.Array(Type.Number())
+    const R = Value.Convert(T, '1')
+    Assert.IsEqual(R, [1])
+  })
+  it('Should convert into array (retain interior)', () => {
+    const T = Type.Array(Type.Number())
+    const R = Value.Convert(T, 'A')
+    Assert.IsEqual(R, ['A'])
+  })
+  it('Should convert into array (object)', () => {
+    const T = Type.Array(
+      Type.Object({
+        x: Type.Number(),
+        y: Type.Number(),
+        z: Type.Number(),
+      }),
+    )
+    const R = Value.Convert(T, { x: '1', y: true, z: null })
+    Assert.IsEqual(R, [{ x: 1, y: 1, z: null }])
+  })
 })


### PR DESCRIPTION
This PR implements Array coercion via the Convert function. It also implements a small type fix for Composite to ensure TNever is appropriately filtered. This PR also implements a minor static and runtime optimization for Distinct keys and Never filtering on Composite.

