### PR TITLE
Relax String Pattern matching

### DIFF
--- a/src/type/patterns/patterns.ts
+++ b/src/type/patterns/patterns.ts
@@ -28,7 +28,7 @@ THE SOFTWARE.
 
 export const PatternBoolean = '(true|false)'
 export const PatternNumber = '(0|[1-9][0-9]*)'
-export const PatternString = '(.*)'
+export const PatternString = '([\S\s]*)'
 export const PatternNever = '(?!.*)'
 export const PatternBooleanExact = `^${PatternBoolean}$`
 export const PatternNumberExact = `^${PatternNumber}$`


### PR DESCRIPTION
Allow newlines in string pattern when using `TemplateLiteral`.