### PR TITLE
Revision 0.33.16

### DIFF
--- a/hammer.mjs
+++ b/hammer.mjs
@@ -32,7 +32,7 @@ export async function benchmark() {
 // Test
 // -------------------------------------------------------------------------------
 export async function test_typescript() {
-  for (const version of ['4.9.5', '5.0.4', '5.1.3', '5.1.6', '5.2.2', '5.3.2', '5.3.3', '5.4.3', '5.4.5', '5.5.2', '5.5.3', '5.5.4', 'next', 'latest']) {
+  for (const version of ['4.9.5', '5.0.4', '5.1.3', '5.1.6', '5.2.2', '5.3.2', '5.3.3', '5.4.3', '5.4.5', '5.5.2', '5.5.3', '5.5.4', '5.6.2', 'next', 'latest']) {
     await shell(`npm install typescript@${version} --no-save`)
     await test_static()
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ajv-formats": "^2.1.1",
         "mocha": "^10.4.0",
         "prettier": "^2.7.1",
-        "typescript": "^5.6.2"
+        "typescript": "^5.6.3"
       }
     },
     "node_modules/@andrewbranch/untar.js": {
@@ -1576,9 +1576,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2738,9 +2738,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true
     },
     "undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.33.15",
+  "version": "0.33.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.33.15",
+      "version": "0.33.16",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.33.15",
+  "version": "0.33.16",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "ajv-formats": "^2.1.1",
     "mocha": "^10.4.0",
     "prettier": "^2.7.1",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.3"
   }
 }


### PR DESCRIPTION
This PR is a publishing prepare for  https://github.com/sinclairzx81/typebox/pull/1015. The update here enables Union errors to be obtained as a sub property of ValueError. The interior errors are of type ValueErrorIterator meaning to obtain each error for each variant, the caller will need to pull back errors through the iterator. 

The following is example demonstrates pulling back union errors using two recursive functions.

```typescript
import { ValueError, ValueErrorIterator } from '@sinclair/typebox/compiler'
import { Value } from '@sinclair/typebox/value'
import { Type } from '@sinclair/typebox'

// ------------------------------------------------------------------
// Type
// ------------------------------------------------------------------

const T = Type.Union([
  Type.Object({ x: Type.Number(), y: Type.Number(), z: Type.Number() }),
  Type.Object({ a: Type.Number(), b: Type.Number(), c: Type.Number() })
])

// ------------------------------------------------------------------
// Recursive Map Interior Errors
// ------------------------------------------------------------------
interface MappedValueError {
  message: string
  path: string
  value: unknown
  errors: MappedValueError[][]
}
function MapValueError(error: ValueError): MappedValueError {
  const { message, path, value } = error
  const errors = error.errors.map(error => MapValueErrorIterator(error)) // .flat()
  return { message, path, value, errors }
}
function MapValueErrorIterator(iterator: ValueErrorIterator): MappedValueError[] {
  return [...iterator].map(error => MapValueError(error))
}

// ------------------------------------------------------------------
// Usage
// ------------------------------------------------------------------

const E = Value.Errors(T, { x: true, y: true, z: true })

const M = MapValueErrorIterator(E)

console.dir(M, { depth: 100 })
```

Additional updates include bumping the TS compiler to latest (5.6.3)