### PR TITLE
Revision 0.32.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.32",
+  "version": "0.32.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.32",
+      "version": "0.32.33",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.32",
+  "version": "0.32.33",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/task/build/esm/compile.ts
+++ b/task/build/esm/compile.ts
@@ -32,7 +32,7 @@ declare function shell(command: string): Promise<void>
 export async function compile(target: string) {
   const options = [
     `--outDir ${target}`,
-    '--target ESNext',
+    '--target ES2020',
     '--module ESNext',
     '--declaration',
   ].join(' ')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "target": "ESNext",
-    "module": "ESNext",
+    "module": "ES2020",
     "moduleResolution": "Node",
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "strict": true,
-    "target": "ESNext",
-    "module": "ES2020",
+    "target": "ES2020",
+    "module": "ESNext",
     "moduleResolution": "Node",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
This PR carries out a small build configuration change for ESM ensuring the build target is for ES2020. Given the build configuration change, will publish as a revision.