### PR TITLE
Revision 0.32.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.28",
+  "version": "0.32.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.28",
+      "version": "0.32.29",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.28",
+  "version": "0.32.29",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/type/keyof/keyof-property-entries.ts
+++ b/src/type/keyof/keyof-property-entries.ts
@@ -26,7 +26,17 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-export * from './keyof-from-mapped-result'
-export * from './keyof-property-entries'
-export * from './keyof-property-keys'
-export * from './keyof'
+import { IndexFromPropertyKeys } from '../indexed/indexed'
+import { KeyOfPropertyKeys } from './keyof-property-keys'
+import { TSchema } from '../schema/index'
+
+/**
+ * `[Utility]` Resolves an array of keys and schemas from the given schema. This method is faster
+ * than obtaining the keys and resolving each individually via indexing. This method was written
+ * accellerate Intersect and Union encoding.
+ */
+export function KeyOfPropertyEntries(schema: TSchema): [key: string, schema: TSchema][] {
+  const keys = KeyOfPropertyKeys(schema) as string[]
+  const schemas = IndexFromPropertyKeys(schema, keys)
+  return keys.map((_, index) => [keys[index], schemas[index]])
+}

--- a/src/value/transform/decode.ts
+++ b/src/value/transform/decode.ts
@@ -29,7 +29,7 @@ THE SOFTWARE.
 import { Kind, TransformKind } from '../../type/symbols/index'
 import { TypeBoxError } from '../../type/error/index'
 import { ValueError } from '../../errors/index'
-import { KeyOfPropertyKeys } from '../../type/keyof/index'
+import { KeyOfPropertyKeys, KeyOfPropertyEntries } from '../../type/keyof/index'
 import { Index } from '../../type/indexed/index'
 import { Deref } from '../deref/index'
 import { Check } from '../check/index'
