### PR TITLE
Revision 0.32.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.30",
+  "version": "0.32.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.30",
+      "version": "0.32.31",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.30",
+  "version": "0.32.31",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/cast/cast.ts
+++ b/src/value/cast/cast.ts
@@ -80,8 +80,9 @@ function ScoreUnion(schema: TSchema, references: TSchema[], value: any): number 
   }
 }
 function SelectUnion(union: TUnion, references: TSchema[], value: any): TSchema {
-  let [select, best] = [union.anyOf[0], 0]
-  for (const schema of union.anyOf) {
+  const schemas = union.anyOf.map((schema) => Deref(schema, references))
+  let [select, best] = [schemas[0], 0]
+  for (const schema of schemas) {
     const score = ScoreUnion(schema, references, value)
     if (score > best) {
       select = schema

--- a/test/runtime/value/cast/union.ts
+++ b/test/runtime/value/cast/union.ts
@@ -145,4 +145,20 @@ describe('value/cast/Union', () => {
       value: 'B',
     })
   })
+  // ----------------------------------------------------------------
+  // https://github.com/sinclairzx81/typebox/issues/880
+  // ----------------------------------------------------------------
+  // prettier-ignore
+  it('Should dereference union variants', () => {
+    const A = Type.Object({ type: Type.Literal('A') }, { $id: 'A' })
+    const B = Type.Object({ type: Type.Literal('B'), value: Type.Number() }, { $id: 'B' })
+    const RA = Type.Union([A, B])
+    const RB = Type.Union([Type.Ref(A), Type.Ref(B)])
+    // variant 0
+    Assert.IsEqual(Value.Cast(RA, [A, B], { type: 'B' }), { type: 'B', value: 0 })
+    Assert.IsEqual(Value.Cast(RB, [A, B], { type: 'B' }), { type: 'B', value: 0 })
+    // variant 1
+    Assert.IsEqual(Value.Cast(RA, [A, B], { type: 'A' }), { type: 'A' })
+    Assert.IsEqual(Value.Cast(RB, [A, B], { type: 'A' }), { type: 'A' })
+  })
 })


### PR DESCRIPTION
This PR implements a fix on Value.Cast to dereference Union variants before scoring them. This is required as the current Union differentiation algorithm only works on instances of TObject and where fall through cases (for example TRef) would blindly score referenced objects with a binary 0 or 1 value. 

It was observed that in fall through cases where no variants match the value, the first union variant was selected.

Fixes https://github.com/sinclairzx81/typebox/issues/880

