### PR TITLE
Revision 0.32.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.22",
+  "version": "0.32.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.22",
+      "version": "0.32.23",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.22",
+  "version": "0.32.23",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/type/constructor/constructor.ts
+++ b/src/type/constructor/constructor.ts
@@ -53,7 +53,7 @@ type StaticParameters<T extends TSchema[], P extends unknown[], Acc extends unkn
 )
 // prettier-ignore
 type StaticConstructor<T extends TSchema[], U extends TSchema, P extends unknown[]> =
-  Ensure<new (...params: StaticParameters<T, P>) => StaticReturnType<U, P>>
+  Ensure<new (...param: StaticParameters<T, P>) => StaticReturnType<U, P>>
 // ------------------------------------------------------------------
 // TConstructor
 // ------------------------------------------------------------------

--- a/src/type/function/function.ts
+++ b/src/type/function/function.ts
@@ -53,7 +53,7 @@ type StaticParameters<T extends TSchema[], P extends unknown[], Acc extends unkn
 )
 // prettier-ignore
 type StaticFunction<T extends TSchema[], U extends TSchema, P extends unknown[]> =
-  Ensure<(...params: StaticParameters<T, P>) => StaticReturnType<U, P>>
+  Ensure<(...param: StaticParameters<T, P>) => StaticReturnType<U, P>>
 
 // ------------------------------------------------------------------
 // TFunction

--- a/src/value/clean/clean.ts
+++ b/src/value/clean/clean.ts
@@ -141,7 +141,7 @@ function FromTuple(schema: TTuple, references: TSchema[], value: unknown): any {
 }
 function FromUnion(schema: TUnion, references: TSchema[], value: unknown): any {
   for (const inner of schema.anyOf) {
-    if (IsCheckable(inner) && Check(inner, value)) {
+    if (IsCheckable(inner) && Check(inner, references, value)) {
       return Visit(inner, references, value)
     }
   }

--- a/test/runtime/value/clean/union.ts
+++ b/test/runtime/value/clean/union.ts
@@ -131,4 +131,25 @@ describe('value/clean/Union', () => {
     const R = Value.Clean(T, { u: null, y: 1 })
     Assert.IsEqual(R, { u: null, y: 1 })
   })
+  // ----------------------------------------------------------------
+  // Union Recursive
+  //
+  // https://github.com/sinclairzx81/typebox/issues/845
+  // ----------------------------------------------------------------
+  it('Should clean recursive with union', () => {
+    const T = Type.Recursive((This) => Type.Object({
+      id: Type.Number(),
+      parent: Type.Union([This, Type.Null()]),
+    }))
+    const R = Value.Clean(T,  {
+      id: 1,
+      unknown: 1,
+      parent: {
+        id: 2,
+        unknown: 1,
+        parent: null
+      },
+    })
+    Assert.IsEqual(R, { id: 1, parent: { id: 2, parent: null } })
+  })
 })

--- a/test/runtime/value/clean/union.ts
+++ b/test/runtime/value/clean/union.ts
@@ -137,17 +137,19 @@ describe('value/clean/Union', () => {
   // https://github.com/sinclairzx81/typebox/issues/845
   // ----------------------------------------------------------------
   it('Should clean recursive with union', () => {
-    const T = Type.Recursive((This) => Type.Object({
-      id: Type.Number(),
-      parent: Type.Union([This, Type.Null()]),
-    }))
-    const R = Value.Clean(T,  {
+    const T = Type.Recursive((This) =>
+      Type.Object({
+        id: Type.Number(),
+        parent: Type.Union([This, Type.Null()]),
+      }),
+    )
+    const R = Value.Clean(T, {
       id: 1,
       unknown: 1,
       parent: {
         id: 2,
         unknown: 1,
-        parent: null
+        parent: null,
       },
     })
     Assert.IsEqual(R, { id: 1, parent: { id: 2, parent: null } })


### PR DESCRIPTION
This PR applies a fix to Union Clean logic where gathered type references were not passed to Check. This issue occurred when attempting to clean Referenced or Recursive schematics. This PR also applies a small rename to inferred Function and Constructor arguments. 