### PR TITLE
Revision 0.32.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.21",
+  "version": "0.32.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.21",
+      "version": "0.32.22",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.21",
+  "version": "0.32.22",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/type/constructor/constructor.ts
+++ b/src/type/constructor/constructor.ts
@@ -29,28 +29,37 @@ THE SOFTWARE.
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Static } from '../static/index'
 import type { Ensure } from '../helpers/index'
+import type { TReadonlyOptional } from '../readonly-optional/index'
+import type { TReadonly } from '../readonly/index'
+import type { TOptional } from '../optional/index'
 import { CloneType, CloneRest } from '../clone/type'
 import { Kind } from '../symbols/index'
 
 // ------------------------------------------------------------------
-// TConstructorStatic
+// StaticFunction
 // ------------------------------------------------------------------
-type ConstructorStaticReturnType<T extends TSchema, P extends unknown[]> = Static<T, P>
+type StaticReturnType<U extends TSchema, P extends unknown[]> = Static<U, P>
 // prettier-ignore
-type ConstructorStaticParameters<T extends TSchema[], P extends unknown[], Acc extends unknown[] = []> = 
+type StaticParameter<T extends TSchema, P extends unknown[]> =
+  T extends TReadonlyOptional<T> ? [Readonly<Static<T, P>>?] :
+  T extends TReadonly<T> ? [Readonly<Static<T, P>>] :
+  T extends TOptional<T> ? [Static<T, P>?] :
+  [Static<T, P>]
+// prettier-ignore
+type StaticParameters<T extends TSchema[], P extends unknown[], Acc extends unknown[] = []> = (
   T extends [infer L extends TSchema, ...infer R extends TSchema[]]
-    ? ConstructorStaticParameters<R, P, [...Acc, Static<L, P>]>
+    ? StaticParameters<R, P, [...Acc, ...StaticParameter<L, P>]>
     : Acc
-// prettier-ignore
-type ConstructorStatic<T extends TSchema[], U extends TSchema, P extends unknown[]> = (
-  Ensure<new (...param: ConstructorStaticParameters<T, P>) => ConstructorStaticReturnType<U, P>>
 )
+// prettier-ignore
+type StaticConstructor<T extends TSchema[], U extends TSchema, P extends unknown[]> =
+  Ensure<new (...params: StaticParameters<T, P>) => StaticReturnType<U, P>>
 // ------------------------------------------------------------------
 // TConstructor
 // ------------------------------------------------------------------
 export interface TConstructor<T extends TSchema[] = TSchema[], U extends TSchema = TSchema> extends TSchema {
   [Kind]: 'Constructor'
-  static: ConstructorStatic<T, U, this['params']>
+  static: StaticConstructor<T, U, this['params']>
   type: 'Constructor'
   parameters: T
   returns: U

--- a/src/type/constructor/constructor.ts
+++ b/src/type/constructor/constructor.ts
@@ -36,7 +36,7 @@ import { CloneType, CloneRest } from '../clone/type'
 import { Kind } from '../symbols/index'
 
 // ------------------------------------------------------------------
-// StaticFunction
+// StaticConstructor
 // ------------------------------------------------------------------
 type StaticReturnType<U extends TSchema, P extends unknown[]> = Static<U, P>
 // prettier-ignore

--- a/test/static/constructor.ts
+++ b/test/static/constructor.ts
@@ -14,6 +14,26 @@ import { Type } from '@sinclair/typebox'
   Expect(T).ToStatic<new (param_0: number, param_1: string) => { method: new (param_0: number, param_1: string) => boolean }>()
 }
 {
+  // readonly-optional
+  const T = Type.Constructor([Type.ReadonlyOptional(Type.Array(Type.Number()))], Type.Number())
+  Expect(T).ToStaticDecode<new (param_0?: readonly number[]) => number>()
+}
+{
+  // readonly
+  const T = Type.Constructor([Type.Readonly(Type.Array(Type.Number()))], Type.Number())
+  Expect(T).ToStaticDecode<new (param_0: readonly number[]) => number>()
+}
+{
+  // optional 1
+  const T = Type.Constructor([Type.Optional(Type.Number())], Type.Number())
+  Expect(T).ToStaticDecode<new (param_0?: number) => number>()
+}
+{
+  // optional 2
+  const T = Type.Constructor([Type.Number(), Type.Optional(Type.Number())], Type.Number())
+  Expect(T).ToStaticDecode<new (param_0: number, param_1?: number) => number>()
+}
+{
   // decode 2
   const S = Type.Transform(Type.Integer())
     .Decode((value) => new Date(value))

--- a/test/static/function.ts
+++ b/test/static/function.ts
@@ -15,6 +15,28 @@ import { Type } from '@sinclair/typebox'
   Expect(T).ToStatic<(param_0: number, param_1: string) => { method: (param_0: number, param_1: string) => boolean }>()
 }
 {
+  // readonly-optional
+  const T = Type.Function([Type.ReadonlyOptional(Type.Array(Type.Number()))], Type.Number())
+  Expect(T).ToStaticDecode<(param_0?: readonly number[]) => number>()
+}
+{
+  // readonly
+  const T = Type.Function([Type.Readonly(Type.Array(Type.Number()))], Type.Number())
+  Expect(T).ToStaticDecode<(param_0: readonly number[]) => number>()
+}
+{
+  // optional 1
+  const T = Type.Function([Type.Optional(Type.Number())], Type.Number())
+  Expect(T).ToStaticDecode<(param_0?: number) => number>()
+}
+{
+  // optional 2
+  const T = Type.Function([Type.Number(), Type.Optional(Type.Number())], Type.Number())
+  Expect(T).ToStaticDecode<(param_0: number, param_1?: number) => number>()
+}
+const F = Type.Constructor([Type.Readonly(Type.Array(Type.String()))], Type.Number())
+
+{
   // decode 2
   const S = Type.Transform(Type.Integer())
     .Decode((value) => new Date(value))


### PR DESCRIPTION
This PR adds support for optional and readonly Function and Constructor arguments. This PR only updates inference for these types.

```typescript
const T = Type.Function([
  Type.Number(),
  Type.Optional(Type.Number())
], Type.Number())

type T = Static<typeof T>

// type T = (param_0: number, param_1?: number) => number

```

