### PR TITLE
Revision 0.32.34

### DIFF
--- a/hammer.mjs
+++ b/hammer.mjs
@@ -32,7 +32,7 @@ export async function benchmark() {
 // Test
 // -------------------------------------------------------------------------------
 export async function test_typescript() {
-  for (const version of ['4.9.5', '5.0.4', '5.1.3', '5.1.6', '5.2.2', '5.3.2', '5.3.3', '5.4.3', 'next', 'latest']) {
+  for (const version of ['4.9.5', '5.0.4', '5.1.3', '5.1.6', '5.2.2', '5.3.2', '5.3.3', '5.4.3', '5.4.5', 'next', 'latest']) {
     await shell(`npm install typescript@${version} --no-save`)
     await test_static()
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.33",
+  "version": "0.32.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.33",
+      "version": "0.32.34",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ajv-formats": "^2.1.1",
         "mocha": "^10.4.0",
         "prettier": "^2.7.1",
-        "typescript": "^5.4.5"
+        "typescript": "^5.5.2"
       }
     },
     "node_modules/@andrewbranch/untar.js": {
@@ -1576,9 +1576,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2738,9 +2738,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.33",
+  "version": "0.32.34",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "ajv-formats": "^2.1.1",
     "mocha": "^10.4.0",
     "prettier": "^2.7.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.2"
   }
 }

--- a/src/type/template-literal/generate.ts
+++ b/src/type/template-literal/generate.ts
@@ -83,6 +83,7 @@ type TFromTemplateLiteralUnionKinds<T extends TTemplateLiteralKind[]> =
 type TFromTemplateLiteralKinds<T extends TTemplateLiteralKind[], Acc extends TLiteralValue[][] = []> = 
   T extends [infer L extends TTemplateLiteralKind, ...infer R extends TTemplateLiteralKind[]]
     ? (
+     L extends TTemplateLiteral<infer S extends TTemplateLiteralKind[]> ? TFromTemplateLiteralKinds<[...S, ...R], Acc> : 
      L extends TLiteral<infer S extends TLiteralValue> ? TFromTemplateLiteralKinds<R, [...Acc, [S]]> : 
      L extends TUnion<infer S extends TTemplateLiteralKind[]> ? TFromTemplateLiteralKinds<R, [...Acc, TFromTemplateLiteralUnionKinds<S>]> : 
      L extends TBoolean ? TFromTemplateLiteralKinds<R, [...Acc, ['true', 'false']]> : 

--- a/test/static/template-literal.ts
+++ b/test/static/template-literal.ts
@@ -112,3 +112,18 @@ import { Type } from '@sinclair/typebox'
     '$propAx}Yx' | '$propBx}Yx' | '$propCx}Yx'
   >()
 }
+// ---------------------------------------------------------------------
+// issue: https://github.com/sinclairzx81/typebox/issues/913
+// ---------------------------------------------------------------------
+{
+  const A = Type.TemplateLiteral([Type.Union([Type.Literal('A'), Type.Literal('B')])])
+  const B = Type.TemplateLiteral([Type.Union([Type.Literal('X'), Type.Literal('Y')])])
+  const L = Type.TemplateLiteral([Type.Literal('KEY'), A, B])
+  const T = Type.Mapped(L, (K) => Type.Null())
+  Expect(T).ToStatic<{
+    KEYAX: null
+    KEYAY: null
+    KEYBX: null
+    KEYBY: null
+  }>()
+}


### PR DESCRIPTION
This PR fixes template literal generation inference for template literals that embed interior template literals. It also upgrades TypeScript to 5.5.2.

Fixes https://github.com/sinclairzx81/typebox/issues/913