@@ -98,10 +98,11 @@ function FromArray(schema: TArray, references: TSchema[], path: string, value: a
 // prettier-ignore
 function FromIntersect(schema: TIntersect, references: TSchema[], path: string, value: any) {
   if (!IsStandardObject(value) || IsValueType(value)) return Default(schema, path, value)
-  const knownKeys = KeyOfPropertyKeys(schema) as string[]
+  const knownEntries = KeyOfPropertyEntries(schema)
+  const knownKeys = knownEntries.map(entry => entry[0])
   const knownProperties = { ...value } as Record<PropertyKey, unknown>
-  for(const key of knownKeys) if(key in knownProperties) {
-    knownProperties[key] = Visit(Index(schema, [key]), references, `${path}/${key}`, knownProperties[key])
+  for(const [knownKey, knownSchema] of knownEntries) if(knownKey in knownProperties) {
+    knownProperties[knownKey] = Visit(knownSchema, references, `${path}/${knownKey}`, knownProperties[knownKey])
   }
   if (!IsTransform(schema.unevaluatedProperties)) {
     return Default(schema, path, knownProperties)

--- a/src/value/transform/encode.ts
+++ b/src/value/transform/encode.ts
@@ -29,7 +29,7 @@ THE SOFTWARE.
 import { Kind, TransformKind } from '../../type/symbols/index'
 import { TypeBoxError } from '../../type/error/index'
 import { ValueError } from '../../errors/index'
-import { KeyOfPropertyKeys } from '../../type/keyof/index'
+import { KeyOfPropertyKeys, KeyOfPropertyEntries } from '../../type/keyof/index'
 import { Index } from '../../type/indexed/index'
 import { Deref } from '../deref/index'
 import { Check } from '../check/index'
@@ -99,10 +99,11 @@ function FromArray(schema: TArray, references: TSchema[], path: string, value: a
 function FromIntersect(schema: TIntersect, references: TSchema[], path: string, value: any) {
   const defaulted = Default(schema, path, value)
   if (!IsStandardObject(value) || IsValueType(value)) return defaulted
-  const knownKeys = KeyOfPropertyKeys(schema) as string[]
+  const knownEntries = KeyOfPropertyEntries(schema)
+  const knownKeys = knownEntries.map(entry => entry[0])
   const knownProperties = { ...defaulted } as Record<PropertyKey, unknown>
-  for(const key of knownKeys) if(key in knownProperties) {
-    knownProperties[key] = Visit(Index(schema, [key]), references, `${path}/${key}`, knownProperties[key])
+  for(const [knownKey, knownSchema] of knownEntries) if(knownKey in knownProperties) {
+    knownProperties[knownKey] = Visit(knownSchema, references, `${path}/${knownKey}`, knownProperties[knownKey])
   }
   if (!IsTransform(schema.unevaluatedProperties)) {
     return Default(schema, path, knownProperties)

--- a/src/value/value/value.ts
+++ b/src/value/value/value.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { TransformDecode, TransformEncode, TransformDecodeCheckError, TransformEncodeCheckError } from '../transform/index'
+import { HasTransform, TransformDecode, TransformEncode, TransformDecodeCheckError, TransformEncodeCheckError } from '../transform/index'
 import { Mutate as MutateValue, type Mutable } from '../mutate/index'
 import { Hash as HashValue } from '../hash/index'
 import { Equal as EqualValue } from '../equal/index'
@@ -95,7 +95,7 @@ export function Decode<T extends TSchema, R = StaticDecode<T>>(schema: T, value:
 export function Decode(...args: any[]) {
   const [schema, references, value] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], [], args[1]]
   if (!Check(schema, references, value)) throw new TransformDecodeCheckError(schema, value, Errors(schema, references, value).First()!)
-  return TransformDecode(schema, references, value)
+  return HasTransform(schema, references) ? TransformDecode(schema, references, value) : value
 }
 /** `[Mutable]` Generates missing properties on a value using default schema annotations if available. This function does not check the value and returns an unknown type. You should Check the result before use. Default is a mutable operation. To avoid mutation, Clone the value first. */
 export function Default(schema: TSchema, references: TSchema[], value: unknown): unknown
@@ -112,7 +112,7 @@ export function Encode<T extends TSchema, R = StaticEncode<T>>(schema: T, value:
 /** Encodes a value or throws if error */
 export function Encode(...args: any[]) {
   const [schema, references, value] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], [], args[1]]
-  const encoded = TransformEncode(schema, references, value)
+  const encoded = HasTransform(schema, references) ? TransformEncode(schema, references, value) : value
   if (!Check(schema, references, encoded)) throw new TransformEncodeCheckError(schema, encoded, Errors(schema, references, encoded).First()!)
   return encoded
 }


### PR DESCRIPTION
This PR provides an optimization on Intersect Encode and Decode by using a different strategy for resolving key and key schematics. It was noted that Key + Index resolve operations were slow when Index was called per iteration, this PR resolves all schematics in a single call resulting in roughly 2x better performance.

Test Case

```typescript
import { Type } from '@sinclair/typebox'
import { Value } from '@sinclair/typebox/value'

const N = Type.Transform(Type.Number())
  .Decode(value => value)
  .Encode(value => value)

const I = Type.Intersect([
  Type.Object({ a: N, b: N, c: N }),
  Type.Object({ d: N, e: N, f: N }),
  Type.Object({ g: N, h: N, i: N })
])

const V = Value.Create(I)
const D = Value.Decode(I, V)
const L = 100_000

console.time('intersect-decode')
for(let i = 0; i < L; i++) Value.Decode(I, V)
console.timeEnd('intersect-decode')

console.time('intersect-encode')
for(let i = 0; i < L; i++) Value.Encode(I, D)
console.timeEnd('intersect-encode')

// before:
//
// intersect-decode: 3.541s
// intersect-encode: 3.483s
//
// after:
//
// intersect-decode: 1.509s
// intersect-encode: 1.369s
```
This PR also updates the Value.Decode and Value.Encode functions to check for HasTransform prior to invoking the codecs. Schematics without Transforms will yield the checked value only leading to significantly better performance. This check was missed on the revision 0.32.0.
