### PR TITLE
Revision 0.33.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.33.9",
+  "version": "0.33.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.33.9",
+      "version": "0.33.10",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.33.9",
+  "version": "0.33.10",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/task/build/package/create-package-json.ts
+++ b/task/build/package/create-package-json.ts
@@ -91,10 +91,19 @@ function resolveMetadata() {
     repository: packageJson.repository,
     // flagged by socket.dev if not present
     scripts: { test: 'echo test' },
-    // disable auto bundle strategy: see https://github.com/esm-dev/esm.sh#bundling-strategy
-    'esm.sh': { 'bundle': false }, 
     types: "./build/cjs/index.d.ts",
     main: "./build/cjs/index.js",
-    module: "./build/esm/index.mjs"
+    module: "./build/esm/index.mjs",
+    // disable auto bundle strategy: see https://github.com/esm-dev/esm.sh#bundling-strategy
+    'esm.sh': { 'bundle': false }, 
+    // specify modules with potential for side effects
+    'sideEffects': [
+      "./build/esm/type/registry/format.mjs",
+      "./build/esm/type/registry/type.mjs",
+      "./build/esm/type/system/policy.mjs",
+      "./build/cjs/type/registry/format.js",
+      "./build/cjs/type/registry/type.js",
+      "./build/cjs/type/system/policy.js"
+    ]
   }
 }

--- a/task/build/package/create-package-json.ts
+++ b/task/build/package/create-package-json.ts
@@ -98,12 +98,12 @@ function resolveMetadata() {
     'esm.sh': { 'bundle': false }, 
     // specify modules with potential for side effects
     'sideEffects': [
-      "./build/esm/type/registry/format.mjs",
-      "./build/esm/type/registry/type.mjs",
-      "./build/esm/type/system/policy.mjs",
-      "./build/cjs/type/registry/format.js",
-      "./build/cjs/type/registry/type.js",
-      "./build/cjs/type/system/policy.js"
+      './build/esm/type/registry/format.mjs',
+      './build/esm/type/registry/type.mjs',
+      './build/esm/type/system/policy.mjs',
+      './build/cjs/type/registry/format.js',
+      './build/cjs/type/registry/type.js',
+      './build/cjs/type/system/policy.js'
     ]
   }
 }


### PR DESCRIPTION
This PR specifies which sub modules have potential for side effects within package.json. These are specific to the Type and Format registries and the TypeSystemPolicy. Configurations span both ESM and CJS builds.

```json
"sideEffects": [
  "./build/esm/type/registry/format.mjs",
  "./build/esm/type/registry/type.mjs",
  "./build/esm/type/system/policy.mjs",
  "./build/cjs/type/registry/format.js",
  "./build/cjs/type/registry/type.js",
  "./build/cjs/type/system/policy.js"
],
```

Fixes: https://github.com/sinclairzx81/typebox/issues/907