### PR TITLE
Revision 0.32.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.29",
+  "version": "0.32.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.29",
+      "version": "0.32.30",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.29",
+  "version": "0.32.30",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/guard/guard.ts
+++ b/src/value/guard/guard.ts
@@ -61,7 +61,7 @@ export function IsIterator(value: unknown): value is IterableIterator<any> {
 // --------------------------------------------------------------------------
 /** Returns true if this value is not an instance of a class */
 export function IsStandardObject(value: unknown): value is ObjectType {
-  return IsObject(value) && !IsArray(value) && IsFunction(value.constructor) && value.constructor.name === 'Object'
+  return IsObject(value) && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)
 }
 /** Returns true if this value is an instance of a class */
 export function IsInstanceObject(value: unknown): value is ObjectType {

--- a/test/runtime/value/guard/guard.ts
+++ b/test/runtime/value/guard/guard.ts
@@ -197,6 +197,10 @@ describe('value/guard/ValueGuard', () => {
     const R = ValueGuard.IsStandardObject(new (class {})())
     Assert.IsFalse(R)
   })
+  it('Should guard StandardObject 5', () => {
+    const R = ValueGuard.IsStandardObject(Object.create(null))
+    Assert.IsTrue(R)
+  })
   // -----------------------------------------------------
   // IsInstanceObject
   // -----------------------------------------------------

--- a/test/runtime/value/transform/object.ts
+++ b/test/runtime/value/transform/object.ts
@@ -3,6 +3,7 @@ import { Assert } from '../../assert'
 import { Value } from '@sinclair/typebox/value'
 import { Type } from '@sinclair/typebox'
 
+// prettier-ignore
 describe('value/transform/Object', () => {
   // --------------------------------------------------------
   // Identity
@@ -154,7 +155,6 @@ describe('value/transform/Object', () => {
   // ----------------------------------------------------------------
   // https://github.com/sinclairzx81/typebox/issues/859
   // ----------------------------------------------------------------
-  // prettier-ignore
   it('Should decode for nested transform with renamed property', () => {
     class User { constructor(public name: string, public createdAt: Date) {} }
     const TDate = Type.Transform(Type.Number())
@@ -172,5 +172,20 @@ describe('value/transform/Object', () => {
 
     Assert.IsEqual(E.name, 'name')
     Assert.IsEqual(E.created_at, 0)
+  })
+  // ----------------------------------------------------------------
+  // https://github.com/sinclairzx81/typebox/issues/865
+  // ----------------------------------------------------------------
+  it('Should decode for null prototype', () => {
+    const N = Type.Transform(Type.Number())
+      .Decode(value => value.toString())
+      .Encode(value => parseInt(value))
+    const T = Type.Object({ x: N })
+    const A = Object.create(null); A.x = 1
+    const B = Object.create(null); B.x = '1'
+    const D = Value.Decode(T, A)
+    const E = Value.Encode(T, B)
+    Assert.IsEqual(D, { x: '1' })    
+    Assert.IsEqual(E, { x: 1 })
   })
 })


### PR DESCRIPTION
This PR adds support for encoding and decoding objects with null prototypes created via `Object.create(null)`

