### PR TITLE
Revision 0.33.0

### DIFF
--- a/hammer.mjs
+++ b/hammer.mjs
@@ -32,7 +32,7 @@ export async function benchmark() {
 // Test
 // -------------------------------------------------------------------------------
 export async function test_typescript() {
-  for (const version of ['4.9.5', '5.0.4', '5.1.3', '5.1.6', '5.2.2', '5.3.2', '5.3.3', '5.4.3', '5.4.5', '5.5.2', 'next', 'latest']) {
+  for (const version of ['4.9.5', '5.0.4', '5.1.3', '5.1.6', '5.2.2', '5.3.2', '5.3.3', '5.4.3', '5.4.5', '5.5.2', '5.5.3', 'next', 'latest']) {
     await shell(`npm install typescript@${version} --no-save`)
     await test_static()
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.35",
+  "version": "0.32.36",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.35",
+      "version": "0.32.36",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ajv-formats": "^2.1.1",
         "mocha": "^10.4.0",
         "prettier": "^2.7.1",
-        "typescript": "^5.5.3"
+        "typescript": "^5.5.4"
       }
     },
     "node_modules/@andrewbranch/untar.js": {
@@ -1576,9 +1576,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2738,9 +2738,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true
     },
     "undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.36",
+  "version": "0.33.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.32.36",
+      "version": "0.33.0",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.35",
+  "version": "0.32.36",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "ajv-formats": "^2.1.1",
     "mocha": "^10.4.0",
     "prettier": "^2.7.1",
-    "typescript": "^5.5.3"
+    "typescript": "^5.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.32.36",
+  "version": "0.33.0",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ THE SOFTWARE.
 // Infrastructure
 // ------------------------------------------------------------------
 export * from './type/clone/index'
+export * from './type/create/index'
 export * from './type/error/index'
 export * from './type/guard/index'
 export * from './type/helpers/index'

--- a/src/system/policy.ts
+++ b/src/system/policy.ts
@@ -32,7 +32,8 @@ export namespace TypeSystemPolicy {
   // ------------------------------------------------------------------
   // TypeSystemPolicy
   // ------------------------------------------------------------------
-  /** Shared assertion routines used by the value and errors modules */
+  /** Sets whether TypeBox should freeze values created by the type system. This function ensures that types cannot be modified once created. The default is `false` */
+  export let ImmutableTypes: boolean = false
   /** Sets whether TypeBox should assert optional properties using the TypeScript `exactOptionalPropertyTypes` assertion policy. The default is `false` */
   export let ExactOptionalPropertyTypes: boolean = false
   /** Sets whether arrays should be treated as a kind of objects. The default is `false` */

--- a/src/system/policy.ts
+++ b/src/system/policy.ts
@@ -30,10 +30,20 @@ import { IsObject, IsArray, IsNumber, IsUndefined } from '../value/guard/index'
 
 export namespace TypeSystemPolicy {
   // ------------------------------------------------------------------
-  // TypeSystemPolicy
+  // TypeSystemPolicy: Instancing
   // ------------------------------------------------------------------
-  /** Sets whether TypeBox should freeze values created by the type system. This function ensures that types cannot be modified once created. The default is `false` */
-  export let ImmutableTypes: boolean = false
+  /**
+   * Configures the instantiation behavior of TypeBox types. The `default` option assigns raw JavaScript
+   * references for embedded types, which may cause side effects if type properties are explicitly updated
+   * outside the TypeBox type builder. The `clone` option creates copies of any shared types upon creation,
+   * preventing unintended side effects. The `freeze` option applies `Object.freeze()` to the type, making
+   * it fully readonly and immutable. Implementations should use `default` whenever possible, as it is the
+   * fastest way to instantiate types. The default setting is `default`.
+   */
+  export let InstanceMode: 'default' | 'clone' | 'freeze' = 'default'
+  // ------------------------------------------------------------------
+  // TypeSystemPolicy: Checking
+  // ------------------------------------------------------------------
   /** Sets whether TypeBox should assert optional properties using the TypeScript `exactOptionalPropertyTypes` assertion policy. The default is `false` */
   export let ExactOptionalPropertyTypes: boolean = false
   /** Sets whether arrays should be treated as a kind of objects. The default is `false` */

--- a/src/type/any/any.ts
+++ b/src/type/any/any.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/index'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -35,6 +36,6 @@ export interface TAny extends TSchema {
 }
 
 /** `[Json]` Creates an Any type */
-export function Any(options: SchemaOptions = {}): TAny {
-  return { ...options, [Kind]: 'Any' } as never
+export function Any(options?: SchemaOptions): TAny {
+  return CreateType({ [Kind]: 'Any' }, options) as never
 }

--- a/src/type/array/array.ts
+++ b/src/type/array/array.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { CloneType } from '../clone/type'
+import { CreateType } from '../create/type'
 import { Ensure } from '../helpers/index'
 import type { SchemaOptions, TSchema } from '../schema/index'
 import type { Static } from '../static/index'
@@ -54,11 +54,6 @@ export interface TArray<T extends TSchema = TSchema> extends TSchema, ArrayOptio
   items: T
 }
 /** `[Json]` Creates an Array type */
-export function Array<T extends TSchema>(schema: T, options: ArrayOptions = {}): TArray<T> {
-  return {
-    ...options,
-    [Kind]: 'Array',
-    type: 'array',
-    items: CloneType(schema),
-  } as never
+export function Array<T extends TSchema>(items: T, options?: ArrayOptions): TArray<T> {
+  return CreateType({ [Kind]: 'Array', type: 'array', items }, options) as never
 }

--- a/src/type/async-iterator/async-iterator.ts
+++ b/src/type/async-iterator/async-iterator.ts
@@ -29,7 +29,7 @@ THE SOFTWARE.
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Static } from '../static/index'
 import { Kind } from '../symbols/index'
-import { CloneType } from '../clone/type'
+import { CreateType } from '../create/type'
 
 export interface TAsyncIterator<T extends TSchema = TSchema> extends TSchema {
   [Kind]: 'AsyncIterator'
@@ -38,11 +38,6 @@ export interface TAsyncIterator<T extends TSchema = TSchema> extends TSchema {
   items: T
 }
 /** `[JavaScript]` Creates a AsyncIterator type */
-export function AsyncIterator<T extends TSchema>(items: T, options: SchemaOptions = {}): TAsyncIterator<T> {
-  return {
-    ...options,
-    [Kind]: 'AsyncIterator',
-    type: 'AsyncIterator',
-    items: CloneType(items),
-  } as never
+export function AsyncIterator<T extends TSchema>(items: T, options?: SchemaOptions): TAsyncIterator<T> {
+  return CreateType({ [Kind]: 'AsyncIterator', type: 'AsyncIterator', items }, options) as never
 }

--- a/src/type/awaited/awaited.ts
+++ b/src/type/awaited/awaited.ts
@@ -30,7 +30,7 @@ import type { TSchema, SchemaOptions } from '../schema/index'
 import { Intersect, type TIntersect } from '../intersect/index'
 import { Union, type TUnion } from '../union/index'
 import { type TPromise } from '../promise/index'
-import { CloneType } from '../clone/type'
+import { CreateType } from '../create/type'
 
 // ------------------------------------------------------------------
 // TypeGuard
@@ -96,6 +96,6 @@ export type TAwaited<T extends TSchema> =
   T extends TPromise<infer S> ? TAwaited<S> :
   T
 /** `[JavaScript]` Constructs a type by recursively unwrapping Promise types */
-export function Awaited<T extends TSchema>(T: T, options: SchemaOptions = {}): TAwaited<T> {
-  return CloneType(AwaitedResolve(T), options)
+export function Awaited<T extends TSchema>(T: T, options?: SchemaOptions): TAwaited<T> {
+  return CreateType(AwaitedResolve(T), options) as never
 }

--- a/src/type/bigint/bigint.ts
+++ b/src/type/bigint/bigint.ts
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
+import { CreateType } from '../create/index'
 
 export interface BigIntOptions extends SchemaOptions {
   exclusiveMaximum?: bigint
@@ -42,10 +43,6 @@ export interface TBigInt extends TSchema, BigIntOptions {
   type: 'bigint'
 }
 /** `[JavaScript]` Creates a BigInt type */
-export function BigInt(options: BigIntOptions = {}): TBigInt {
-  return {
-    ...options,
-    [Kind]: 'BigInt',
-    type: 'bigint',
-  } as never
+export function BigInt(options?: BigIntOptions): TBigInt {
+  return CreateType({ [Kind]: 'BigInt', type: 'bigint' }, options) as never
 }

--- a/src/type/boolean/boolean.ts
+++ b/src/type/boolean/boolean.ts
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
+import { CreateType } from '../create/index'
 
 export interface TBoolean extends TSchema {
   [Kind]: 'Boolean'
@@ -35,10 +36,6 @@ export interface TBoolean extends TSchema {
   type: 'boolean'
 }
 /** `[Json]` Creates a Boolean type */
-export function Boolean(options: SchemaOptions = {}): TBoolean {
-  return {
-    ...options,
-    [Kind]: 'Boolean',
-    type: 'boolean',
-  } as never
+export function Boolean(options?: SchemaOptions): TBoolean {
+  return CreateType({ [Kind]: 'Boolean', type: 'boolean' }, options) as never
 }

--- a/src/type/clone/type.ts
+++ b/src/type/clone/type.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import type { TSchema, SchemaOptions } from '../schema/index'
+import { TSchema, SchemaOptions } from '../schema/index'
 import { Clone } from './value'
 
 /** Clones a Rest */
@@ -34,6 +34,6 @@ export function CloneRest<T extends TSchema[]>(schemas: T): T {
   return schemas.map((schema) => CloneType(schema)) as never
 }
 /** Clones a Type */
-export function CloneType<T extends TSchema>(schema: T, options: SchemaOptions = {}): T {
-  return { ...Clone(schema), ...options }
+export function CloneType<T extends TSchema>(schema: T, options?: SchemaOptions): T {
+  return options === undefined ? Clone(schema) : Clone({ ...options, ...schema })
 }

--- a/src/type/composite/composite.ts
+++ b/src/type/composite/composite.ts
@@ -114,7 +114,7 @@ type TCompositeEvaluate<
 // prettier-ignore
 export type TComposite<T extends TSchema[]> = TCompositeEvaluate<T>
 // prettier-ignore
-export function Composite<T extends TSchema[]>(T: [...T], options: ObjectOptions = {}): TComposite<T> {
+export function Composite<T extends TSchema[]>(T: [...T], options?: ObjectOptions): TComposite<T> {
   const K = CompositeKeys(T)
   const P = CompositeProperties(T, K)
   const R = Object(P, options)

--- a/src/type/const/const.ts
+++ b/src/type/const/const.ts
@@ -44,7 +44,7 @@ import { Readonly, type TReadonly } from '../readonly/index'
 import { Undefined, type TUndefined } from '../undefined/index'
 import { Uint8Array, type TUint8Array } from '../uint8array/index'
 import { Unknown, type TUnknown } from '../unknown/index'
-import { CloneType } from '../clone/index'
+import { CreateType } from '../create/index'
 
 // ------------------------------------------------------------------
 // ValueGuard
@@ -130,6 +130,6 @@ function FromValue<T, Root extends boolean>(value: T, root: Root): FromValue<T, 
 export type TConst<T> = FromValue<T, true>
 
 /** `[JavaScript]` Creates a readonly const type from the given value. */
-export function Const</* const (not supported in 4.0) */ T>(T: T, options: SchemaOptions = {}): TConst<T> {
-  return CloneType(FromValue(T, true), options) as never
+export function Const</* const (not supported in 4.0) */ T>(T: T, options?: SchemaOptions): TConst<T> {
+  return CreateType(FromValue(T, true), options) as never
 }

--- a/src/type/constructor-parameters/constructor-parameters.ts
+++ b/src/type/constructor-parameters/constructor-parameters.ts
@@ -30,7 +30,6 @@ import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Ensure } from '../helpers/index'
 import type { TConstructor } from '../constructor/index'
 import { Tuple, type TTuple } from '../tuple/index'
-import { CloneRest } from '../clone/type'
 
 // ------------------------------------------------------------------
 // ConstructorParameters
@@ -41,6 +40,6 @@ export type TConstructorParameters<T extends TConstructor<TSchema[], TSchema>> =
 )
 
 /** `[JavaScript]` Extracts the ConstructorParameters from the given Constructor type */
-export function ConstructorParameters<T extends TConstructor<TSchema[], TSchema>>(schema: T, options: SchemaOptions = {}): TConstructorParameters<T> {
-  return Tuple(CloneRest(schema.parameters), { ...options })
+export function ConstructorParameters<T extends TConstructor<TSchema[], TSchema>>(schema: T, options?: SchemaOptions): TConstructorParameters<T> {
+  return Tuple(schema.parameters, options)
 }

--- a/src/type/constructor/constructor.ts
+++ b/src/type/constructor/constructor.ts
@@ -32,7 +32,7 @@ import type { Ensure } from '../helpers/index'
 import type { TReadonlyOptional } from '../readonly-optional/index'
 import type { TReadonly } from '../readonly/index'
 import type { TOptional } from '../optional/index'
-import { CloneType, CloneRest } from '../clone/type'
+import { CreateType } from '../create/type'
 import { Kind } from '../symbols/index'
 
 // ------------------------------------------------------------------
@@ -66,11 +66,5 @@ export interface TConstructor<T extends TSchema[] = TSchema[], U extends TSchema
 }
 /** `[JavaScript]` Creates a Constructor type */
 export function Constructor<T extends TSchema[], U extends TSchema>(parameters: [...T], returns: U, options?: SchemaOptions): TConstructor<T, U> {
-  return {
-    ...options,
-    [Kind]: 'Constructor',
-    type: 'Constructor',
-    parameters: CloneRest(parameters),
-    returns: CloneType(returns),
-  } as never
+  return CreateType({ [Kind]: 'Constructor', type: 'Constructor', parameters, returns }, options) as never
 }

--- a/src/type/create/index.ts
+++ b/src/type/create/index.ts
@@ -26,16 +26,4 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { CreateType } from '../create/type'
-import type { TSchema, SchemaOptions } from '../schema/index'
-import { Kind } from '../symbols/index'
-
-export interface TVoid extends TSchema {
-  [Kind]: 'Void'
-  static: void
-  type: 'void'
-}
-/** `[JavaScript]` Creates a Void type */
-export function Void(options?: SchemaOptions): TVoid {
-  return CreateType({ [Kind]: 'Void', type: 'void' }, options) as never
-}
+export * from './type'

--- a/src/type/create/type.ts
+++ b/src/type/create/type.ts
@@ -31,9 +31,9 @@ import { SchemaOptions } from '../schema/schema'
 import { Immutable } from './immutable'
 import { Clone } from '../clone/value'
 
-/** Creates a raw TypeBox schematics. */
+/** Creates TypeBox schematics using the configured InstanceMode */
 export function CreateType(schema: Record<any, unknown>, options?: SchemaOptions): unknown {
-  const result = options !== undefined ? { ...options, ...schema } : schema
+  const result = options !== undefined ? Object.assign(options, schema) : schema
   switch (TypeSystemPolicy.InstanceMode) {
     case 'freeze':
       return Immutable(result)

--- a/src/type/create/type.ts
+++ b/src/type/create/type.ts
@@ -29,9 +29,17 @@ THE SOFTWARE.
 import { TypeSystemPolicy } from '../../system/policy'
 import { SchemaOptions } from '../schema/schema'
 import { Immutable } from './immutable'
+import { Clone } from '../clone/value'
 
 /** Creates a raw TypeBox schematics. */
 export function CreateType(schema: Record<any, unknown>, options?: SchemaOptions): unknown {
   const result = options !== undefined ? { ...options, ...schema } : schema
-  return TypeSystemPolicy.ImmutableTypes ? Immutable(result) : result
+  switch (TypeSystemPolicy.InstanceMode) {
+    case 'freeze':
+      return Immutable(result)
+    case 'clone':
+      return Clone(result)
+    default:
+      return result
+  }
 }

--- a/src/type/create/type.ts
+++ b/src/type/create/type.ts
@@ -26,16 +26,12 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { CreateType } from '../create/type'
-import type { TSchema, SchemaOptions } from '../schema/index'
-import { Kind } from '../symbols/index'
+import { TypeSystemPolicy } from '../../system/policy'
+import { SchemaOptions } from '../schema/schema'
+import { Immutable } from './immutable'
 
-export interface TVoid extends TSchema {
-  [Kind]: 'Void'
-  static: void
-  type: 'void'
-}
-/** `[JavaScript]` Creates a Void type */
-export function Void(options?: SchemaOptions): TVoid {
-  return CreateType({ [Kind]: 'Void', type: 'void' }, options) as never
+/** Creates a raw TypeBox schematics. */
+export function CreateType(schema: Record<any, unknown>, options?: SchemaOptions): unknown {
+  const result = options !== undefined ? { ...options, ...schema } : schema
+  return TypeSystemPolicy.ImmutableTypes ? Immutable(result) : result
 }

--- a/src/type/date/date.ts
+++ b/src/type/date/date.ts
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
+import { CreateType } from '../create/type'
 
 export interface DateOptions extends SchemaOptions {
   /** The exclusive maximum timestamp value */
@@ -47,10 +48,6 @@ export interface TDate extends TSchema, DateOptions {
   type: 'date'
 }
 /** `[JavaScript]` Creates a Date type */
-export function Date(options: DateOptions = {}): TDate {
-  return {
-    ...options,
-    [Kind]: 'Date',
-    type: 'Date',
-  } as never
+export function Date(options?: DateOptions): TDate {
+  return CreateType({ [Kind]: 'Date', type: 'Date' }, options) as never
 }

--- a/src/type/discard/discard.ts
+++ b/src/type/discard/discard.ts
@@ -30,6 +30,7 @@ function DiscardKey(value: Record<PropertyKey, any>, key: PropertyKey) {
   const { [key]: _, ...rest } = value
   return rest
 }
+/** Discards property keys from the given value. This function returns a shallow Clone. */
 export function Discard(value: Record<PropertyKey, any>, keys: PropertyKey[]) {
   return keys.reduce((acc, key) => DiscardKey(acc, key), value)
 }

--- a/src/type/enum/enum.ts
+++ b/src/type/enum/enum.ts
@@ -47,7 +47,7 @@ export interface TEnum<T extends Record<string, string | number> = Record<string
   anyOf: TLiteral<T[keyof T]>[]
 }
 /** `[Json]` Creates a Enum type */
-export function Enum<V extends TEnumValue, T extends Record<TEnumKey, V>>(item: T, options: SchemaOptions = {}): TEnum<T> {
+export function Enum<V extends TEnumValue, T extends Record<TEnumKey, V>>(item: T, options?: SchemaOptions): TEnum<T> {
   if (IsUndefined(item)) throw new Error('Enum undefined or empty')
   const values1 = globalThis.Object.getOwnPropertyNames(item)
     .filter((key) => isNaN(key as any))

--- a/src/type/exclude/exclude.ts
+++ b/src/type/exclude/exclude.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { UnionToTuple, AssertRest, AssertType } from '../helpers/index'
 import type { TMappedResult } from '../mapped/index'
@@ -35,7 +36,6 @@ import { Never, type TNever } from '../never/index'
 import { type Static } from '../static/index'
 import { type TUnionEvaluated } from '../union/index'
 import { ExtendsCheck, ExtendsResult } from '../extends/index'
-import { CloneType } from '../clone/type'
 import { ExcludeFromMappedResult, type TExcludeFromMappedResult } from './exclude-from-mapped-result'
 import { ExcludeFromTemplateLiteral, type TExcludeFromTemplateLiteral } from './exclude-from-template-literal'
 
@@ -72,10 +72,10 @@ export function Exclude<L extends TSchema, R extends TSchema>(unionType: L, excl
 /** `[Json]` Constructs a type by excluding from unionType all union members that are assignable to excludedMembers */
 export function Exclude(L: TSchema, R: TSchema, options: SchemaOptions = {}): any {
   // overloads
-  if (IsTemplateLiteral(L)) return CloneType(ExcludeFromTemplateLiteral(L, R), options)
-  if (IsMappedResult(L)) return CloneType(ExcludeFromMappedResult(L, R), options)
+  if (IsTemplateLiteral(L)) return CreateType(ExcludeFromTemplateLiteral(L, R), options)
+  if (IsMappedResult(L)) return CreateType(ExcludeFromMappedResult(L, R), options)
   // prettier-ignore
-  return CloneType(
+  return CreateType(
     IsUnion(L) ? ExcludeRest(L.anyOf, R) : 
     ExtendsCheck(L, R) !== ExtendsResult.False ? Never() : L
   , options)

--- a/src/type/extends/extends-from-mapped-key.ts
+++ b/src/type/extends/extends-from-mapped-key.ts
@@ -51,7 +51,7 @@ function FromPropertyKey<
   U extends TSchema,
   L extends TSchema,
   R extends TSchema
->(K: K, U: U, L: L, R: R, options: SchemaOptions): TFromPropertyKey<K, U, L, R> {
+>(K: K, U: U, L: L, R: R, options?: SchemaOptions): TFromPropertyKey<K, U, L, R> {
   return {
     [K]: Extends(Literal(K as TLiteralValue), U, L, R, options) as any
   } as never
@@ -77,7 +77,7 @@ function FromPropertyKeys<
   U extends TSchema,
   L extends TSchema,
   R extends TSchema
->(K: [...K], U: U, L: L, R: R, options: SchemaOptions): TFromPropertyKeys<K, U, L, R> {
+>(K: [...K], U: U, L: L, R: R, options?: SchemaOptions): TFromPropertyKeys<K, U, L, R> {
   return K.reduce((Acc, LK) => {
     return { ...Acc, ...FromPropertyKey(LK, U, L, R, options) }
   }, {} as TProperties) as never
@@ -100,7 +100,7 @@ function FromMappedKey<
   U extends TSchema,
   L extends TSchema,
   R extends TSchema
->(K: K, U: U, L: L, R: R, options: SchemaOptions): TFromMappedKey<K, U, L, R> {
+>(K: K, U: U, L: L, R: R, options?: SchemaOptions): TFromMappedKey<K, U, L, R> {
   return FromPropertyKeys(K.keys, U, L, R, options) as never
 }
 // ------------------------------------------------------------------
@@ -123,7 +123,7 @@ export function ExtendsFromMappedKey<
   L extends TSchema,
   R extends TSchema,
   P extends TProperties = TFromMappedKey<T, U, L, R>
->(T: T, U: U, L: L, R: R, options: SchemaOptions): TMappedResult<P> {
+>(T: T, U: U, L: L, R: R, options?: SchemaOptions): TMappedResult<P> {
   const P = FromMappedKey(T, U, L, R, options)
   return MappedResult(P) as never
 }

--- a/src/type/extends/extends-from-mapped-key.ts
+++ b/src/type/extends/extends-from-mapped-key.ts
@@ -32,6 +32,7 @@ import type { Assert } from '../helpers/index'
 import { MappedResult, type TMappedResult, type TMappedKey } from '../mapped/index'
 import { Literal, type TLiteral, type TLiteralValue } from '../literal/index'
 import { Extends, type TExtends } from './extends'
+import { Clone } from '../clone/value'
 
 // ------------------------------------------------------------------
 // FromPropertyKey
@@ -53,7 +54,7 @@ function FromPropertyKey<
   R extends TSchema
 >(K: K, U: U, L: L, R: R, options?: SchemaOptions): TFromPropertyKey<K, U, L, R> {
   return {
-    [K]: Extends(Literal(K as TLiteralValue), U, L, R, options) as any
+    [K]: Extends(Literal(K as TLiteralValue), U, L, R, Clone(options)) as any
   } as never
 }
 // ------------------------------------------------------------------

--- a/src/type/extends/extends-from-mapped-result.ts
+++ b/src/type/extends/extends-from-mapped-result.ts
@@ -30,6 +30,7 @@ import type { TSchema, SchemaOptions } from '../schema/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult } from '../mapped/index'
 import { Extends, type TExtends } from './extends'
+import { Clone } from '../clone/value'
 
 // ------------------------------------------------------------------
 // FromProperties
@@ -51,7 +52,7 @@ function FromProperties<
   False extends TSchema
 >(P: P, Right: Right, True: True, False: False, options?: SchemaOptions): TFromProperties<P, Right, True, False> {
   const Acc = {} as TProperties
-  for(const K2 of globalThis.Object.getOwnPropertyNames(P)) Acc[K2] = Extends(P[K2], Right, True, False, options)
+  for(const K2 of globalThis.Object.getOwnPropertyNames(P)) Acc[K2] = Extends(P[K2], Right, True, False, Clone(options))
   return Acc as never
 }
 // ------------------------------------------------------------------

--- a/src/type/extends/extends-from-mapped-result.ts
+++ b/src/type/extends/extends-from-mapped-result.ts
@@ -49,7 +49,7 @@ function FromProperties<
   Right extends TSchema,
   True extends TSchema,
   False extends TSchema
->(P: P, Right: Right, True: True, False: False, options: SchemaOptions): TFromProperties<P, Right, True, False> {
+>(P: P, Right: Right, True: True, False: False, options?: SchemaOptions): TFromProperties<P, Right, True, False> {
   const Acc = {} as TProperties
   for(const K2 of globalThis.Object.getOwnPropertyNames(P)) Acc[K2] = Extends(P[K2], Right, True, False, options)
   return Acc as never
@@ -72,7 +72,7 @@ function FromMappedResult<
   Right extends TSchema,
   True extends TSchema,
   False extends TSchema
->(Left: Left, Right: Right, True: True, False: False, options: SchemaOptions): TFromMappedResult<Left, Right, True, False> {
+>(Left: Left, Right: Right, True: True, False: False, options?: SchemaOptions): TFromMappedResult<Left, Right, True, False> {
   return FromProperties(Left.properties, Right, True, False, options) as never
 }
 // ------------------------------------------------------------------
@@ -95,7 +95,7 @@ export function ExtendsFromMappedResult<
   True extends TSchema,
   False extends TSchema,
   P extends TProperties = TFromMappedResult<Left, Right, True, False>
->(Left: Left, Right: Right, True: True, False: False, options: SchemaOptions): TMappedResult<P> {
+>(Left: Left, Right: Right, True: True, False: False, options?: SchemaOptions): TMappedResult<P> {
   const P = FromMappedResult(Left, Right, True, False, options)
   return MappedResult(P) as never
 }

--- a/src/type/extends/extends.ts
+++ b/src/type/extends/extends.ts
@@ -33,7 +33,6 @@ import { type TUnion, Union } from '../union/index'
 import { TMappedKey, TMappedResult } from '../mapped/index'
 import { ExtendsCheck, ExtendsResult } from './extends-check'
 import { UnionToTuple } from '../helpers/index'
-
 import { ExtendsFromMappedKey, type TExtendsFromMappedKey } from './extends-from-mapped-key'
 import { ExtendsFromMappedResult, type TExtendsFromMappedResult } from './extends-from-mapped-result'
 

--- a/src/type/extends/extends.ts
+++ b/src/type/extends/extends.ts
@@ -26,13 +26,14 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Static } from '../static/index'
 import { type TUnion, Union } from '../union/index'
 import { TMappedKey, TMappedResult } from '../mapped/index'
 import { ExtendsCheck, ExtendsResult } from './extends-check'
 import { UnionToTuple } from '../helpers/index'
-import { CloneType } from '../clone/type'
+
 import { ExtendsFromMappedKey, type TExtendsFromMappedKey } from './extends-from-mapped-key'
 import { ExtendsFromMappedResult, type TExtendsFromMappedResult } from './extends-from-mapped-result'
 
@@ -70,11 +71,11 @@ export function Extends<L extends TMappedKey, R extends TSchema, T extends TSche
 /** `[Json]` Creates a Conditional type */
 export function Extends<L extends TSchema, R extends TSchema, T extends TSchema, F extends TSchema>(L: L, R: R, T: T, F: F, options?: SchemaOptions): TExtends<L, R, T, F>
 /** `[Json]` Creates a Conditional type */
-export function Extends<L extends TSchema, R extends TSchema, T extends TSchema, F extends TSchema>(L: L, R: R, T: T, F: F, options: SchemaOptions = {}) {
+export function Extends<L extends TSchema, R extends TSchema, T extends TSchema, F extends TSchema>(L: L, R: R, T: T, F: F, options?: SchemaOptions) {
   // prettier-ignore
   return (
     IsMappedResult(L) ? ExtendsFromMappedResult(L, R, T, F, options) :
-    IsMappedKey(L) ? CloneType(ExtendsFromMappedKey(L, R, T, F, options)) :
-    CloneType(ExtendsResolve(L, R, T, F), options)
+    IsMappedKey(L) ? CreateType(ExtendsFromMappedKey(L, R, T, F, options)) :
+    CreateType(ExtendsResolve(L, R, T, F), options)
   ) as never
 }

--- a/src/type/extract/extract.ts
+++ b/src/type/extract/extract.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { AssertRest, AssertType, UnionToTuple } from '../helpers/index'
 import type { TMappedResult } from '../mapped/index'
@@ -35,7 +36,6 @@ import { Never, type TNever } from '../never/index'
 import { type TUnionEvaluated } from '../union/index'
 import { type TTemplateLiteral } from '../template-literal/index'
 import { ExtendsCheck, ExtendsResult } from '../extends/index'
-import { CloneType } from '../clone/type'
 import { ExtractFromMappedResult, type TExtractFromMappedResult } from './extract-from-mapped-result'
 import { ExtractFromTemplateLiteral, type TExtractFromTemplateLiteral } from './extract-from-template-literal'
 
@@ -50,7 +50,7 @@ import { IsMappedResult, IsTemplateLiteral, IsUnion } from '../guard/kind'
 // prettier-ignore
 type TExtractRest<L extends TSchema[], R extends TSchema> = AssertRest<UnionToTuple<
   { [K in keyof L]: Static<AssertType<L[K]>> extends Static<R> ? L[K] : never
-}[number]>> extends infer R extends TSchema[] ? TUnionEvaluated<R> : never
+  }[number]>> extends infer R extends TSchema[] ? TUnionEvaluated<R> : never
 
 function ExtractRest<L extends TSchema[], R extends TSchema>(L: [...L], R: R) {
   const extracted = L.filter((inner) => ExtendsCheck(inner, R) !== ExtendsResult.False)
@@ -71,13 +71,13 @@ export function Extract<L extends TTemplateLiteral, R extends TSchema>(type: L, 
 /** `[Json]` Constructs a type by extracting from type all union members that are assignable to union */
 export function Extract<L extends TSchema, R extends TSchema>(type: L, union: R, options?: SchemaOptions): TExtract<L, R>
 /** `[Json]` Constructs a type by extracting from type all union members that are assignable to union */
-export function Extract(L: TSchema, R: TSchema, options: SchemaOptions = {}): any {
+export function Extract(L: TSchema, R: TSchema, options?: SchemaOptions): never {
   // overloads
-  if (IsTemplateLiteral(L)) return CloneType(ExtractFromTemplateLiteral(L, R), options)
-  if (IsMappedResult(L)) return CloneType(ExtractFromMappedResult(L, R), options)
+  if (IsTemplateLiteral(L)) return CreateType(ExtractFromTemplateLiteral(L, R), options) as never
+  if (IsMappedResult(L)) return CreateType(ExtractFromMappedResult(L, R), options) as never
   // prettier-ignore
-  return CloneType(
+  return CreateType(
     IsUnion(L) ? ExtractRest(L.anyOf, R) :
-    ExtendsCheck(L, R) !== ExtendsResult.False ? L : Never()
-  , options)
+      ExtendsCheck(L, R) !== ExtendsResult.False ? L : Never()
+    , options) as never
 }

--- a/src/type/function/function.ts
+++ b/src/type/function/function.ts
@@ -26,13 +26,13 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Static } from '../static/index'
 import type { Ensure } from '../helpers/index'
 import type { TReadonlyOptional } from '../readonly-optional/index'
 import type { TReadonly } from '../readonly/index'
 import type { TOptional } from '../optional/index'
-import { CloneType, CloneRest } from '../clone/type'
 import { Kind } from '../symbols/index'
 
 // ------------------------------------------------------------------
@@ -67,11 +67,5 @@ export interface TFunction<T extends TSchema[] = TSchema[], U extends TSchema = 
 }
 /** `[JavaScript]` Creates a Function type */
 export function Function<T extends TSchema[], U extends TSchema>(parameters: [...T], returns: U, options?: SchemaOptions): TFunction<T, U> {
-  return {
-    ...options,
-    [Kind]: 'Function',
-    type: 'Function',
-    parameters: CloneRest(parameters),
-    returns: CloneType(returns),
-  } as never
+  return CreateType({ [Kind]: 'Function', type: 'Function', parameters, returns }, options) as never
 }

--- a/src/type/guard/value.ts
+++ b/src/type/guard/value.ts
@@ -26,6 +26,9 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+// --------------------------------------------------------------------------
+// Object Instances
+// --------------------------------------------------------------------------
 /** Returns true if this value is an async iterator */
 export function IsAsyncIterator(value: unknown): value is AsyncIterableIterator<unknown> {
   return IsObject(value) && !IsArray(value) && !IsUint8Array(value) && Symbol.asyncIterator in value
@@ -61,6 +64,14 @@ export function IsNull(value: unknown): value is null {
 /** Returns true if this value is number */
 export function IsNumber(value: unknown): value is number {
   return typeof value === 'number'
+}
+/** Returns true if this value is not an instance of a class */
+export function IsStandardObject(value: unknown): value is Record<PropertyKey, unknown> {
+  return IsObject(value) && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)
+}
+/** Returns true if this value is an instance of a class */
+export function IsInstanceObject(value: unknown): value is Record<PropertyKey, unknown> {
+  return IsObject(value) && !IsArray(value) && IsFunction(value.constructor) && value.constructor.name !== 'Object'
 }
 /** Returns true if this value is an object */
 export function IsObject(value: unknown): value is Record<PropertyKey, unknown> {

--- a/src/type/guard/value.ts
+++ b/src/type/guard/value.ts
@@ -65,14 +65,6 @@ export function IsNull(value: unknown): value is null {
 export function IsNumber(value: unknown): value is number {
   return typeof value === 'number'
 }
-/** Returns true if this value is not an instance of a class */
-export function IsStandardObject(value: unknown): value is Record<PropertyKey, unknown> {
-  return IsObject(value) && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)
-}
-/** Returns true if this value is an instance of a class */
-export function IsInstanceObject(value: unknown): value is Record<PropertyKey, unknown> {
-  return IsObject(value) && !IsArray(value) && IsFunction(value.constructor) && value.constructor.name !== 'Object'
-}
 /** Returns true if this value is an object */
 export function IsObject(value: unknown): value is Record<PropertyKey, unknown> {
   return typeof value === 'object' && value !== null

--- a/src/type/indexed/indexed-from-mapped-key.ts
+++ b/src/type/indexed/indexed-from-mapped-key.ts
@@ -46,7 +46,7 @@ type TMappedIndexPropertyKey<
 function MappedIndexPropertyKey<
   T extends TSchema, 
   K extends PropertyKey
->(T: T, K: K, options: SchemaOptions): TMappedIndexPropertyKey<T, K> {
+>(T: T, K: K, options?: SchemaOptions): TMappedIndexPropertyKey<T, K> {
   return { [K]: Index(T, [K], options) } as never
 }
 // ------------------------------------------------------------------
@@ -62,7 +62,7 @@ type TMappedIndexPropertyKeys<T extends TSchema, K extends PropertyKey[], Acc ex
 function MappedIndexPropertyKeys<
   T extends TSchema, 
   K extends PropertyKey[]
->(T: T, K: [...K], options: SchemaOptions): TMappedIndexPropertyKeys<T, K> {
+>(T: T, K: [...K], options?: SchemaOptions): TMappedIndexPropertyKeys<T, K> {
   return K.reduce((Acc, L) => {
     return { ...Acc, ...MappedIndexPropertyKey(T, L, options) }
   }, {} as TProperties) as never
@@ -78,7 +78,7 @@ type TMappedIndexProperties<T extends TSchema, K extends TMappedKey> = Evaluate<
 function MappedIndexProperties<
   T extends TSchema, 
   K extends TMappedKey
->(T: T, K: K, options: SchemaOptions): TMappedIndexProperties<T, K> {
+>(T: T, K: K, options?: SchemaOptions): TMappedIndexProperties<T, K> {
   return MappedIndexPropertyKeys(T, K.keys, options) as never
 }
 // ------------------------------------------------------------------
@@ -97,7 +97,7 @@ export function IndexFromMappedKey<
   T extends TSchema, 
   K extends TMappedKey, 
   P extends TProperties = TMappedIndexProperties<T, K>
->(T: T, K: K, options: SchemaOptions): TMappedResult<P> {
+>(T: T, K: K, options?: SchemaOptions): TMappedResult<P> {
   const P = MappedIndexProperties(T, K, options)
   return MappedResult(P) as never
 }

--- a/src/type/indexed/indexed-from-mapped-key.ts
+++ b/src/type/indexed/indexed-from-mapped-key.ts
@@ -31,6 +31,7 @@ import type { Ensure, Evaluate } from '../helpers/index'
 import type { TProperties } from '../object/index'
 import { Index, type TIndex } from './indexed'
 import { MappedResult, type TMappedResult, type TMappedKey } from '../mapped/index'
+import { Clone } from '../clone/value'
 
 // ------------------------------------------------------------------
 // MappedIndexPropertyKey
@@ -47,7 +48,7 @@ function MappedIndexPropertyKey<
   T extends TSchema, 
   K extends PropertyKey
 >(T: T, K: K, options?: SchemaOptions): TMappedIndexPropertyKey<T, K> {
-  return { [K]: Index(T, [K], options) } as never
+  return { [K]: Index(T, [K], Clone(options)) } as never
 }
 // ------------------------------------------------------------------
 // MappedIndexPropertyKeys

--- a/src/type/indexed/indexed-from-mapped-result.ts
+++ b/src/type/indexed/indexed-from-mapped-result.ts
@@ -46,7 +46,7 @@ type TFromProperties<
 function FromProperties<
   T extends TSchema,
   P extends TProperties
->(T: T, P: P, options: SchemaOptions): TFromProperties<T, P> {
+>(T: T, P: P, options?: SchemaOptions): TFromProperties<T, P> {
   const Acc = {} as Record<PropertyKey, TSchema>
   for(const K2 of Object.getOwnPropertyNames(P)) {
     Acc[K2] = Index(T, IndexPropertyKeys(P[K2]), options)
@@ -67,7 +67,7 @@ type TFromMappedResult<
 function FromMappedResult<
   T extends TSchema,
   R extends TMappedResult
->(T: T, R: R, options: SchemaOptions): TFromMappedResult<T, R> {
+>(T: T, R: R, options?: SchemaOptions): TFromMappedResult<T, R> {
   return FromProperties(T, R.properties, options) as never
 }
 // ------------------------------------------------------------------
@@ -86,7 +86,7 @@ export function IndexFromMappedResult<
   T extends TSchema,
   R extends TMappedResult,
   P extends TProperties = TFromMappedResult<T, R>
->(T: T, R: R, options: SchemaOptions): TMappedResult<P> {
+>(T: T, R: R, options?: SchemaOptions): TMappedResult<P> {
   const P = FromMappedResult(T, R, options)
   return MappedResult(P) as never
 }

--- a/src/type/indexed/indexed.ts
+++ b/src/type/indexed/indexed.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import { type TSchema, SchemaOptions } from '../schema/index'
 import { type TObject, type TProperties } from '../object/index'
 import { type Assert } from '../helpers/index'
@@ -38,7 +39,6 @@ import { type TTuple } from '../tuple/index'
 import { type TArray } from '../array/index'
 import { IntersectEvaluated, type TIntersectEvaluated } from '../intersect/index'
 import { UnionEvaluated, type TUnionEvaluated } from '../union/index'
-import { CloneType } from '../clone/type'
 
 import { IndexPropertyKeys, type TIndexPropertyKeys } from './indexed-property-keys'
 import { IndexFromMappedKey, type TIndexFromMappedKey } from './indexed-from-mapped-key'
@@ -259,12 +259,14 @@ export function Index<T extends TSchema, K extends TSchema, I extends PropertyKe
 /** `[Json]` Returns an Indexed property type for the given keys */
 export function Index<T extends TSchema, K extends PropertyKey[]>(T: T, K: readonly [...K], options?: SchemaOptions): TIndex<T, K>
 /** `[Json]` Returns an Indexed property type for the given keys */
-export function Index(T: TSchema, K: any, options: SchemaOptions = {}): any {
+export function Index(T: TSchema, K: any, options?: SchemaOptions): any {
+  // mapped-types
+  if (IsMappedResult(K)) return IndexFromMappedResult(T, K, options)
+  if (IsMappedKey(K)) return IndexFromMappedKey(T, K, options)
   // prettier-ignore
-  return (
-    IsMappedResult(K) ? CloneType(IndexFromMappedResult(T, K, options)) :
-    IsMappedKey(K) ? CloneType(IndexFromMappedKey(T, K, options)) :
-    IsSchema(K) ? CloneType(FromSchema(T, IndexPropertyKeys(K)), options) :
-    CloneType(FromSchema(T, K as string[]), options)
-  )
+  return CreateType(
+    IsSchema(K) 
+      ? FromSchema(T, IndexPropertyKeys(K)) 
+      : FromSchema(T, K as string[])
+  , options) as never
 }

--- a/src/type/instance-type/instance-type.ts
+++ b/src/type/instance-type/instance-type.ts
@@ -26,13 +26,13 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { TConstructor } from '../constructor/index'
-import { CloneType } from '../clone/type'
 
 export type TInstanceType<T extends TConstructor<TSchema[], TSchema>> = T['returns']
 
 /** `[JavaScript]` Extracts the InstanceType from the given Constructor type */
-export function InstanceType<T extends TConstructor<any[], any>>(schema: T, options: SchemaOptions = {}): TInstanceType<T> {
-  return CloneType(schema.returns, options)
+export function InstanceType<T extends TConstructor<any[], any>>(schema: T, options?: SchemaOptions): TInstanceType<T> {
+  return CreateType(schema.returns, options)
 }

--- a/src/type/integer/integer.ts
+++ b/src/type/integer/integer.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -42,10 +43,6 @@ export interface TInteger extends TSchema, IntegerOptions {
   type: 'integer'
 }
 /** `[Json]` Creates an Integer type */
-export function Integer(options: IntegerOptions = {}): TInteger {
-  return {
-    ...options,
-    [Kind]: 'Integer',
-    type: 'integer',
-  } as never
+export function Integer(options?: IntegerOptions): TInteger {
+  return CreateType({ [Kind]: 'Integer', type: 'integer' }, options) as never
 }

--- a/src/type/intersect/intersect-create.ts
+++ b/src/type/intersect/intersect-create.ts
@@ -26,10 +26,11 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema } from '../schema/index'
 import { Kind } from '../symbols/index'
-import { CloneType, CloneRest } from '../clone/type'
 import type { TIntersect, IntersectOptions } from './intersect-type'
+import { IsObject as IsObjectValue } from '../guard/value'
 
 // ------------------------------------------------------------------
 // TypeGuard
@@ -39,14 +40,14 @@ import { IsObject, IsSchema } from '../guard/kind'
 // IntersectCreate
 // ------------------------------------------------------------------
 // prettier-ignore
-export function IntersectCreate<T extends TSchema[]>(T: [...T], options: IntersectOptions): TIntersect<T> {
+export function IntersectCreate<T extends TSchema[]>(T: [...T], options: IntersectOptions = {}): TIntersect<T> {
   const allObjects = T.every((schema) => IsObject(schema))
   const clonedUnevaluatedProperties = IsSchema(options.unevaluatedProperties) 
-    ? { unevaluatedProperties: CloneType(options.unevaluatedProperties) } 
+    ? { unevaluatedProperties: options.unevaluatedProperties } 
     : {}
-  return (
+  return CreateType(
     (options.unevaluatedProperties === false || IsSchema(options.unevaluatedProperties) || allObjects
-      ? { ...options, ...clonedUnevaluatedProperties, [Kind]: 'Intersect', type: 'object', allOf: CloneRest(T) }
-      : { ...options, ...clonedUnevaluatedProperties, [Kind]: 'Intersect', allOf: CloneRest(T) })
-  ) as never
+      ? { ...clonedUnevaluatedProperties, [Kind]: 'Intersect', type: 'object', allOf: T }
+      : { ...clonedUnevaluatedProperties, [Kind]: 'Intersect', allOf: T })
+  , options) as never
 }

--- a/src/type/intersect/intersect-create.ts
+++ b/src/type/intersect/intersect-create.ts
@@ -30,7 +30,6 @@ import { CreateType } from '../create/type'
 import type { TSchema } from '../schema/index'
 import { Kind } from '../symbols/index'
 import type { TIntersect, IntersectOptions } from './intersect-type'
-import { IsObject as IsObjectValue } from '../guard/value'
 
 // ------------------------------------------------------------------
 // TypeGuard

--- a/src/type/intersect/intersect-evaluated.ts
+++ b/src/type/intersect/intersect-evaluated.ts
@@ -28,9 +28,8 @@ THE SOFTWARE.
 
 import type { SchemaOptions, TSchema } from '../schema/index'
 import { OptionalKind } from '../symbols/index'
-import { CloneType } from '../clone/type'
+import { CreateType } from '../create/type'
 import { Discard } from '../discard/index'
-
 import { Never, type TNever } from '../never/index'
 import { Optional, type TOptional } from '../optional/index'
 import type { TReadonly } from '../readonly/index'
@@ -116,8 +115,8 @@ export type TIntersectEvaluated<T extends TSchema[]> = (
 )
 /** `[Json]` Creates an evaluated Intersect type */
 export function IntersectEvaluated<T extends TSchema[], R = TIntersectEvaluated<T>>(T: [...T], options: IntersectOptions = {}): R {
-  if (T.length === 0) return Never(options) as R
-  if (T.length === 1) return CloneType(T[0], options) as R
+  if (T.length === 0) return Never(options) as never
+  if (T.length === 1) return CreateType(T[0], options) as never
   if (T.some((schema) => IsTransform(schema))) throw new Error('Cannot intersect transform types')
-  return ResolveIntersect(T, options) as R
+  return ResolveIntersect(T, options) as never
 }

--- a/src/type/intersect/intersect.ts
+++ b/src/type/intersect/intersect.ts
@@ -26,10 +26,9 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema } from '../schema/index'
-import { CloneType } from '../clone/type'
 import { Never, type TNever } from '../never/index'
-
 import { TIntersect, IntersectOptions } from './intersect-type'
 import { IntersectCreate } from './intersect-create'
 
@@ -47,9 +46,9 @@ export type Intersect<T extends TSchema[]> = (
   TIntersect<T>
 )
 /** `[Json]` Creates an evaluated Intersect type */
-export function Intersect<T extends TSchema[]>(T: [...T], options: IntersectOptions = {}): Intersect<T> {
-  if (T.length === 0) return Never(options) as Intersect<T>
-  if (T.length === 1) return CloneType(T[0], options) as Intersect<T>
+export function Intersect<T extends TSchema[]>(T: [...T], options?: IntersectOptions): Intersect<T> {
+  if (T.length === 0) return Never(options) as never
+  if (T.length === 1) return CreateType(T[0], options) as never
   if (T.some((schema) => IsTransform(schema))) throw new Error('Cannot intersect transform types')
-  return IntersectCreate(T, options) as Intersect<T>
+  return IntersectCreate(T, options) as never
 }

--- a/src/type/intrinsic/intrinsic-from-mapped-key.ts
+++ b/src/type/intrinsic/intrinsic-from-mapped-key.ts
@@ -70,9 +70,17 @@ function MappedIntrinsicPropertyKeys<
   K extends PropertyKey[],
   M extends IntrinsicMode
 >(K: [...K], M: M, options: SchemaOptions): TMappedIntrinsicPropertyKeys<K, M> {
-  return K.reduce((Acc, L) => {
-    return { ...Acc, ...MappedIntrinsicPropertyKey(L, M, options) }
+  const result = K.reduce((Acc, L) => {
+    console.log('--------------------------')
+    const X = MappedIntrinsicPropertyKey(L, M, options)
+    const R = { ...Acc, ...X }
+    console.log('BEFORE', Acc)
+    console.log('APPLY', X)
+    console.log('AFTER', R)
+    return R
   }, {} as TProperties) as never
+  console.log('OUTPUT', result)
+  return result
 }
 // ------------------------------------------------------------------
 // MappedIntrinsicProperties

--- a/src/type/intrinsic/intrinsic-from-mapped-key.ts
+++ b/src/type/intrinsic/intrinsic-from-mapped-key.ts
@@ -32,6 +32,7 @@ import { Assert } from '../helpers/index'
 import { MappedResult, type TMappedResult, type TMappedKey } from '../mapped/index'
 import { Intrinsic, type TIntrinsic, type IntrinsicMode } from './intrinsic'
 import { Literal, type TLiteral, type TLiteralValue } from '../literal/index'
+import { Clone } from '../clone/value'
 
 // ------------------------------------------------------------------
 // MappedIntrinsicPropertyKey
@@ -49,7 +50,7 @@ function MappedIntrinsicPropertyKey<
   M extends IntrinsicMode,
 >(K: K, M: M, options: SchemaOptions): TMappedIntrinsicPropertyKey<K, M> {
   return {
-    [K]: Intrinsic(Literal(K as TLiteralValue), M, options)
+    [K]: Intrinsic(Literal(K as TLiteralValue), M, Clone(options))
   } as never
 }
 // ------------------------------------------------------------------
@@ -71,15 +72,9 @@ function MappedIntrinsicPropertyKeys<
   M extends IntrinsicMode
 >(K: [...K], M: M, options: SchemaOptions): TMappedIntrinsicPropertyKeys<K, M> {
   const result = K.reduce((Acc, L) => {
-    console.log('--------------------------')
-    const X = MappedIntrinsicPropertyKey(L, M, options)
-    const R = { ...Acc, ...X }
-    console.log('BEFORE', Acc)
-    console.log('APPLY', X)
-    console.log('AFTER', R)
-    return R
+    return { ...Acc, ...MappedIntrinsicPropertyKey(L, M, options) }
   }, {} as TProperties) as never
-  console.log('OUTPUT', result)
+  
   return result
 }
 // ------------------------------------------------------------------

--- a/src/type/intrinsic/intrinsic.ts
+++ b/src/type/intrinsic/intrinsic.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { TemplateLiteral, TemplateLiteralParseExact, IsTemplateLiteralExpressionFinite, TemplateLiteralExpressionGenerate, type TTemplateLiteral, type TTemplateLiteralKind } from '../template-literal/index'
 import { IntrinsicFromMappedKey, type TIntrinsicFromMappedKey } from './intrinsic-from-mapped-key'
@@ -134,7 +135,7 @@ export function Intrinsic<T extends TMappedKey, M extends IntrinsicMode>(schema:
 /** Applies an intrinsic string manipulation to the given type. */
 export function Intrinsic<T extends TSchema, M extends IntrinsicMode>(schema: T, mode: M, options?: SchemaOptions): TIntrinsic<T, M>
 /** Applies an intrinsic string manipulation to the given type. */
-export function Intrinsic(schema: TSchema, mode: IntrinsicMode, options: SchemaOptions = {}): any {
+export function Intrinsic(schema: TSchema, mode: IntrinsicMode, options: SchemaOptions = {}): never {
   // prettier-ignore
   return (
     // Intrinsic-Mapped-Inference
@@ -143,6 +144,7 @@ export function Intrinsic(schema: TSchema, mode: IntrinsicMode, options: SchemaO
     IsTemplateLiteral(schema) ? FromTemplateLiteral(schema, mode, schema) :
     IsUnion(schema) ? Union(FromRest(schema.anyOf, mode), options) :
     IsLiteral(schema) ? Literal(FromLiteralValue(schema.const, mode), options) :
-    schema
-  )
+    // Default Type
+    CreateType(schema, options)
+  ) as never
 }

--- a/src/type/iterator/iterator.ts
+++ b/src/type/iterator/iterator.ts
@@ -26,9 +26,9 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Static } from '../static/index'
-import { CloneType } from '../clone/type'
 import { Kind } from '../symbols/index'
 
 export interface TIterator<T extends TSchema = TSchema> extends TSchema {
@@ -38,11 +38,6 @@ export interface TIterator<T extends TSchema = TSchema> extends TSchema {
   items: T
 }
 /** `[JavaScript]` Creates an Iterator type */
-export function Iterator<T extends TSchema>(items: T, options: SchemaOptions = {}): TIterator<T> {
-  return {
-    ...options,
-    [Kind]: 'Iterator',
-    type: 'Iterator',
-    items: CloneType(items),
-  } as never
+export function Iterator<T extends TSchema>(items: T, options?: SchemaOptions): TIterator<T> {
+  return CreateType({ [Kind]: 'Iterator', type: 'Iterator', items }, options) as never
 }

--- a/src/type/keyof/keyof-from-mapped-result.ts
+++ b/src/type/keyof/keyof-from-mapped-result.ts
@@ -31,7 +31,7 @@ import type { Ensure, Evaluate } from '../helpers/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult } from '../mapped/index'
 import { KeyOf, type TKeyOf } from './keyof'
-
+import { Clone } from '../clone/value'
 // ------------------------------------------------------------------
 // FromProperties
 // ------------------------------------------------------------------
@@ -46,7 +46,7 @@ function FromProperties<
   K extends TProperties
 >(K: K, options?: SchemaOptions): TFromProperties<K> {
   const Acc = {} as TProperties
-  for(const K2 of globalThis.Object.getOwnPropertyNames(K)) Acc[K2] = KeyOf(K[K2], options)
+  for(const K2 of globalThis.Object.getOwnPropertyNames(K)) Acc[K2] = KeyOf(K[K2], Clone(options))
   return Acc as never
 }
 // ------------------------------------------------------------------

--- a/src/type/keyof/keyof-from-mapped-result.ts
+++ b/src/type/keyof/keyof-from-mapped-result.ts
@@ -44,7 +44,7 @@ type TFromProperties<
 // prettier-ignore
 function FromProperties<
   K extends TProperties
->(K: K, options: SchemaOptions): TFromProperties<K> {
+>(K: K, options?: SchemaOptions): TFromProperties<K> {
   const Acc = {} as TProperties
   for(const K2 of globalThis.Object.getOwnPropertyNames(K)) Acc[K2] = KeyOf(K[K2], options)
   return Acc as never
@@ -61,7 +61,7 @@ type TFromMappedResult<
 // prettier-ignore
 function FromMappedResult<
   R extends TMappedResult
->(R: R, options: SchemaOptions): TFromMappedResult<R> {
+>(R: R, options?: SchemaOptions): TFromMappedResult<R> {
   return FromProperties(R.properties, options) as never
 }
 // ------------------------------------------------------------------
@@ -78,7 +78,7 @@ export type TKeyOfFromMappedResult<
 export function KeyOfFromMappedResult<
   R extends TMappedResult,
   P extends TProperties = TFromMappedResult<R>
->(R: R, options: SchemaOptions): TMappedResult<P> {
+>(R: R, options?: SchemaOptions): TMappedResult<P> {
   const P = FromMappedResult(R, options)
   return MappedResult(P) as never
 }

--- a/src/type/keyof/keyof.ts
+++ b/src/type/keyof/keyof.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema } from '../schema/index'
 import type { Assert, Ensure } from '../helpers/index'
 import type { TMappedResult } from '../mapped/index'
@@ -34,7 +35,6 @@ import { Literal, type TLiteral, type TLiteralValue } from '../literal/index'
 import { Number, type TNumber } from '../number/index'
 import { KeyOfPropertyKeys, type TKeyOfPropertyKeys } from './keyof-property-keys'
 import { UnionEvaluated, type TUnionEvaluated } from '../union/index'
-import { CloneType } from '../clone/type'
 import { KeyOfFromMappedResult, type TKeyOfFromMappedResult } from './keyof-from-mapped-result'
 
 // ------------------------------------------------------------------
@@ -73,13 +73,13 @@ export function KeyOf<T extends TMappedResult>(T: T, options?: SchemaOptions): T
 /** `[Json]` Creates a KeyOf type */
 export function KeyOf<T extends TSchema>(T: T, options?: SchemaOptions): TKeyOf<T>
 /** `[Json]` Creates a KeyOf type */
-export function KeyOf(T: TSchema, options: SchemaOptions = {}): any {
+export function KeyOf(T: TSchema, options?: SchemaOptions): never {
   if (IsMappedResult(T)) {
-    return KeyOfFromMappedResult(T, options)
+    return KeyOfFromMappedResult(T, options) as never
   } else {
     const K = KeyOfPropertyKeys(T)
     const S = KeyOfPropertyKeysToRest(K)
     const U = UnionEvaluated(S)
-    return CloneType(U, options)
+    return CreateType(U, options) as never
   }
 }

--- a/src/type/literal/literal.ts
+++ b/src/type/literal/literal.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -43,11 +44,13 @@ export interface TLiteral<T extends TLiteralValue = TLiteralValue> extends TSche
   const: T
 }
 /** `[Json]` Creates a Literal type */
-export function Literal<T extends TLiteralValue>(value: T, options: SchemaOptions = {}): TLiteral<T> {
-  return {
-    ...options,
-    [Kind]: 'Literal',
-    const: value,
-    type: typeof value as 'string' | 'number' | 'boolean',
-  } as never
+export function Literal<T extends TLiteralValue>(value: T, options?: SchemaOptions): TLiteral<T> {
+  return CreateType(
+    {
+      [Kind]: 'Literal',
+      const: value,
+      type: typeof value as 'string' | 'number' | 'boolean',
+    },
+    options,
+  ) as never
 }

--- a/src/type/mapped/mapped-key.ts
+++ b/src/type/mapped/mapped-key.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -36,8 +37,8 @@ export interface TMappedKey<T extends PropertyKey[] = PropertyKey[]> extends TSc
 }
 // prettier-ignore
 export function MappedKey<T extends PropertyKey[]>(T: [...T]): TMappedKey<T> {
-  return {
+  return CreateType({
     [Kind]: 'MappedKey',
     keys: T
-  } as never
+  }) as never
 }

--- a/src/type/mapped/mapped-result.ts
+++ b/src/type/mapped/mapped-result.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema } from '../schema/index'
 import type { TProperties } from '../object/index'
 import { Kind } from '../symbols/index'
@@ -37,8 +38,8 @@ export interface TMappedResult<T extends TProperties = TProperties> extends TSch
 }
 // prettier-ignore
 export function MappedResult<T extends TProperties>(properties: T): TMappedResult<T> {
-  return {
+  return CreateType({
     [Kind]: 'MappedResult',
     properties
-  } as never
+  }) as never
 }

--- a/src/type/mapped/mapped.ts
+++ b/src/type/mapped/mapped.ts
@@ -29,7 +29,7 @@ THE SOFTWARE.
 import type { TSchema } from '../schema/index'
 import type { Ensure, Evaluate, Assert } from '../helpers/index'
 import { Kind, OptionalKind, ReadonlyKind } from '../symbols/index'
-import { CloneType } from '../clone/type'
+import { CreateType } from '../create/type'
 import { Discard } from '../discard/index'
 // evaluation types
 import { Array, type TArray } from '../array/index'
@@ -261,9 +261,9 @@ export function Mapped<K extends TSchema, I extends PropertyKey[] = TIndexProper
 /** `[Json]` Creates a Mapped object type */
 export function Mapped<K extends PropertyKey[], F extends TMappedFunction<K> = TMappedFunction<K>, R extends TMapped<K, F> = TMapped<K, F>>(key: [...K], map: F, options?: ObjectOptions): R
 /** `[Json]` Creates a Mapped object type */
-export function Mapped(key: any, map: Function, options: ObjectOptions = {}) {
+export function Mapped(key: any, map: Function, options?: ObjectOptions) {
   const K = IsSchema(key) ? IndexPropertyKeys(key) : (key as PropertyKey[])
   const RT = map({ [Kind]: 'MappedKey', keys: K } as TMappedKey)
   const R = MappedFunctionReturnType(K, RT)
-  return CloneType(Object(R), options)
+  return Object(R, options)
 }

--- a/src/type/never/never.ts
+++ b/src/type/never/never.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -35,10 +36,6 @@ export interface TNever extends TSchema {
   not: {}
 }
 /** `[Json]` Creates a Never type */
-export function Never(options: SchemaOptions = {}): TNever {
-  return {
-    ...options,
-    [Kind]: 'Never',
-    not: {},
-  } as never
+export function Never(options?: SchemaOptions): TNever {
+  return CreateType({ [Kind]: 'Never', not: {} }, options) as never
 }

--- a/src/type/not/not.ts
+++ b/src/type/not/not.ts
@@ -26,9 +26,9 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Static } from '../static/index'
-import { CloneType } from '../clone/type'
 import { Kind } from '../symbols/index'
 
 export interface TNot<T extends TSchema = TSchema> extends TSchema {
@@ -37,10 +37,6 @@ export interface TNot<T extends TSchema = TSchema> extends TSchema {
   not: T
 }
 /** `[Json]` Creates a Not type */
-export function Not<T extends TSchema>(schema: T, options?: SchemaOptions): TNot<T> {
-  return {
-    ...options,
-    [Kind]: 'Not',
-    not: CloneType(schema),
-  } as never
+export function Not<T extends TSchema>(not: T, options?: SchemaOptions): TNot<T> {
+  return CreateType({ [Kind]: 'Not', not }, options) as never
 }

--- a/src/type/null/null.ts
+++ b/src/type/null/null.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -35,10 +36,6 @@ export interface TNull extends TSchema {
   type: 'null'
 }
 /** `[Json]` Creates a Null type */
-export function Null(options: SchemaOptions = {}): TNull {
-  return {
-    ...options,
-    [Kind]: 'Null',
-    type: 'null',
-  } as never
+export function Null(options?: SchemaOptions): TNull {
+  return CreateType({ [Kind]: 'Null', type: 'null' }, options) as never
 }

--- a/src/type/number/number.ts
+++ b/src/type/number/number.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -42,10 +43,6 @@ export interface TNumber extends TSchema, NumberOptions {
   type: 'number'
 }
 /** `[Json]` Creates a Number type */
-export function Number(options: NumberOptions = {}): TNumber {
-  return {
-    ...options,
-    [Kind]: 'Number',
-    type: 'number',
-  } as never
+export function Number(options?: NumberOptions): TNumber {
+  return CreateType({ [Kind]: 'Number', type: 'number' }, options) as never
 }

--- a/src/type/omit/omit-from-mapped-key.ts
+++ b/src/type/omit/omit-from-mapped-key.ts
@@ -45,7 +45,7 @@ type TFromPropertyKey<
 function FromPropertyKey<
   T extends TSchema,
   K extends PropertyKey,
->(T: T, K: K, options: SchemaOptions): TFromPropertyKey<T, K> {
+>(T: T, K: K, options?: SchemaOptions): TFromPropertyKey<T, K> {
   return {
     [K]: Omit(T, [K], options)
   } as never
@@ -67,7 +67,7 @@ type TFromPropertyKeys<
 function FromPropertyKeys<
   T extends TSchema,
   K extends PropertyKey[]
->(T: T, K: [...K], options: SchemaOptions): TFromPropertyKeys<T, K> {
+>(T: T, K: [...K], options?: SchemaOptions): TFromPropertyKeys<T, K> {
   return K.reduce((Acc, LK) => {
     return { ...Acc, ...FromPropertyKey(T, LK, options) }
   }, {} as TProperties) as never
@@ -86,7 +86,7 @@ type TFromMappedKey<
 function FromMappedKey<
   T extends TSchema,
   K extends TMappedKey,
->(T: T, K: K, options: SchemaOptions): TFromMappedKey<T, K> {
+>(T: T, K: K, options?: SchemaOptions): TFromMappedKey<T, K> {
   return FromPropertyKeys(T, K.keys, options) as never
 }
 // ------------------------------------------------------------------
@@ -105,7 +105,7 @@ export function OmitFromMappedKey<
   T extends TSchema,
   K extends TMappedKey,
   P extends TProperties = TFromMappedKey<T, K>
->(T: T, K: K, options: SchemaOptions): TMappedResult<P> {
+>(T: T, K: K, options?: SchemaOptions): TMappedResult<P> {
   const P = FromMappedKey(T, K, options)
   return MappedResult(P) as never
 }

--- a/src/type/omit/omit-from-mapped-key.ts
+++ b/src/type/omit/omit-from-mapped-key.ts
@@ -30,6 +30,7 @@ import type { TSchema, SchemaOptions } from '../schema/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult, type TMappedKey } from '../mapped/index'
 import { Omit, type TOmit } from './omit'
+import { Clone } from '../clone/value'
 
 // ------------------------------------------------------------------
 // FromPropertyKey
@@ -47,7 +48,7 @@ function FromPropertyKey<
   K extends PropertyKey,
 >(T: T, K: K, options?: SchemaOptions): TFromPropertyKey<T, K> {
   return {
-    [K]: Omit(T, [K], options)
+    [K]: Omit(T, [K], Clone(options))
   } as never
 }
 // ------------------------------------------------------------------

--- a/src/type/omit/omit-from-mapped-result.ts
+++ b/src/type/omit/omit-from-mapped-result.ts
@@ -46,7 +46,7 @@ type TFromProperties<
 function FromProperties<
   P extends TProperties,
   K extends PropertyKey[],
->(P: P, K: [...K], options: SchemaOptions): TFromProperties<P, K> {
+>(P: P, K: [...K], options?: SchemaOptions): TFromProperties<P, K> {
   const Acc = {} as TProperties
   for(const K2 of globalThis.Object.getOwnPropertyNames(P)) Acc[K2] = Omit(P[K2], K, options)
   return Acc as never
@@ -65,7 +65,7 @@ type TFromMappedResult<
 function FromMappedResult<
   R extends TMappedResult,
   K extends PropertyKey[]
->(R: R, K: [...K], options: SchemaOptions): TFromMappedResult<R, K> {
+>(R: R, K: [...K], options?: SchemaOptions): TFromMappedResult<R, K> {
   return FromProperties(R.properties, K, options) as never
 }
 // ------------------------------------------------------------------
@@ -84,7 +84,7 @@ export function OmitFromMappedResult<
   R extends TMappedResult,
   K extends PropertyKey[],
   P extends TProperties = TFromMappedResult<R, K>
->(R: R, K: [...K], options: SchemaOptions): TMappedResult<P> {
+>(R: R, K: [...K], options?: SchemaOptions): TMappedResult<P> {
   const P = FromMappedResult(R, K, options)
   return MappedResult(P) as never
 }

--- a/src/type/omit/omit-from-mapped-result.ts
+++ b/src/type/omit/omit-from-mapped-result.ts
@@ -31,6 +31,7 @@ import type { Ensure, Evaluate } from '../helpers/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult } from '../mapped/index'
 import { Omit, type TOmit } from './omit'
+import { Clone } from '../clone/value'
 
 // ------------------------------------------------------------------
 // FromProperties
@@ -48,7 +49,7 @@ function FromProperties<
   K extends PropertyKey[],
 >(P: P, K: [...K], options?: SchemaOptions): TFromProperties<P, K> {
   const Acc = {} as TProperties
-  for(const K2 of globalThis.Object.getOwnPropertyNames(P)) Acc[K2] = Omit(P[K2], K, options)
+  for(const K2 of globalThis.Object.getOwnPropertyNames(P)) Acc[K2] = Omit(P[K2], K, Clone(options))
   return Acc as never
 }
 // ------------------------------------------------------------------

--- a/src/type/omit/omit.ts
+++ b/src/type/omit/omit.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { TupleToUnion, Evaluate } from '../helpers/index'
 import { type TRecursive } from '../recursive/index'
@@ -36,7 +37,6 @@ import { Object, type TObject, type TProperties } from '../object/index'
 import { IndexPropertyKeys, type TIndexPropertyKeys } from '../indexed/index'
 import { Discard } from '../discard/index'
 import { TransformKind } from '../symbols/index'
-import { CloneType } from '../clone/type'
 import { OmitFromMappedKey, type TOmitFromMappedKey } from './omit-from-mapped-key'
 import { OmitFromMappedResult, type TOmitFromMappedResult } from './omit-from-mapped-result'
 
@@ -115,13 +115,13 @@ export function Omit<T extends TSchema, K extends TMappedKey>(T: T, K: K, option
 export function Omit<T extends TSchema, K extends TSchema, I extends PropertyKey[] = TIndexPropertyKeys<K>>(T: T, K: K, options?: SchemaOptions): TOmit<T, I>
 /** `[Json]` Constructs a type whose keys are omitted from the given type */
 export function Omit<T extends TSchema, K extends PropertyKey[]>(T: T, K: readonly [...K], options?: SchemaOptions): TOmit<T, K>
-export function Omit(T: TSchema, K: any, options: SchemaOptions = {}): any {
+export function Omit(T: TSchema, K: any, options?: SchemaOptions): any {
   // mapped
   if (IsMappedKey(K)) return OmitFromMappedKey(T, K, options)
   if (IsMappedResult(T)) return OmitFromMappedResult(T, K, options)
   // non-mapped
   const I = IsSchema(K) ? IndexPropertyKeys(K) : (K as string[])
   const D = Discard(T, [TransformKind, '$id', 'required']) as TSchema
-  const R = CloneType(OmitResolve(T, I), options)
-  return { ...D, ...R }
+  const R = OmitResolve(T, I)
+  return CreateType({ ...D, ...R }, options)
 }

--- a/src/type/optional/optional.ts
+++ b/src/type/optional/optional.ts
@@ -26,10 +26,10 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema } from '../schema/index'
 import type { Ensure } from '../helpers/index'
 import { OptionalKind } from '../symbols/index'
-import { CloneType } from '../clone/type'
 import { Discard } from '../discard/index'
 import type { TMappedResult } from '../mapped/index'
 
@@ -40,14 +40,14 @@ import { IsMappedResult } from '../guard/kind'
 // ------------------------------------------------------------------
 type TRemoveOptional<T extends TSchema> = T extends TOptional<infer S> ? S : T
 function RemoveOptional<T extends TSchema>(schema: T) {
-  return Discard(CloneType(schema), [OptionalKind])
+  return CreateType(Discard(schema, [OptionalKind]))
 }
 // ------------------------------------------------------------------
 // AddOptional
 // ------------------------------------------------------------------
 type TAddOptional<T extends TSchema> = T extends TOptional<infer S> ? TOptional<S> : Ensure<TOptional<T>>
 function AddOptional<T extends TSchema>(schema: T) {
-  return { ...CloneType(schema), [OptionalKind]: 'Optional' }
+  return CreateType({ ...schema, [OptionalKind]: 'Optional' })
 }
 // prettier-ignore
 export type TOptionalWithFlag<T extends TSchema, F extends boolean> = 

--- a/src/type/parameters/parameters.ts
+++ b/src/type/parameters/parameters.ts
@@ -30,7 +30,6 @@ import type { TSchema, SchemaOptions } from '../schema/index'
 import type { TFunction } from '../function/index'
 import type { Ensure } from '../helpers/index'
 import { Tuple, type TTuple } from '../tuple/index'
-import { CloneRest } from '../clone/type'
 
 // ------------------------------------------------------------------
 // Parameters
@@ -38,6 +37,6 @@ import { CloneRest } from '../clone/type'
 export type TParameters<T extends TFunction> = Ensure<TTuple<T['parameters']>>
 
 /** `[JavaScript]` Extracts the Parameters from the given Function type */
-export function Parameters<T extends TFunction<TSchema[], TSchema>>(schema: T, options: SchemaOptions = {}): TParameters<T> {
-  return Tuple(CloneRest(schema.parameters), { ...options })
+export function Parameters<T extends TFunction<TSchema[], TSchema>>(schema: T, options?: SchemaOptions): TParameters<T> {
+  return Tuple(schema.parameters, options)
 }

--- a/src/type/partial/partial-from-mapped-result.ts
+++ b/src/type/partial/partial-from-mapped-result.ts
@@ -44,7 +44,7 @@ type TFromProperties<
 // prettier-ignore
 function FromProperties<
   P extends TProperties
->(K: P, options: SchemaOptions): TFromProperties<P> {
+>(K: P, options?: SchemaOptions): TFromProperties<P> {
   const Acc = {} as TProperties
   for(const K2 of globalThis.Object.getOwnPropertyNames(K)) Acc[K2] = Partial(K[K2], options)
   return Acc as never
@@ -61,7 +61,7 @@ type TFromMappedResult<
 // prettier-ignore
 function FromMappedResult<
   R extends TMappedResult
->(R: R, options: SchemaOptions): TFromMappedResult<R> {
+>(R: R, options?: SchemaOptions): TFromMappedResult<R> {
   return FromProperties(R.properties, options) as never
 }
 // ------------------------------------------------------------------
@@ -78,7 +78,7 @@ export type TPartialFromMappedResult<
 export function PartialFromMappedResult<
   R extends TMappedResult,
   P extends TProperties = TFromMappedResult<R>
->(R: R, options: SchemaOptions): TMappedResult<P> {
+>(R: R, options?: SchemaOptions): TMappedResult<P> {
   const P = FromMappedResult(R, options)
   return MappedResult(P) as never
 }

--- a/src/type/partial/partial-from-mapped-result.ts
+++ b/src/type/partial/partial-from-mapped-result.ts
@@ -31,6 +31,7 @@ import type { Ensure, Evaluate } from '../helpers/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult } from '../mapped/index'
 import { Partial, type TPartial } from './partial'
+import { Clone } from '../clone/value'
 
 // ------------------------------------------------------------------
 // FromProperties
@@ -46,7 +47,7 @@ function FromProperties<
   P extends TProperties
 >(K: P, options?: SchemaOptions): TFromProperties<P> {
   const Acc = {} as TProperties
-  for(const K2 of globalThis.Object.getOwnPropertyNames(K)) Acc[K2] = Partial(K[K2], options)
+  for(const K2 of globalThis.Object.getOwnPropertyNames(K)) Acc[K2] = Partial(K[K2], Clone(options))
   return Acc as never
 }
 // ------------------------------------------------------------------

--- a/src/type/partial/partial.ts
+++ b/src/type/partial/partial.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Evaluate } from '../helpers/index'
 import type { TMappedResult } from '../mapped/index'
@@ -38,7 +39,6 @@ import { type TIntersect, Intersect } from '../intersect/index'
 import { type TUnion, Union } from '../union/index'
 import { Discard } from '../discard/index'
 import { TransformKind } from '../symbols/index'
-import { CloneType } from '../clone/type'
 
 import { PartialFromMappedResult, type TPartialFromMappedResult } from './partial-from-mapped-result'
 
@@ -104,9 +104,9 @@ export function Partial<T extends TMappedResult>(T: T, options?: SchemaOptions):
 /** `[Json]` Constructs a type where all properties are optional */
 export function Partial<T extends TSchema>(T: T, options?: SchemaOptions): TPartial<T>
 /** `[Json]` Constructs a type where all properties are optional */
-export function Partial(T: TSchema, options: SchemaOptions = {}): any {
+export function Partial(T: TSchema, options?: SchemaOptions): any {
   if (IsMappedResult(T)) return PartialFromMappedResult(T, options)
   const D = Discard(T, [TransformKind, '$id', 'required']) as TSchema
-  const R = CloneType(PartialResolve(T), options)
-  return { ...D, ...R } as never
+  const R = PartialResolve(T)
+  return CreateType({ ...options, ...D, ...R }) as never
 }

--- a/src/type/pick/pick-from-mapped-key.ts
+++ b/src/type/pick/pick-from-mapped-key.ts
@@ -30,6 +30,7 @@ import type { TSchema, SchemaOptions } from '../schema/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult, type TMappedKey } from '../mapped/index'
 import { Pick, type TPick } from './pick'
+import { Clone } from '../clone/value'
 
 // ------------------------------------------------------------------
 // FromPropertyKey
@@ -47,7 +48,7 @@ function FromPropertyKey<
   K extends PropertyKey,
 >(T: T, K: K, options?: SchemaOptions): TFromPropertyKey<T, K> {
   return {
-    [K]: Pick(T, [K], options)
+    [K]: Pick(T, [K], Clone(options))
   } as never
 }
 // ------------------------------------------------------------------

--- a/src/type/pick/pick-from-mapped-key.ts
+++ b/src/type/pick/pick-from-mapped-key.ts
@@ -45,7 +45,7 @@ type TFromPropertyKey<
 function FromPropertyKey<
   T extends TSchema,
   K extends PropertyKey,
->(T: T, K: K, options: SchemaOptions): TFromPropertyKey<T, K> {
+>(T: T, K: K, options?: SchemaOptions): TFromPropertyKey<T, K> {
   return {
     [K]: Pick(T, [K], options)
   } as never
@@ -67,7 +67,7 @@ type TFromPropertyKeys<
 function FromPropertyKeys<
   T extends TSchema,
   K extends PropertyKey[]
->(T: T, K: [...K], options: SchemaOptions): TFromPropertyKeys<T, K> {
+>(T: T, K: [...K], options?: SchemaOptions): TFromPropertyKeys<T, K> {
   return K.reduce((Acc, LK) => {
     return { ...Acc, ...FromPropertyKey(T, LK, options) }
   }, {} as TProperties) as never
@@ -86,7 +86,7 @@ type TFromMappedKey<
 function FromMappedKey<
   T extends TSchema,
   K extends TMappedKey,
->(T: T, K: K, options: SchemaOptions): TFromMappedKey<T, K> {
+>(T: T, K: K, options?: SchemaOptions): TFromMappedKey<T, K> {
   return FromPropertyKeys(T, K.keys, options) as never
 }
 // ------------------------------------------------------------------
@@ -105,7 +105,7 @@ export function PickFromMappedKey<
   T extends TSchema,
   K extends TMappedKey,
   P extends TProperties = TFromMappedKey<T, K>
->(T: T, K: K, options: SchemaOptions): TMappedResult<P> {
+>(T: T, K: K, options?: SchemaOptions): TMappedResult<P> {
   const P = FromMappedKey(T, K, options)
   return MappedResult(P) as never
 }

--- a/src/type/pick/pick-from-mapped-result.ts
+++ b/src/type/pick/pick-from-mapped-result.ts
@@ -31,6 +31,7 @@ import type { Ensure, Evaluate } from '../helpers/index'
 import type { TProperties } from '../object/index'
 import { MappedResult, type TMappedResult } from '../mapped/index'
 import { Pick, type TPick } from './pick'
+import { Clone } from '../clone/value'
 
 // ------------------------------------------------------------------
 // FromProperties
@@ -48,7 +49,7 @@ function FromProperties<
   K extends PropertyKey[],
 >(P: P, K: [...K], options?: SchemaOptions): TFromProperties<P, K> {
   const Acc = {} as TProperties
-  for(const K2 of globalThis.Object.getOwnPropertyNames(P)) Acc[K2] = Pick(P[K2], K, options)
+  for(const K2 of globalThis.Object.getOwnPropertyNames(P)) Acc[K2] = Pick(P[K2], K, Clone(options))
   return Acc as never
 }
 // ------------------------------------------------------------------

--- a/src/type/pick/pick-from-mapped-result.ts
+++ b/src/type/pick/pick-from-mapped-result.ts
@@ -46,7 +46,7 @@ type TFromProperties<
 function FromProperties<
   P extends TProperties,
   K extends PropertyKey[],
->(P: P, K: [...K], options: SchemaOptions): TFromProperties<P, K> {
+>(P: P, K: [...K], options?: SchemaOptions): TFromProperties<P, K> {
   const Acc = {} as TProperties
   for(const K2 of globalThis.Object.getOwnPropertyNames(P)) Acc[K2] = Pick(P[K2], K, options)
   return Acc as never
@@ -65,7 +65,7 @@ type TFromMappedResult<
 function FromMappedResult<
   R extends TMappedResult,
   K extends PropertyKey[]
->(R: R, K: [...K], options: SchemaOptions): TFromMappedResult<R, K> {
+>(R: R, K: [...K], options?: SchemaOptions): TFromMappedResult<R, K> {
   return FromProperties(R.properties, K, options) as never
 }
 // ------------------------------------------------------------------
@@ -84,7 +84,7 @@ export function PickFromMappedResult<
   R extends TMappedResult,
   K extends PropertyKey[],
   P extends TProperties = TFromMappedResult<R, K>
->(R: R, K: [...K], options: SchemaOptions): TMappedResult<P> {
+>(R: R, K: [...K], options?: SchemaOptions): TMappedResult<P> {
   const P = FromMappedResult(R, K, options)
   return MappedResult(P) as never
 }

--- a/src/type/pick/pick.ts
+++ b/src/type/pick/pick.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { TupleToUnion, Evaluate } from '../helpers/index'
 import { type TRecursive } from '../recursive/index'
@@ -36,7 +37,6 @@ import type { TMappedKey, TMappedResult } from '../mapped/index'
 import { IndexPropertyKeys, type TIndexPropertyKeys } from '../indexed/index'
 import { Discard } from '../discard/index'
 import { TransformKind } from '../symbols/index'
-import { CloneType } from '../clone/type'
 import { PickFromMappedKey, type TPickFromMappedKey } from './pick-from-mapped-key'
 import { PickFromMappedResult, type TPickFromMappedResult } from './pick-from-mapped-result'
 
@@ -106,13 +106,13 @@ export function Pick<T extends TSchema, K extends TMappedKey>(T: T, K: K, option
 export function Pick<T extends TSchema, K extends TSchema, I extends PropertyKey[] = TIndexPropertyKeys<K>>(T: T, K: K, options?: SchemaOptions): TPick<T, I>
 /** `[Json]` Constructs a type whose keys are picked from the given type */
 export function Pick<T extends TSchema, K extends PropertyKey[]>(T: T, K: readonly [...K], options?: SchemaOptions): TPick<T, K>
-export function Pick(T: TSchema, K: any, options: SchemaOptions = {}): any {
+export function Pick(T: TSchema, K: any, options?: SchemaOptions): any {
   // mapped
   if (IsMappedKey(K)) return PickFromMappedKey(T, K, options)
   if (IsMappedResult(T)) return PickFromMappedResult(T, K, options)
   // non-mapped
   const I = IsSchema(K) ? IndexPropertyKeys(K) : (K as string[])
   const D = Discard(T, [TransformKind, '$id', 'required']) as TSchema
-  const R = CloneType(PickResolve(T, I), options)
-  return { ...D, ...R }
+  const R = PickResolve(T, I)
+  return CreateType({ ...D, ...R }, options)
 }

--- a/src/type/promise/promise.ts
+++ b/src/type/promise/promise.ts
@@ -26,9 +26,9 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Static } from '../static/index'
-import { CloneType } from '../clone/type'
 import { Kind } from '../symbols/index'
 
 export interface TPromise<T extends TSchema = TSchema> extends TSchema {
@@ -38,11 +38,6 @@ export interface TPromise<T extends TSchema = TSchema> extends TSchema {
   item: TSchema
 }
 /** `[JavaScript]` Creates a Promise type */
-export function Promise<T extends TSchema>(item: T, options: SchemaOptions = {}): TPromise<T> {
-  return {
-    ...options,
-    [Kind]: 'Promise',
-    type: 'Promise',
-    item: CloneType(item),
-  } as never
+export function Promise<T extends TSchema>(item: T, options?: SchemaOptions): TPromise<T> {
+  return CreateType({ [Kind]: 'Promise', type: 'Promise', item }, options) as never
 }

--- a/src/type/readonly/readonly.ts
+++ b/src/type/readonly/readonly.ts
@@ -26,10 +26,10 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema } from '../schema/index'
 import type { Ensure } from '../helpers/index'
 import { ReadonlyKind } from '../symbols/index'
-import { CloneType } from '../clone/type'
 import { Discard } from '../discard/index'
 import type { TMappedResult } from '../mapped/index'
 
@@ -40,14 +40,14 @@ import { IsMappedResult } from '../guard/kind'
 // ------------------------------------------------------------------
 type TRemoveReadonly<T extends TSchema> = T extends TReadonly<infer S> ? S : T
 function RemoveReadonly<T extends TSchema>(schema: T) {
-  return Discard(CloneType(schema), [ReadonlyKind])
+  return CreateType(Discard(schema, [ReadonlyKind]))
 }
 // ------------------------------------------------------------------
 // AddReadonly
 // ------------------------------------------------------------------
 type TAddReadonly<T extends TSchema> = T extends TReadonly<infer S> ? TReadonly<S> : Ensure<TReadonly<T>>
 function AddReadonly<T extends TSchema>(schema: T) {
-  return { ...CloneType(schema), [ReadonlyKind]: 'Readonly' }
+  return CreateType({ ...schema, [ReadonlyKind]: 'Readonly' })
 }
 // prettier-ignore
 export type TReadonlyWithFlag<T extends TSchema, F extends boolean> = 

--- a/src/type/record/record.ts
+++ b/src/type/record/record.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema } from '../schema/index'
 import type { Static } from '../static/index'
 import type { Evaluate, Ensure, Assert } from '../helpers/index'
@@ -44,7 +45,6 @@ import { IsTemplateLiteralFinite, TIsTemplateLiteralFinite, type TTemplateLitera
 import { PatternStringExact, PatternNumberExact, PatternNeverExact } from '../patterns/index'
 import { IndexPropertyKeys } from '../indexed/index'
 import { Kind, Hint } from '../symbols/index'
-import { CloneType } from '../clone/type'
 // ------------------------------------------------------------------
 // ValueGuard
 // ------------------------------------------------------------------
@@ -58,12 +58,12 @@ import { IsInteger, IsLiteral, IsAny, IsNever, IsNumber, IsString, IsRegExp, IsT
 // ------------------------------------------------------------------
 // prettier-ignore
 function RecordCreateFromPattern(pattern: string, T: TSchema, options: ObjectOptions): TRecord<TSchema, TSchema> {
-  return { 
+  return CreateType({ 
     ...options, 
     [Kind]: 'Record', 
     type: 'object', 
-    patternProperties: { [pattern]: CloneType(T) } 
-  } as never
+    patternProperties: { [pattern]: T } 
+  }) as never
 }
 // ------------------------------------------------------------------
 // RecordCreateFromKeys
@@ -71,7 +71,7 @@ function RecordCreateFromPattern(pattern: string, T: TSchema, options: ObjectOpt
 // prettier-ignore
 function RecordCreateFromKeys(K: string[], T: TSchema, options: ObjectOptions): TObject<TProperties> {
   const Acc = {} as TProperties
-  for(const K2 of K) Acc[K2] = CloneType(T)
+  for(const K2 of K) Acc[K2] = T
   return Object(Acc, { ...options, [Hint]: 'Record' })
 }
 // ------------------------------------------------------------------

--- a/src/type/record/record.ts
+++ b/src/type/record/record.ts
@@ -59,11 +59,10 @@ import { IsInteger, IsLiteral, IsAny, IsNever, IsNumber, IsString, IsRegExp, IsT
 // prettier-ignore
 function RecordCreateFromPattern(pattern: string, T: TSchema, options: ObjectOptions): TRecord<TSchema, TSchema> {
   return CreateType({ 
-    ...options, 
     [Kind]: 'Record', 
     type: 'object', 
     patternProperties: { [pattern]: T } 
-  }) as never
+  }, options) as never
 }
 // ------------------------------------------------------------------
 // RecordCreateFromKeys

--- a/src/type/recursive/recursive.ts
+++ b/src/type/recursive/recursive.ts
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { CloneType } from '../clone/type'
+import { CreateType } from '../create/type'
 import { IsUndefined } from '../guard/value'
 import { Kind, Hint } from '../symbols/index'
 import { Static } from '../static/index'
@@ -56,8 +57,8 @@ let Ordinal = 0
 /** `[Json]` Creates a Recursive type */
 export function Recursive<T extends TSchema>(callback: (thisType: TThis) => T, options: SchemaOptions = {}): TRecursive<T> {
   if (IsUndefined(options.$id)) (options as any).$id = `T${Ordinal++}`
-  const thisType = callback({ [Kind]: 'This', $ref: `${options.$id}` } as any)
+  const thisType = CloneType(callback({ [Kind]: 'This', $ref: `${options.$id}` } as any))
   thisType.$id = options.$id
   // prettier-ignore
-  return CloneType({ ...options, [Hint]: 'Recursive', ...thisType }) as never
+  return CreateType({ [Hint]: 'Recursive', ...thisType }, options) as never
 }

--- a/src/type/ref/ref.ts
+++ b/src/type/ref/ref.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Static } from '../static/index'
 import { Kind } from '../symbols/index'
@@ -46,12 +47,8 @@ export function Ref<T extends TSchema>(schema: T, options?: SchemaOptions): TRef
 /** `[Json]` Creates a Ref type. */
 export function Ref<T extends TSchema>($ref: string, options?: SchemaOptions): TRef<T>
 /** `[Json]` Creates a Ref type. */
-export function Ref(unresolved: TSchema | string, options: SchemaOptions = {}) {
-  if (IsString(unresolved)) return { ...options, [Kind]: 'Ref', $ref: unresolved }
+export function Ref(unresolved: TSchema | string, options?: SchemaOptions) {
+  if (IsString(unresolved)) return CreateType({ [Kind]: 'Ref', $ref: unresolved }, options)
   if (IsUndefined(unresolved.$id)) throw new Error('Reference target type must specify an $id')
-  return {
-    ...options,
-    [Kind]: 'Ref',
-    $ref: unresolved.$id!,
-  }
+  return CreateType({ [Kind]: 'Ref', $ref: unresolved.$id! }, options)
 }

--- a/src/type/regexp/regexp.ts
+++ b/src/type/regexp/regexp.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { SchemaOptions } from '../schema/index'
 import type { TSchema } from '../schema/index'
 import { IsString } from '../guard/value'
@@ -50,7 +51,7 @@ export function RegExp(pattern: string, options?: RegExpOptions): TRegExp
 /** `[JavaScript]` Creates a RegExp type */
 export function RegExp(regex: RegExp, options?: RegExpOptions): TRegExp
 /** `[JavaScript]` Creates a RegExp type */
-export function RegExp(unresolved: RegExp | string, options: RegExpOptions = {}) {
+export function RegExp(unresolved: RegExp | string, options?: RegExpOptions) {
   const expr = IsString(unresolved) ? new globalThis.RegExp(unresolved) : unresolved
-  return { ...options, [Kind]: 'RegExp', type: 'RegExp', source: expr.source, flags: expr.flags } as never
+  return CreateType({ [Kind]: 'RegExp', type: 'RegExp', source: expr.source, flags: expr.flags }, options) as never
 }

--- a/src/type/required/required-from-mapped-result.ts
+++ b/src/type/required/required-from-mapped-result.ts
@@ -44,7 +44,7 @@ type TFromProperties<
 // prettier-ignore
 function FromProperties<
   P extends TProperties
->(P: P, options: SchemaOptions): TFromProperties<P> {
+>(P: P, options?: SchemaOptions): TFromProperties<P> {
   const Acc = {} as TProperties
   for(const K2 of globalThis.Object.getOwnPropertyNames(P)) Acc[K2] = Required(P[K2], options)
   return Acc as never
@@ -61,7 +61,7 @@ type TFromMappedResult<
 // prettier-ignore
 function FromMappedResult<
   R extends TMappedResult
->(R: R, options: SchemaOptions): TFromMappedResult<R> {
+>(R: R, options?: SchemaOptions): TFromMappedResult<R> {
   return FromProperties(R.properties, options) as never
 }
 // ------------------------------------------------------------------
@@ -78,7 +78,7 @@ export type TRequiredFromMappedResult<
 export function RequiredFromMappedResult<
   R extends TMappedResult,
   P extends TProperties = TFromMappedResult<R>
->(R: R, options: SchemaOptions): TMappedResult<P> {
+>(R: R, options?: SchemaOptions): TMappedResult<P> {
   const P = FromMappedResult(R, options)
   return MappedResult(P) as never
 }

--- a/src/type/required/required.ts
+++ b/src/type/required/required.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Evaluate } from '../helpers/index'
 import type { TMappedResult } from '../mapped/index'
@@ -38,7 +39,6 @@ import { type TUnion, Union } from '../union/index'
 import { type TObject, type TProperties, Object } from '../object/index'
 
 import { OptionalKind, TransformKind } from '../symbols/index'
-import { CloneType } from '../clone/type'
 import { Discard } from '../discard/index'
 
 import { RequiredFromMappedResult, type TRequiredFromMappedResult } from './required-from-mapped-result'
@@ -106,12 +106,12 @@ export function Required<T extends TMappedResult>(T: T, options?: SchemaOptions)
 /** `[Json]` Constructs a type where all properties are required */
 export function Required<T extends TSchema>(T: T, options?: SchemaOptions): TRequired<T>
 /** `[Json]` Constructs a type where all properties are required */
-export function Required<T extends TSchema>(T: T, options: SchemaOptions = {}) {
+export function Required<T extends TSchema>(T: T, options?: SchemaOptions): never {
   if (IsMappedResult(T)) {
-    return RequiredFromMappedResult(T, options)
+    return RequiredFromMappedResult(T, options) as never
   } else {
     const D = Discard(T, [TransformKind, '$id', 'required']) as TSchema
-    const R = CloneType(RequiredResolve(T) as any, options)
-    return { ...D, ...R }
+    const R = RequiredResolve(T) as any
+    return CreateType({ ...D, ...R }, options) as never
   }
 }

--- a/src/type/required/required.ts
+++ b/src/type/required/required.ts
@@ -37,10 +37,8 @@ import { type TRecursive } from '../recursive/index'
 import { type TIntersect, Intersect } from '../intersect/index'
 import { type TUnion, Union } from '../union/index'
 import { type TObject, type TProperties, Object } from '../object/index'
-
 import { OptionalKind, TransformKind } from '../symbols/index'
 import { Discard } from '../discard/index'
-
 import { RequiredFromMappedResult, type TRequiredFromMappedResult } from './required-from-mapped-result'
 
 // ------------------------------------------------------------------

--- a/src/type/rest/rest.ts
+++ b/src/type/rest/rest.ts
@@ -30,7 +30,6 @@ import type { TSchema } from '../schema/index'
 import type { TIntersect } from '../intersect/index'
 import type { TUnion } from '../union/index'
 import type { TTuple } from '../tuple/index'
-import { CloneRest } from '../clone/type'
 
 // ------------------------------------------------------------------
 // TypeGuard
@@ -41,16 +40,16 @@ import { IsIntersect, IsUnion, IsTuple } from '../guard/kind'
 // ------------------------------------------------------------------
 // prettier-ignore
 type TRestResolve<T extends TSchema> = 
-  T extends TIntersect<infer S> ? [...S] : 
-  T extends TUnion<infer S> ? [...S] : 
-  T extends TTuple<infer S> ? [...S] : 
+  T extends TIntersect<infer S extends TSchema[]> ? S : 
+  T extends TUnion<infer S extends TSchema[]> ? S : 
+  T extends TTuple<infer S extends TSchema[]> ? S : 
   []
 // prettier-ignore
 function RestResolve<T extends TSchema>(T: T) {
   return (
-    IsIntersect(T) ? CloneRest(T.allOf) : 
-    IsUnion(T) ? CloneRest(T.anyOf) : 
-    IsTuple(T) ? CloneRest(T.items ?? []) : 
+    IsIntersect(T) ? T.allOf : 
+    IsUnion(T) ? T.anyOf : 
+    IsTuple(T) ? T.items ?? [] : 
     []
   ) as never
 }
@@ -61,5 +60,5 @@ export type TRest<T extends TSchema> = TRestResolve<T>
 
 /** `[Json]` Extracts interior Rest elements from Tuple, Intersect and Union types */
 export function Rest<T extends TSchema>(T: T): TRest<T> {
-  return CloneRest(RestResolve(T))
+  return RestResolve(T)
 }

--- a/src/type/return-type/return-type.ts
+++ b/src/type/return-type/return-type.ts
@@ -26,13 +26,13 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { SchemaOptions } from '../schema/index'
 import type { TFunction } from '../function/index'
-import { CloneType } from '../clone/type'
 
 export type TReturnType<T extends TFunction> = T['returns']
 
 /** `[JavaScript]` Extracts the ReturnType from the given Function type */
-export function ReturnType<T extends TFunction<any[], any>>(schema: T, options: SchemaOptions = {}): TReturnType<T> {
-  return CloneType(schema.returns, options)
+export function ReturnType<T extends TFunction<any[], any>>(schema: T, options?: SchemaOptions): TReturnType<T> {
+  return CreateType(schema.returns, options) as never
 }

--- a/src/type/string/string.ts
+++ b/src/type/string/string.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -81,6 +82,6 @@ export interface TString extends TSchema, StringOptions {
 }
 
 /** `[Json]` Creates a String type */
-export function String(options: StringOptions = {}): TString {
-  return { ...options, [Kind]: 'String', type: 'string' } as never
+export function String(options?: StringOptions): TString {
+  return CreateType({ [Kind]: 'String', type: 'string' }, options) as never
 }

--- a/src/type/symbol/symbol.ts
+++ b/src/type/symbol/symbol.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -37,5 +38,5 @@ export interface TSymbol extends TSchema, SchemaOptions {
 }
 /** `[JavaScript]` Creates a Symbol type */
 export function Symbol(options?: SchemaOptions): TSymbol {
-  return { ...options, [Kind]: 'Symbol', type: 'symbol' } as never
+  return CreateType({ [Kind]: 'Symbol', type: 'symbol' }, options) as never
 }

--- a/src/type/template-literal/template-literal.ts
+++ b/src/type/template-literal/template-literal.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Assert } from '../helpers/index'
 import type { TUnion } from '../union/index'
@@ -94,9 +95,9 @@ export function TemplateLiteral<T extends string>(syntax: T, options?: SchemaOpt
 export function TemplateLiteral<T extends TTemplateLiteralKind[]>(kinds: [...T], options?: SchemaOptions): TTemplateLiteral<T>
 /** `[Json]` Creates a TemplateLiteral type */
 // prettier-ignore
-export function TemplateLiteral(unresolved: TTemplateLiteralKind[] | string, options: SchemaOptions = {}): any {
+export function TemplateLiteral(unresolved: TTemplateLiteralKind[] | string, options?: SchemaOptions): any {
   const pattern = IsString(unresolved) 
     ? TemplateLiteralPattern(TemplateLiteralSyntax(unresolved)) 
     : TemplateLiteralPattern(unresolved as TTemplateLiteralKind[])
-  return { ...options, [Kind]: 'TemplateLiteral', type: 'string', pattern }
+  return CreateType({ [Kind]: 'TemplateLiteral', type: 'string', pattern }, options)
 }

--- a/src/type/transform/transform.ts
+++ b/src/type/transform/transform.ts
@@ -29,7 +29,6 @@ THE SOFTWARE.
 import type { TSchema } from '../schema/index'
 import type { Static, StaticDecode } from '../static/index'
 import { TransformKind } from '../symbols/index'
-import { CloneType } from '../clone/type'
 
 // ------------------------------------------------------------------
 // TypeGuard
@@ -58,10 +57,9 @@ export class TransformEncodeBuilder<T extends TSchema, D extends TransformFuncti
     const Codec = { Decode: this.decode, Encode: encode }
     return { ...schema, [TransformKind]: Codec }
   }
-  public Encode<E extends TransformFunction<ReturnType<D>, StaticDecode<T>>>(encode: E): TTransform<T, ReturnType<D>> {
-    const schema = CloneType(this.schema)
+  public Encode<E extends TransformFunction<ReturnType<D>, StaticDecode<T>>>(encode: E): TTransform<T, ReturnType<D>> { 
     return (
-      IsTransform(schema) ? this.EncodeTransform(encode, schema): this.EncodeSchema(encode, schema)
+      IsTransform(this.schema) ? this.EncodeTransform(encode, this.schema): this.EncodeSchema(encode, this.schema)
     ) as never
   }
 }

--- a/src/type/tuple/tuple.ts
+++ b/src/type/tuple/tuple.ts
@@ -26,9 +26,9 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import type { Static } from '../static/index'
-import { CloneRest } from '../clone/type'
 import { Kind } from '../symbols/index'
 
 // ------------------------------------------------------------------
@@ -52,13 +52,11 @@ export interface TTuple<T extends TSchema[] = TSchema[]> extends TSchema {
   maxItems: number
 }
 /** `[Json]` Creates a Tuple type */
-export function Tuple<T extends TSchema[]>(items: [...T], options: SchemaOptions = {}): TTuple<T> {
-  // return TupleResolver.Resolve(T)
-  const [additionalItems, minItems, maxItems] = [false, items.length, items.length]
+export function Tuple<T extends TSchema[]>(items: [...T], options?: SchemaOptions): TTuple<T> {
   // prettier-ignore
-  return (
+  return CreateType(
     items.length > 0 ?
-      { ...options, [Kind]: 'Tuple', type: 'array', items: CloneRest(items), additionalItems, minItems, maxItems } :
-      { ...options, [Kind]: 'Tuple', type: 'array', minItems, maxItems }
-  ) as never
+      { [Kind]: 'Tuple', type: 'array', items, additionalItems: false, minItems: items.length, maxItems: items.length } :
+      { [Kind]: 'Tuple', type: 'array', minItems: items.length, maxItems: items.length },
+  options) as never
 }

--- a/src/type/type/javascript.ts
+++ b/src/type/type/javascript.ts
@@ -49,19 +49,19 @@ import { Void, type TVoid } from '../void/index'
 /** JavaScript Type Builder with Static Resolution for TypeScript */
 export class JavaScriptTypeBuilder extends JsonTypeBuilder {
   /** `[JavaScript]` Creates a AsyncIterator type */
-  public AsyncIterator<T extends TSchema>(items: T, options: SchemaOptions = {}): TAsyncIterator<T> {
+  public AsyncIterator<T extends TSchema>(items: T, options?: SchemaOptions): TAsyncIterator<T> {
     return AsyncIterator(items, options)
   }
   /** `[JavaScript]` Constructs a type by recursively unwrapping Promise types */
-  public Awaited<T extends TSchema>(schema: T, options: SchemaOptions = {}): TAwaited<T> {
+  public Awaited<T extends TSchema>(schema: T, options?: SchemaOptions): TAwaited<T> {
     return Awaited(schema, options)
   }
   /** `[JavaScript]` Creates a BigInt type */
-  public BigInt(options: BigIntOptions = {}): TBigInt {
+  public BigInt(options?: BigIntOptions): TBigInt {
     return BigInt(options)
   }
   /** `[JavaScript]` Extracts the ConstructorParameters from the given Constructor type */
-  public ConstructorParameters<T extends TConstructor<TSchema[], TSchema>>(schema: T, options: SchemaOptions = {}): TConstructorParameters<T> {
+  public ConstructorParameters<T extends TConstructor<TSchema[], TSchema>>(schema: T, options?: SchemaOptions): TConstructorParameters<T> {
     return ConstructorParameters(schema, options)
   }
   /** `[JavaScript]` Creates a Constructor type */
@@ -77,19 +77,19 @@ export class JavaScriptTypeBuilder extends JsonTypeBuilder {
     return FunctionType(parameters, returns, options)
   }
   /** `[JavaScript]` Extracts the InstanceType from the given Constructor type */
-  public InstanceType<T extends TConstructor<any[], any>>(schema: T, options: SchemaOptions = {}): TInstanceType<T> {
+  public InstanceType<T extends TConstructor<any[], any>>(schema: T, options?: SchemaOptions): TInstanceType<T> {
     return InstanceType(schema, options)
   }
   /** `[JavaScript]` Creates an Iterator type */
-  public Iterator<T extends TSchema>(items: T, options: SchemaOptions = {}): TIterator<T> {
+  public Iterator<T extends TSchema>(items: T, options?: SchemaOptions): TIterator<T> {
     return Iterator(items, options)
   }
   /** `[JavaScript]` Extracts the Parameters from the given Function type */
-  public Parameters<T extends TFunction<TSchema[], TSchema>>(schema: T, options: SchemaOptions = {}): TParameters<T> {
+  public Parameters<T extends TFunction<TSchema[], TSchema>>(schema: T, options?: SchemaOptions): TParameters<T> {
     return Parameters(schema, options)
   }
   /** `[JavaScript]` Creates a Promise type */
-  public Promise<T extends TSchema>(item: T, options: SchemaOptions = {}): TPromise<T> {
+  public Promise<T extends TSchema>(item: T, options?: SchemaOptions): TPromise<T> {
     return Promise(item, options)
   }
   /** `[JavaScript]` Creates a RegExp type */
@@ -97,11 +97,11 @@ export class JavaScriptTypeBuilder extends JsonTypeBuilder {
   /** `[JavaScript]` Creates a RegExp type */
   public RegExp(regex: RegExp, options?: RegExpOptions): TRegExp
   /** `[JavaScript]` Creates a RegExp type */
-  public RegExp(unresolved: string | RegExp, options: RegExpOptions = {}) {
+  public RegExp(unresolved: string | RegExp, options?: RegExpOptions) {
     return RegExp(unresolved as any, options)
   }
   /** `[JavaScript]` Extracts the ReturnType from the given Function type */
-  public ReturnType<T extends TFunction<any[], any>>(schema: T, options: SchemaOptions = {}): TReturnType<T> {
+  public ReturnType<T extends TFunction<any[], any>>(schema: T, options?: SchemaOptions): TReturnType<T> {
     return ReturnType(schema, options)
   }
   /** `[JavaScript]` Creates a Symbol type */
@@ -109,15 +109,15 @@ export class JavaScriptTypeBuilder extends JsonTypeBuilder {
     return Symbol(options)
   }
   /** `[JavaScript]` Creates a Undefined type */
-  public Undefined(options: SchemaOptions = {}): TUndefined {
+  public Undefined(options?: SchemaOptions): TUndefined {
     return Undefined(options)
   }
   /** `[JavaScript]` Creates a Uint8Array type */
-  public Uint8Array(options: Uint8ArrayOptions = {}): TUint8Array {
+  public Uint8Array(options?: Uint8ArrayOptions): TUint8Array {
     return Uint8Array(options)
   }
   /** `[JavaScript]` Creates a Void type */
-  public Void(options: SchemaOptions = {}): TVoid {
+  public Void(options?: SchemaOptions): TVoid {
     return Void(options)
   }
 }

--- a/src/type/type/json.ts
+++ b/src/type/type/json.ts
@@ -114,19 +114,19 @@ export class JsonTypeBuilder {
   // Types
   // ------------------------------------------------------------------------
   /** `[Json]` Creates an Any type */
-  public Any(options: SchemaOptions = {}): TAny {
+  public Any(options?: SchemaOptions): TAny {
     return Any(options)
   }
   /** `[Json]` Creates an Array type */
-  public Array<T extends TSchema>(schema: T, options: ArrayOptions = {}): TArray<T> {
+  public Array<T extends TSchema>(schema: T, options?: ArrayOptions): TArray<T> {
     return Array(schema, options)
   }
   /** `[Json]` Creates a Boolean type */
-  public Boolean(options: SchemaOptions = {}): TBoolean {
+  public Boolean(options?: SchemaOptions): TBoolean {
     return Boolean(options)
   }
   /** `[Json]` Intrinsic function to Capitalize LiteralString types */
-  public Capitalize<T extends TSchema>(schema: T, options: SchemaOptions = {}): TCapitalize<T> {
+  public Capitalize<T extends TSchema>(schema: T, options?: SchemaOptions): TCapitalize<T> {
     return Capitalize(schema, options)
   }
   /** `[Json]` Creates a Composite object type */
@@ -134,7 +134,7 @@ export class JsonTypeBuilder {
     return Composite(schemas, options) // (error) TS 5.4.0-dev - review TComposite implementation
   }
   /** `[JavaScript]` Creates a readonly const type from the given value. */
-  public Const</* const (not supported in 4.0) */ T>(value: T, options: SchemaOptions = {}): TConst<T> {
+  public Const</* const (not supported in 4.0) */ T>(value: T, options?: SchemaOptions): TConst<T> {
     return Const(value, options)
   }
   /** `[Json]` Creates a dereferenced type */
@@ -142,7 +142,7 @@ export class JsonTypeBuilder {
     return Deref(schema, references)
   }
   /** `[Json]` Creates a Enum type */
-  public Enum<V extends TEnumValue, T extends Record<TEnumKey, V>>(item: T, options: SchemaOptions = {}): TEnum<T> {
+  public Enum<V extends TEnumValue, T extends Record<TEnumKey, V>>(item: T, options?: SchemaOptions): TEnum<T> {
     return Enum(item, options)
   }
   /** `[Json]` Constructs a type by excluding from unionType all union members that are assignable to excludedMembers */
@@ -152,7 +152,7 @@ export class JsonTypeBuilder {
   /** `[Json]` Constructs a type by excluding from unionType all union members that are assignable to excludedMembers */
   public Exclude<L extends TSchema, R extends TSchema>(unionType: L, excludedMembers: R, options?: SchemaOptions): TExclude<L, R>
   /** `[Json]` Constructs a type by excluding from unionType all union members that are assignable to excludedMembers */
-  public Exclude(unionType: TSchema, excludedMembers: TSchema, options: SchemaOptions = {}): any {
+  public Exclude(unionType: TSchema, excludedMembers: TSchema, options?: SchemaOptions): any {
     return Exclude(unionType, excludedMembers, options)
   }
   /** `[Json]` Creates a Conditional type */
@@ -162,7 +162,7 @@ export class JsonTypeBuilder {
   /** `[Json]` Creates a Conditional type */
   public Extends<L extends TSchema, R extends TSchema, T extends TSchema, F extends TSchema>(L: L, R: R, T: T, F: F, options?: SchemaOptions): TExtends<L, R, T, F>
   /** `[Json]` Creates a Conditional type */
-  public Extends<L extends TSchema, R extends TSchema, T extends TSchema, F extends TSchema>(L: L, R: R, T: T, F: F, options: SchemaOptions = {}) {
+  public Extends<L extends TSchema, R extends TSchema, T extends TSchema, F extends TSchema>(L: L, R: R, T: T, F: F, options?: SchemaOptions) {
     return Extends(L, R, T, F, options)
   }
   /** `[Json]` Constructs a type by extracting from type all union members that are assignable to union */
@@ -172,7 +172,7 @@ export class JsonTypeBuilder {
   /** `[Json]` Constructs a type by extracting from type all union members that are assignable to union */
   public Extract<L extends TSchema, R extends TSchema>(type: L, union: R, options?: SchemaOptions): TExtract<L, R>
   /** `[Json]` Constructs a type by extracting from type all union members that are assignable to union */
-  public Extract(type: TSchema, union: TSchema, options: SchemaOptions = {}): any {
+  public Extract(type: TSchema, union: TSchema, options?: SchemaOptions): any {
     return Extract(type, union, options)
   }
   /** `[Json]` Returns an Indexed property type for the given keys */
@@ -184,15 +184,15 @@ export class JsonTypeBuilder {
   /** `[Json]` Returns an Indexed property type for the given keys */
   public Index<T extends TSchema, K extends PropertyKey[]>(T: T, K: readonly [...K], options?: SchemaOptions): TIndex<T, K>
   /** `[Json]` Returns an Indexed property type for the given keys */
-  public Index(schema: TSchema, unresolved: any, options: SchemaOptions = {}): any {
+  public Index(schema: TSchema, unresolved: any, options?: SchemaOptions): any {
     return Index(schema, unresolved, options)
   }
   /** `[Json]` Creates an Integer type */
-  public Integer(options: IntegerOptions = {}): TInteger {
+  public Integer(options?: IntegerOptions): TInteger {
     return Integer(options)
   }
   /** `[Json]` Creates an Intersect type */
-  public Intersect<T extends TSchema[]>(T: [...T], options: IntersectOptions = {}): Intersect<T> {
+  public Intersect<T extends TSchema[]>(T: [...T], options?: IntersectOptions): Intersect<T> {
     return Intersect(T, options)
   }
   /** `[Json]` Creates a KeyOf type */
@@ -200,15 +200,15 @@ export class JsonTypeBuilder {
   /** `[Json]` Creates a KeyOf type */
   public KeyOf<T extends TSchema>(schema: T, options?: SchemaOptions): TKeyOf<T>
   /** `[Json]` Creates a KeyOf type */
-  public KeyOf(schema: TSchema, options: SchemaOptions = {}): any {
+  public KeyOf(schema: TSchema, options?: SchemaOptions): any {
     return KeyOf(schema, options)
   }
   /** `[Json]` Creates a Literal type */
-  public Literal<T extends TLiteralValue>(value: T, options: SchemaOptions = {}): TLiteral<T> {
+  public Literal<T extends TLiteralValue>(value: T, options?: SchemaOptions): TLiteral<T> {
     return Literal(value, options)
   }
   /** `[Json]` Intrinsic function to Lowercase LiteralString types */
-  public Lowercase<T extends TSchema>(schema: T, options: SchemaOptions = {}): TLowercase<T> {
+  public Lowercase<T extends TSchema>(schema: T, options?: SchemaOptions): TLowercase<T> {
     return Lowercase(schema, options)
   }
   /** `[Json]` Creates a Mapped object type */
@@ -216,11 +216,11 @@ export class JsonTypeBuilder {
   /** `[Json]` Creates a Mapped object type */
   public Mapped<K extends PropertyKey[], F extends TMappedFunction<K> = TMappedFunction<K>, R extends TMapped<K, F> = TMapped<K, F>>(key: [...K], map: F, options?: ObjectOptions): R
   /** `[Json]` Creates a Mapped object type */
-  public Mapped(key: any, map: TMappedFunction<any>, options: ObjectOptions = {}): any {
+  public Mapped(key: any, map: TMappedFunction<any>, options?: ObjectOptions): any {
     return Mapped(key, map, options)
   }
   /** `[Json]` Creates a Never type */
-  public Never(options: SchemaOptions = {}): TNever {
+  public Never(options?: SchemaOptions): TNever {
     return Never(options)
   }
   /** `[Json]` Creates a Not type */
@@ -228,15 +228,15 @@ export class JsonTypeBuilder {
     return Not(schema, options)
   }
   /** `[Json]` Creates a Null type */
-  public Null(options: SchemaOptions = {}): TNull {
+  public Null(options?: SchemaOptions): TNull {
     return Null(options)
   }
   /** `[Json]` Creates a Number type */
-  public Number(options: NumberOptions = {}): TNumber {
+  public Number(options?: NumberOptions): TNumber {
     return Number(options)
   }
   /** `[Json]` Creates an Object type */
-  public Object<T extends TProperties>(properties: T, options: ObjectOptions = {}): TObject<T> {
+  public Object<T extends TProperties>(properties: T, options?: ObjectOptions): TObject<T> {
     return Object(properties, options)
   }
   /** `[Json]` Constructs a type whose keys are omitted from the given type */
@@ -248,7 +248,7 @@ export class JsonTypeBuilder {
   /** `[Json]` Constructs a type whose keys are omitted from the given type */
   public Omit<T extends TSchema, K extends PropertyKey[]>(T: T, K: readonly [...K], options?: SchemaOptions): TOmit<T, K>
   /** `[Json]` Constructs a type whose keys are omitted from the given type */
-  public Omit(schema: TSchema, unresolved: any, options: SchemaOptions = {}): any {
+  public Omit(schema: TSchema, unresolved: any, options?: SchemaOptions): any {
     return Omit(schema, unresolved, options)
   }
   /** `[Json]` Constructs a type where all properties are optional */
@@ -256,7 +256,7 @@ export class JsonTypeBuilder {
   /** `[Json]` Constructs a type where all properties are optional */
   public Partial<T extends TSchema>(schema: T, options?: ObjectOptions): TPartial<T>
   /** `[Json]` Constructs a type where all properties are optional */
-  public Partial(schema: TSchema, options: ObjectOptions = {}): any {
+  public Partial(schema: TSchema, options?: ObjectOptions): any {
     return Partial(schema, options)
   }
   /** `[Json]` Constructs a type whose keys are picked from the given type */
@@ -268,15 +268,15 @@ export class JsonTypeBuilder {
   /** `[Json]` Constructs a type whose keys are picked from the given type */
   public Pick<T extends TSchema, K extends PropertyKey[]>(T: T, K: readonly [...K], options?: SchemaOptions): TPick<T, K>
   /** `[Json]` Constructs a type whose keys are picked from the given type */
-  public Pick(schema: TSchema, unresolved: any, options: SchemaOptions = {}): any {
+  public Pick(schema: TSchema, unresolved: any, options?: SchemaOptions): any {
     return Pick(schema, unresolved, options)
   }
   /** `[Json]` Creates a Record type */
-  public Record<K extends TSchema, T extends TSchema>(key: K, schema: T, options: ObjectOptions = {}): TRecordOrObject<K, T> {
+  public Record<K extends TSchema, T extends TSchema>(key: K, schema: T, options?: ObjectOptions): TRecordOrObject<K, T> {
     return Record(key, schema, options)
   }
   /** `[Json]` Creates a Recursive type */
-  public Recursive<T extends TSchema>(callback: (thisType: TThis) => T, options: SchemaOptions = {}): TRecursive<T> {
+  public Recursive<T extends TSchema>(callback: (thisType: TThis) => T, options?: SchemaOptions): TRecursive<T> {
     return Recursive(callback, options)
   }
   /** `[Json]` Creates a Ref type. The referenced type must contain a $id */
@@ -284,7 +284,7 @@ export class JsonTypeBuilder {
   /** `[Json]` Creates a Ref type. */
   public Ref<T extends TSchema>($ref: string, options?: SchemaOptions): TRef<T>
   /** `[Json]` Creates a Ref type. */
-  public Ref(unresolved: TSchema | string, options: SchemaOptions = {}) {
+  public Ref(unresolved: TSchema | string, options?: SchemaOptions) {
     return Ref(unresolved as any, options)
   }
   /** `[Json]` Constructs a type where all properties are required */
@@ -292,7 +292,7 @@ export class JsonTypeBuilder {
   /** `[Json]` Constructs a type where all properties are required */
   public Required<T extends TSchema>(schema: T, options?: ObjectOptions): TRequired<T>
   /** `[Json]` Constructs a type where all properties are required */
-  public Required(schema: TSchema, options: ObjectOptions = {}): any {
+  public Required(schema: TSchema, options?: ObjectOptions): any {
     return Required(schema, options)
   }
   /** `[Json]` Extracts interior Rest elements from Tuple, Intersect and Union types */
@@ -300,7 +300,7 @@ export class JsonTypeBuilder {
     return Rest(schema)
   }
   /** `[Json]` Creates a String type */
-  public String(options: StringOptions = {}): TString {
+  public String(options?: StringOptions): TString {
     return String(options)
   }
   /** `[Json]` Creates a TemplateLiteral type from template dsl string */
@@ -308,7 +308,7 @@ export class JsonTypeBuilder {
   /** `[Json]` Creates a TemplateLiteral type */
   public TemplateLiteral<T extends TTemplateLiteralKind[]>(kinds: [...T], options?: SchemaOptions): TTemplateLiteral<T>
   /** `[Json]` Creates a TemplateLiteral type */
-  public TemplateLiteral(unresolved: TTemplateLiteralKind[] | string, options: SchemaOptions = {}) {
+  public TemplateLiteral(unresolved: TTemplateLiteralKind[] | string, options?: SchemaOptions) {
     return TemplateLiteral(unresolved as any, options)
   }
   /** `[Json]` Creates a Transform type */
@@ -316,27 +316,27 @@ export class JsonTypeBuilder {
     return Transform(schema)
   }
   /** `[Json]` Creates a Tuple type */
-  public Tuple<T extends TSchema[]>(items: [...T], options: SchemaOptions = {}): TTuple<T> {
+  public Tuple<T extends TSchema[]>(items: [...T], options?: SchemaOptions): TTuple<T> {
     return Tuple(items, options)
   }
   /** `[Json]` Intrinsic function to Uncapitalize LiteralString types */
-  public Uncapitalize<T extends TSchema>(schema: T, options: SchemaOptions = {}): TUncapitalize<T> {
+  public Uncapitalize<T extends TSchema>(schema: T, options?: SchemaOptions): TUncapitalize<T> {
     return Uncapitalize(schema, options)
   }
   /** `[Json]` Creates a Union type */
-  public Union<T extends TSchema[]>(schemas: [...T], options: SchemaOptions = {}): Union<T> {
+  public Union<T extends TSchema[]>(schemas: [...T], options?: SchemaOptions): Union<T> {
     return Union(schemas, options)
   }
   /** `[Json]` Creates an Unknown type */
-  public Unknown(options: SchemaOptions = {}): TUnknown {
+  public Unknown(options?: SchemaOptions): TUnknown {
     return Unknown(options)
   }
   /** `[Json]` Creates a Unsafe type that will infers as the generic argument T */
-  public Unsafe<T>(options: UnsafeOptions = {}): TUnsafe<T> {
+  public Unsafe<T>(options?: UnsafeOptions): TUnsafe<T> {
     return Unsafe(options)
   }
   /** `[Json]` Intrinsic function to Uppercase LiteralString types */
-  public Uppercase<T extends TSchema>(schema: T, options: SchemaOptions = {}): TUppercase<T> {
+  public Uppercase<T extends TSchema>(schema: T, options?: SchemaOptions): TUppercase<T> {
     return Uppercase(schema, options)
   }
 }

--- a/src/type/uint8array/uint8array.ts
+++ b/src/type/uint8array/uint8array.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -39,6 +40,6 @@ export interface TUint8Array extends TSchema, Uint8ArrayOptions {
   type: 'uint8array'
 }
 /** `[JavaScript]` Creates a Uint8Array type */
-export function Uint8Array(options: Uint8ArrayOptions = {}): TUint8Array {
-  return { ...options, [Kind]: 'Uint8Array', type: 'Uint8Array' } as never
+export function Uint8Array(options?: Uint8ArrayOptions): TUint8Array {
+  return CreateType({ [Kind]: 'Uint8Array', type: 'Uint8Array' }, options) as never
 }

--- a/src/type/undefined/undefined.ts
+++ b/src/type/undefined/undefined.ts
@@ -37,5 +37,5 @@ export interface TUndefined extends TSchema {
 }
 /** `[JavaScript]` Creates a Undefined type */
 export function Undefined(options?: SchemaOptions): TUndefined {
-  return CreateType({ ...options, [Kind]: 'Undefined', type: 'undefined' }, options) as never
+  return CreateType({ [Kind]: 'Undefined', type: 'undefined' }, options) as never
 }

--- a/src/type/undefined/undefined.ts
+++ b/src/type/undefined/undefined.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -35,6 +36,6 @@ export interface TUndefined extends TSchema {
   type: 'undefined'
 }
 /** `[JavaScript]` Creates a Undefined type */
-export function Undefined(options: SchemaOptions = {}): TUndefined {
-  return { ...options, [Kind]: 'Undefined', type: 'undefined' } as never
+export function Undefined(options?: SchemaOptions): TUndefined {
+  return CreateType({ ...options, [Kind]: 'Undefined', type: 'undefined' }, options) as never
 }

--- a/src/type/union/union-create.ts
+++ b/src/type/union/union-create.ts
@@ -27,10 +27,10 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import type { TSchema, SchemaOptions } from '../schema/index'
-import { CloneRest } from '../clone/type'
+import { CreateType } from '../create/type'
 import { TUnion } from './union-type'
 import { Kind } from '../symbols/index'
 
-export function UnionCreate<T extends TSchema[]>(T: [...T], options: SchemaOptions): TUnion<T> {
-  return { ...options, [Kind]: 'Union', anyOf: CloneRest(T) } as never
+export function UnionCreate<T extends TSchema[]>(T: [...T], options?: SchemaOptions): TUnion<T> {
+  return CreateType({ [Kind]: 'Union', anyOf: T }, options) as never
 }

--- a/src/type/union/union-evaluated.ts
+++ b/src/type/union/union-evaluated.ts
@@ -26,9 +26,9 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { SchemaOptions, TSchema } from '../schema/index'
 import { OptionalKind } from '../symbols/index'
-import { CloneType } from '../clone/type'
 import { Discard } from '../discard/index'
 import { Never, type TNever } from '../never/index'
 import { Optional, type TOptional } from '../optional/index'
@@ -95,7 +95,7 @@ type TResolveUnion<T extends TSchema[], R extends TSchema[] = TRemoveOptionalFro
     : TUnion<R>
 )
 // prettier-ignore
-function ResolveUnion<T extends TSchema[]>(T: T, options: SchemaOptions): TResolveUnion<T> {
+function ResolveUnion<T extends TSchema[]>(T: T, options?: SchemaOptions): TResolveUnion<T> {
   return (
     IsUnionOptional(T)
       ? Optional(UnionCreate(RemoveOptionalFromRest(T) as TSchema[], options))
@@ -112,11 +112,11 @@ export type TUnionEvaluated<T extends TSchema[]> = (
   TResolveUnion<T>
 )
 /** `[Json]` Creates an evaluated Union type */
-export function UnionEvaluated<T extends TSchema[], R = TUnionEvaluated<T>>(T: [...T], options: SchemaOptions = {}): R {
+export function UnionEvaluated<T extends TSchema[], R = TUnionEvaluated<T>>(T: [...T], options?: SchemaOptions): R {
   // prettier-ignore
   return (
     T.length === 0 ? Never(options) :
-    T.length === 1 ? CloneType(T[0], options) :
+    T.length === 1 ? CreateType(T[0], options) :
     ResolveUnion(T, options)
   ) as never
 }

--- a/src/type/union/union.ts
+++ b/src/type/union/union.ts
@@ -29,7 +29,7 @@ THE SOFTWARE.
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { type TNever, Never } from '../never/index'
 import type { TUnion } from './union-type'
-import { CloneType } from '../clone/type'
+import { CreateType } from '../create/type'
 import { UnionCreate } from './union-create'
 
 // prettier-ignore
@@ -39,11 +39,11 @@ export type Union<T extends TSchema[]> = (
   TUnion<T>
 )
 /** `[Json]` Creates a Union type */
-export function Union<T extends TSchema[]>(T: [...T], options: SchemaOptions = {}): Union<T> {
+export function Union<T extends TSchema[]>(T: [...T], options?: SchemaOptions): Union<T> {
   // prettier-ignore
   return (
     T.length === 0 ? Never(options) :
-    T.length === 1 ? CloneType(T[0], options) :
+    T.length === 1 ? CreateType(T[0], options) :
     UnionCreate(T, options)
   ) as Union<T>
 }

--- a/src/type/unknown/unknown.ts
+++ b/src/type/unknown/unknown.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -34,9 +35,6 @@ export interface TUnknown extends TSchema {
   static: unknown
 }
 /** `[Json]` Creates an Unknown type */
-export function Unknown(options: SchemaOptions = {}): TUnknown {
-  return {
-    ...options,
-    [Kind]: 'Unknown',
-  } as never
+export function Unknown(options?: SchemaOptions): TUnknown {
+  return CreateType({ [Kind]: 'Unknown' }, options) as never
 }

--- a/src/type/unsafe/unsafe.ts
+++ b/src/type/unsafe/unsafe.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { CreateType } from '../create/type'
 import type { TSchema, SchemaOptions } from '../schema/index'
 import { Kind } from '../symbols/index'
 
@@ -38,8 +39,5 @@ export interface TUnsafe<T> extends TSchema {
 }
 /** `[Json]` Creates a Unsafe type that will infers as the generic argument T */
 export function Unsafe<T>(options: UnsafeOptions = {}): TUnsafe<T> {
-  return {
-    ...options,
-    [Kind]: options[Kind] ?? 'Unsafe',
-  } as never
+  return CreateType({ [Kind]: options[Kind] ?? 'Unsafe' }, options) as never
 }

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -1,3 +1,10 @@
+import { TypeSystemPolicy } from '@sinclair/typebox/system'
+
+// ------------------------------------------------------------------
+// Immutable Types:
+// ------------------------------------------------------------------
+TypeSystemPolicy.ImmutableTypes = true
+
 import './compiler/index'
 import './compiler-ajv/index'
 import './errors/index'

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -1,9 +1,9 @@
 import { TypeSystemPolicy } from '@sinclair/typebox/system'
 
 // ------------------------------------------------------------------
-// Immutable Types:
+// InstanceMode: Freeze (Detect Unintended Side Effects)
 // ------------------------------------------------------------------
-TypeSystemPolicy.ImmutableTypes = true
+TypeSystemPolicy.InstanceMode = 'freeze'
 
 import './compiler/index'
 import './compiler-ajv/index'

--- a/test/runtime/index.ts
+++ b/test/runtime/index.ts
@@ -3,7 +3,7 @@ import { TypeSystemPolicy } from '@sinclair/typebox/system'
 // ------------------------------------------------------------------
 // InstanceMode: Freeze (Detect Unintended Side Effects)
 // ------------------------------------------------------------------
-TypeSystemPolicy.InstanceMode = 'freeze'
+TypeSystemPolicy.InstanceMode = 'default'
 
 import './compiler/index'
 import './compiler-ajv/index'

--- a/test/runtime/type/guard/type/ref.ts
+++ b/test/runtime/type/guard/type/ref.ts
@@ -1,5 +1,5 @@
 import { TypeGuard } from '@sinclair/typebox'
-import { Type } from '@sinclair/typebox'
+import { Type, CloneType } from '@sinclair/typebox'
 import { Assert } from '../../../assert/index'
 
 describe('guard/type/TRef', () => {
@@ -14,7 +14,7 @@ describe('guard/type/TRef', () => {
   })
   it('Should not guard for TRef with invalid $ref', () => {
     const T = Type.Number({ $id: 'T' })
-    const S = Type.Ref(T)
+    const S = CloneType(Type.Ref(T))
     // @ts-ignore
     S.$ref = 1
     const R = TypeGuard.IsRef(S)

--- a/test/runtime/type/guard/type/template-literal.ts
+++ b/test/runtime/type/guard/type/template-literal.ts
@@ -1,5 +1,5 @@
 import { TypeGuard } from '@sinclair/typebox'
-import { Type, TemplateLiteralGenerate } from '@sinclair/typebox'
+import { Type, CloneType, TemplateLiteralGenerate } from '@sinclair/typebox'
 import { Assert } from '../../../assert/index'
 
 describe('guard/type/TTemplateLiteral', () => {
@@ -33,13 +33,13 @@ describe('guard/type/TTemplateLiteral', () => {
     Assert.IsTrue(R)
   })
   it('Should not guard for missing ^ expression prefix', () => {
-    const T = Type.TemplateLiteral([Type.Literal('hello')])
+    const T = CloneType(Type.TemplateLiteral([Type.Literal('hello')]))
     // @ts-ignore
     T.pattern = T.pattern.slice(1)
     Assert.IsFalse(TypeGuard.IsTemplateLiteral(T))
   })
   it('Should not guard for missing $ expression postfix', () => {
-    const T = Type.TemplateLiteral([Type.Literal('hello')])
+    const T = CloneType(Type.TemplateLiteral([Type.Literal('hello')]))
     // @ts-ignore
     T.pattern = T.pattern.slice(0, T.pattern.length - 1)
     Assert.IsFalse(TypeGuard.IsTemplateLiteral(T))


### PR DESCRIPTION
This PR provides an implementation for immutable type schematics. It is both an optimization for TypeBox's type builder, and a new mechanism for opt-in protections against indirect schema mutation. This feature replaces the previous implementation which would naively clone each composited type.

As of this PR, TypeBox will no longer clone created schematics by default. This change may introduce referencing issues for implementations that manually assign properties on the types outside of options (see below for fallbacks)

```typescript
const S = Type.String({ })

const T = Type.Object({ x: S })
// {
//   type: 'object',
//   properties: {
//     x: { type: 'string' }
//   },
//   required: [ 'x' ]
// }

S.format = 'uuid' // mutate S in someway

console.log(T)
// {
//   type: 'object',
//   properties: {
//     x: { type: 'string', format: 'uuid' } // note indirect mutation on T
//   },
//   required: [ 'x' ]
// }
```

Because of this change, a minor revision is required.

### TypeSystemPolicy InstanceMode

Inline with this PR, TypeBox introduces a new TypeSystemPolicy InstanceMode configuration which provides control over how TypeBox types are instanced. This configuration is documented as follows.

```typescript
export namespace TypeSystemPolicy {
  // ------------------------------------------------------------------
  // TypeSystemPolicy: Instancing
  // ------------------------------------------------------------------
  /**
   * Configures the instantiation behavior of TypeBox types. The `default` option assigns raw JavaScript
   * references for embedded types, which may cause side effects if type properties are explicitly updated
   * outside the TypeBox type builder. The `clone` option creates copies of any shared types upon creation,
   * preventing unintended side effects. The `freeze` option applies `Object.freeze()` to the type, making
   * it fully readonly and immutable. Implementations should use `default` whenever possible, as it is the
   * fastest way to instantiate types. The default setting is `default`.
   */
  export let InstanceMode: 'default' | 'clone' | 'freeze' = 'default'
}
```
For older applications that mutate schematics outside of the TypeBox type builder, It is possible to configure the InstanceMode as `clone` which retains previous instancing behaviors. It is however recommended to migrate to `default` if possible as this yield higher performance. For applications that are not aware for if they are mutating schematics, setting the InstanceMode to `freeze` should raise runtime errors at locations where the mutation occurs.


