### PR TITLE
Revision 0.33.17

### DIFF
--- a/changelog/0.33.0.md
+++ b/changelog/0.33.0.md
@@ -1,4 +1,8 @@
 ### 0.33.0
+- [Revision 0.33.17](https://github.com/sinclairzx81/typebox/pull/1042)
+  - [1041](https://github.com/sinclairzx81/typebox/issues/1041) Avoid Exponentiation operator on Value.Hash
+- [Revision 0.33.16](https://github.com/sinclairzx81/typebox/pull/1015)
+  - [1015](https://github.com/sinclairzx81/typebox/issues/1015) Add sub error iterators to ValueError
 - [Revision 0.33.15](https://github.com/sinclairzx81/typebox/pull/1025)
   - [1024](https://github.com/sinclairzx81/typebox/issues/1024) Fix to correctly resolve default Dates
 - [Revision 0.33.14](https://github.com/sinclairzx81/typebox/pull/1019)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.33.16",
+  "version": "0.33.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.33.16",
+      "version": "0.33.17",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.33.16",
+  "version": "0.33.17",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/hash/hash.ts
+++ b/src/value/hash/hash.ts
@@ -57,7 +57,7 @@ enum ByteMarker {
 // State
 // ------------------------------------------------------------------
 let Accumulator = BigInt('14695981039346656037')
-const [Prime, Size] = [BigInt('1099511628211'), BigInt('18446744073709551616' /* 2 ^ 64 */)] // ES2015: BigInt('2') ** BigInt('64')]
+const [Prime, Size] = [BigInt('1099511628211'), BigInt('18446744073709551616' /* 2 ^ 64 */)]
 const Bytes = Array.from({ length: 256 }).map((_, i) => BigInt(i))
 const F64 = new Float64Array(1)
 const F64In = new DataView(F64.buffer)

--- a/src/value/hash/hash.ts
+++ b/src/value/hash/hash.ts
@@ -57,7 +57,7 @@ enum ByteMarker {
 // State
 // ------------------------------------------------------------------
 let Accumulator = BigInt('14695981039346656037')
-const [Prime, Size] = [BigInt('1099511628211'), BigInt('2') ** BigInt('64')]
+const [Prime, Size] = [BigInt('1099511628211'), BigInt('18446744073709551616' /* 2 ^ 64 */)] // ES2015: BigInt('2') ** BigInt('64')]
 const Bytes = Array.from({ length: 256 }).map((_, i) => BigInt(i))
 const F64 = new Float64Array(1)
 const F64In = new DataView(F64.buffer)


### PR DESCRIPTION
This PR adds a fix for Value.Hash to work in ES2015. It replaces the computation of Size with a constant initializer. This avoids problems with bundlers being unable to transpile the Exponentiation operator `**`.  

Fixes: https://github.com/sinclairzx81/typebox/issues/1041