### PR TITLE
Revision 0.32.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.23",
+  "version": "0.32.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.23",
+      "version": "0.32.24",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.23",
+  "version": "0.32.24",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/convert/convert.ts
+++ b/src/value/convert/convert.ts
@@ -54,7 +54,7 @@ import type { TUndefined } from '../../type/undefined/index'
 // ------------------------------------------------------------------
 // ValueGuard
 // ------------------------------------------------------------------
-import { IsArray, IsObject, IsDate, IsUndefined, IsString, IsNumber, IsBoolean, IsBigInt, IsSymbol } from '../guard/index'
+import { IsArray, IsObject, IsDate, IsUndefined, IsString, IsNumber, IsBoolean, IsBigInt, IsSymbol, HasPropertyKey } from '../guard/index'
 // ------------------------------------------------------------------
 // Conversions
 // ------------------------------------------------------------------
@@ -194,11 +194,13 @@ function FromNumber(schema: TNumber, references: TSchema[], value: any): unknown
 function FromObject(schema: TObject, references: TSchema[], value: any): unknown {
   const isConvertable = IsObject(value)
   if(!isConvertable) return value
-  return Object.getOwnPropertyNames(schema.properties).reduce((value, key) => {
-    return !IsUndefined(value[key])
-      ? ({ ...value, [key]: Visit(schema.properties[key], references, value[key]) })
-      : ({ ...value })
-  }, value) 
+  const result: Record<PropertyKey, unknown> = {}
+  for(const key of Object.keys(value)) {
+    result[key] = HasPropertyKey(schema.properties, key)
+      ? Visit(schema.properties[key], references, value[key])
+      : value[key]
+  }
+  return result
 }
 function FromRecord(schema: TRecord, references: TSchema[], value: any): unknown {
   const propertyKey = Object.getOwnPropertyNames(schema.patternProperties)[0]

--- a/src/value/value/value.ts
+++ b/src/value/value/value.ts
@@ -75,11 +75,11 @@ export function Clean(schema: TSchema, value: unknown): unknown
 export function Clean(...args: any[]) {
   return CleanValue.apply(CleanValue, args as any)
 }
-/** Converts any type mismatched values to their target type if a reasonable conversion is possible */
+/** Converts any type mismatched values to their target type if a reasonable conversion is possible. */
 export function Convert(schema: TSchema, references: TSchema[], value: unknown): unknown
-/** Converts any type mismatched values to their target type if a reasonable conversion is possibl. */
+/** Converts any type mismatched values to their target type if a reasonable conversion is possible. */
 export function Convert(schema: TSchema, value: unknown): unknown
-/** Converts any type mismatched values to their target type if a reasonable conversion is possible */
+/** Converts any type mismatched values to their target type if a reasonable conversion is possible. */
 export function Convert(...args: any[]) {
   return ConvertValue.apply(ConvertValue, args as any)
 }

--- a/test/runtime/value/convert/object.ts
+++ b/test/runtime/value/convert/object.ts
@@ -2,13 +2,21 @@ import { Value } from '@sinclair/typebox/value'
 import { Type } from '@sinclair/typebox'
 import { Assert } from '../../assert/index'
 
+// prettier-ignore
 describe('value/convert/Object', () => {
   it('Should convert properties', () => {
-    // prettier-ignore
     const T = Type.Object({
       x: Type.Number(),
       y: Type.Boolean(),
       z: Type.Boolean()
+    })
+    const R = Value.Convert(T, { x: '42', y: 'true', z: 'hello' })
+    Assert.IsEqual(R, { x: 42, y: true, z: 'hello' })
+  })
+  it('Should convert known properties', () => {
+    const T = Type.Object({
+      x: Type.Number(),
+      y: Type.Boolean()
     })
     const R = Value.Convert(T, { x: '42', y: 'true', z: 'hello' })
     Assert.IsEqual(R, { x: 42, y: true, z: 'hello' })


### PR DESCRIPTION
This PR implements a small optimization on Value.Convert. It changes the Object property conversion to avoid reducing on properties, instead opting to populate in empty object (avoiding recurrent object initialization)

In future, additional optimizations may be possible by changing Convert from a immutable function to mutable (will need to be on the next minor revision as this would technically a breaking change)