### PR TITLE
fix: typebox imports not being tree shaken

### DIFF
--- a/task/build/package/create-package-json.ts
+++ b/task/build/package/create-package-json.ts
@@ -95,6 +95,7 @@ function resolveMetadata() {
     'esm.sh': { 'bundle': false }, 
     types: "./build/cjs/index.d.ts",
     main: "./build/cjs/index.js",
-    module: "./build/esm/index.mjs"
+    module: "./build/esm/index.mjs",
+    sideEffects: false
   }
 }


### PR DESCRIPTION
Current build tooling will not purge unused typebox imports, as it can't be sure the import is pure (free of side effects). This can be solved by adding the `sideEffects: false` field to the `package.json`.

For example importing `SOME_CONSTANT` from
```ts
import { Type } from '@sinclairzx81/typebox'

export const MyUnusedSchema = /*#__PURE__*/
  Type.String()

export const SOME_CONSTANT = 1
```

will currently result in output similar to
```js
var import_typebox = require("@sinclair/typebox");
// no further usage of import_typebox

var SOME_CONSTANT = 1
```

as the package import is not denoted to be free of side effects. With the proposed change, it would instead result in
```js
var SOME_CONSTANT = 1
```

allowing to completely exclude TypeBox from the bundle. For more information see https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free.