### PR TITLE
feat: allow importing Decode/Encode directly

### DIFF
--- a/src/value/decode/decode.ts
+++ b/src/value/decode/decode.ts
@@ -26,35 +26,20 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-// ------------------------------------------------------------------
-// Errors (re-export)
-// ------------------------------------------------------------------
-export { ValueError, ValueErrorType, ValueErrorIterator } from '../errors/index'
-// ------------------------------------------------------------------
-// Guards
-// ------------------------------------------------------------------
-export * from './guard/index'
-// ------------------------------------------------------------------
-// Operators
-// ------------------------------------------------------------------
-export * from './assert/index'
-export * from './cast/index'
-export * from './check/index'
-export * from './clean/index'
-export * from './clone/index'
-export * from './convert/index'
-export * from './create/index'
-export * from './decode/index'
-export * from './default/index'
-export * from './delta/index'
-export * from './encode/index'
-export * from './equal/index'
-export * from './hash/index'
-export * from './mutate/index'
-export * from './parse/index'
-export * from './pointer/index'
-export * from './transform/index'
-// ------------------------------------------------------------------
-// Namespace
-// ------------------------------------------------------------------
-export { Value } from './value/index'
+import { HasTransform, TransformDecode, TransformDecodeCheckError } from '../transform/index'
+import { Check } from '../check/index'
+import { Errors } from '../../errors/index'
+
+import type { TSchema } from '../../type/schema/index'
+import type { StaticDecode } from '../../type/static/index'
+
+/** Decodes a value or throws if error */
+export function Decode<T extends TSchema, Static = StaticDecode<T>, Result extends Static = Static>(schema: T, references: TSchema[], value: unknown): Result
+/** Decodes a value or throws if error */
+export function Decode<T extends TSchema, Static = StaticDecode<T>, Result extends Static = Static>(schema: T, value: unknown): Result
+/** Decodes a value or throws if error */
+export function Decode(...args: any[]): any {
+  const [schema, references, value] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], [], args[1]]
+  if (!Check(schema, references, value)) throw new TransformDecodeCheckError(schema, value, Errors(schema, references, value).First()!)
+  return HasTransform(schema, references) ? TransformDecode(schema, references, value) : value
+}

--- a/src/value/decode/index.ts
+++ b/src/value/decode/index.ts
@@ -26,35 +26,4 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-// ------------------------------------------------------------------
-// Errors (re-export)
-// ------------------------------------------------------------------
-export { ValueError, ValueErrorType, ValueErrorIterator } from '../errors/index'
-// ------------------------------------------------------------------
-// Guards
-// ------------------------------------------------------------------
-export * from './guard/index'
-// ------------------------------------------------------------------
-// Operators
-// ------------------------------------------------------------------
-export * from './assert/index'
-export * from './cast/index'
-export * from './check/index'
-export * from './clean/index'
-export * from './clone/index'
-export * from './convert/index'
-export * from './create/index'
-export * from './decode/index'
-export * from './default/index'
-export * from './delta/index'
-export * from './encode/index'
-export * from './equal/index'
-export * from './hash/index'
-export * from './mutate/index'
-export * from './parse/index'
-export * from './pointer/index'
-export * from './transform/index'
-// ------------------------------------------------------------------
-// Namespace
-// ------------------------------------------------------------------
-export { Value } from './value/index'
+export * from './decode'

--- a/src/value/encode/encode.ts
+++ b/src/value/encode/encode.ts
@@ -26,35 +26,21 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-// ------------------------------------------------------------------
-// Errors (re-export)
-// ------------------------------------------------------------------
-export { ValueError, ValueErrorType, ValueErrorIterator } from '../errors/index'
-// ------------------------------------------------------------------
-// Guards
-// ------------------------------------------------------------------
-export * from './guard/index'
-// ------------------------------------------------------------------
-// Operators
-// ------------------------------------------------------------------
-export * from './assert/index'
-export * from './cast/index'
-export * from './check/index'
-export * from './clean/index'
-export * from './clone/index'
-export * from './convert/index'
-export * from './create/index'
-export * from './decode/index'
-export * from './default/index'
-export * from './delta/index'
-export * from './encode/index'
-export * from './equal/index'
-export * from './hash/index'
-export * from './mutate/index'
-export * from './parse/index'
-export * from './pointer/index'
-export * from './transform/index'
-// ------------------------------------------------------------------
-// Namespace
-// ------------------------------------------------------------------
-export { Value } from './value/index'
+import { HasTransform, TransformEncode, TransformEncodeCheckError } from '../transform/index'
+import { Check } from '../check/index'
+import { Errors } from '../../errors/index'
+
+import type { TSchema } from '../../type/schema/index'
+import type { StaticEncode } from '../../type/static/index'
+
+/** Encodes a value or throws if error */
+export function Encode<T extends TSchema, Static = StaticEncode<T>, Result extends Static = Static>(schema: T, references: TSchema[], value: unknown): Result
+/** Encodes a value or throws if error */
+export function Encode<T extends TSchema, Static = StaticEncode<T>, Result extends Static = Static>(schema: T, value: unknown): Result
+/** Encodes a value or throws if error */
+export function Encode(...args: any[]): any {
+  const [schema, references, value] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], [], args[1]]
+  const encoded = HasTransform(schema, references) ? TransformEncode(schema, references, value) : value
+  if (!Check(schema, references, encoded)) throw new TransformEncodeCheckError(schema, encoded, Errors(schema, references, encoded).First()!)
+  return encoded
+}

--- a/src/value/encode/index.ts
+++ b/src/value/encode/index.ts
@@ -26,35 +26,4 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-// ------------------------------------------------------------------
-// Errors (re-export)
-// ------------------------------------------------------------------
-export { ValueError, ValueErrorType, ValueErrorIterator } from '../errors/index'
-// ------------------------------------------------------------------
-// Guards
-// ------------------------------------------------------------------
-export * from './guard/index'
-// ------------------------------------------------------------------
-// Operators
-// ------------------------------------------------------------------
-export * from './assert/index'
-export * from './cast/index'
-export * from './check/index'
-export * from './clean/index'
-export * from './clone/index'
-export * from './convert/index'
-export * from './create/index'
-export * from './decode/index'
-export * from './default/index'
-export * from './delta/index'
-export * from './encode/index'
-export * from './equal/index'
-export * from './hash/index'
-export * from './mutate/index'
-export * from './parse/index'
-export * from './pointer/index'
-export * from './transform/index'
-// ------------------------------------------------------------------
-// Namespace
-// ------------------------------------------------------------------
-export { Value } from './value/index'
+export * from './encode'

--- a/src/value/value/value.ts
+++ b/src/value/value/value.ts
@@ -26,139 +26,20 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { HasTransform, TransformDecode, TransformEncode, TransformDecodeCheckError, TransformEncodeCheckError } from '../transform/index'
-import { Assert as AssertValue } from '../assert/index'
-import { Mutate as MutateValue, type Mutable } from '../mutate/index'
-import { Hash as HashValue } from '../hash/index'
-import { Equal as EqualValue } from '../equal/index'
-import { Cast as CastValue } from '../cast/index'
-import { Clone as CloneValue } from '../clone/index'
-import { Convert as ConvertValue } from '../convert/index'
-import { Create as CreateValue } from '../create/index'
-import { Clean as CleanValue } from '../clean/index'
-import { Check as CheckValue } from '../check/index'
-import { Parse as ParseValue } from '../parse/index'
-import { Default as DefaultValue } from '../default/index'
-import { Diff as DiffValue, Patch as PatchValue, Edit } from '../delta/index'
-import { Errors as ValueErrors, ValueErrorIterator } from '../../errors/index'
+export { Errors, ValueErrorIterator } from '../../errors/index'
 
-import type { TSchema } from '../../type/schema/index'
-import type { Static, StaticDecode, StaticEncode } from '../../type/static/index'
-
-/** Asserts a value matches the given type or throws an `AssertError` if invalid. */
-export function Assert<T extends TSchema, R = Static<T>>(schema: T, references: TSchema[], value: unknown): asserts value is R
-/** Asserts a value matches the given type or throws an `AssertError` if invalid. */
-export function Assert<T extends TSchema, R = Static<T>>(schema: T, value: unknown): asserts value is R
-/** Asserts a value matches the given type or throws an `AssertError` if invalid. */
-export function Assert(...args: any[]): any {
-  return AssertValue.apply(AssertValue, args as any)
-}
-/** Casts a value into a given type. The return value will retain as much information of the original value as possible. */
-export function Cast<T extends TSchema>(schema: T, references: TSchema[], value: unknown): Static<T>
-/** Casts a value into a given type. The return value will retain as much information of the original value as possible. */
-export function Cast<T extends TSchema>(schema: T, value: unknown): Static<T>
-/** Casts a value into a given type. The return value will retain as much information of the original value as possible. */
-export function Cast(...args: any[]): any {
-  return CastValue.apply(CastValue, args as any)
-}
-/** Creates a value from the given type and references */
-export function Create<T extends TSchema>(schema: T, references: TSchema[]): Static<T>
-/** Creates a value from the given type */
-export function Create<T extends TSchema>(schema: T): Static<T>
-/** Creates a value from the given type */
-export function Create(...args: any[]): any {
-  return CreateValue.apply(CreateValue, args as any)
-}
-/** Returns true if the value matches the given type and references */
-export function Check<T extends TSchema>(schema: T, references: TSchema[], value: unknown): value is Static<T>
-/** Returns true if the value matches the given type */
-export function Check<T extends TSchema>(schema: T, value: unknown): value is Static<T>
-/** Returns true if the value matches the given type */
-export function Check(...args: any[]): any {
-  return CheckValue.apply(CheckValue, args as any)
-}
-/** `[Mutable]` Removes excess properties from a value and returns the result. This function does not check the value and returns an unknown type. You should Check the result before use. Clean is a mutable operation. To avoid mutation, Clone the value first. */
-export function Clean(schema: TSchema, references: TSchema[], value: unknown): unknown
-/** `[Mutable]` Removes excess properties from a value and returns the result. This function does not check the value and returns an unknown type. You should Check the result before use. Clean is a mutable operation. To avoid mutation, Clone the value first. */
-export function Clean(schema: TSchema, value: unknown): unknown
-/** `[Mutable]` Removes excess properties from a value and returns the result. This function does not check the value and returns an unknown type. You should Check the result before use. Clean is a mutable operation. To avoid mutation, Clone the value first. */
-export function Clean(...args: any[]): any {
-  return CleanValue.apply(CleanValue, args as any)
-}
-/** `[Mutable]` Converts any type mismatched values to their target type if a reasonable conversion is possible. */
-export function Convert(schema: TSchema, references: TSchema[], value: unknown): unknown
-/** `[Mutable]` Converts any type mismatched values to their target type if a reasonable conversion is possible. */
-export function Convert(schema: TSchema, value: unknown): unknown
-/** `[Mutable]` Converts any type mismatched values to their target type if a reasonable conversion is possible. */
-export function Convert(...args: any[]): any {
-  return ConvertValue.apply(ConvertValue, args as any)
-}
-/** Returns a structural clone of the given value */
-export function Clone<T>(value: T): T {
-  return CloneValue(value)
-}
-/** Decodes a value or throws if error */
-export function Decode<T extends TSchema, Static = StaticDecode<T>, Result extends Static = Static>(schema: T, references: TSchema[], value: unknown): Result
-/** Decodes a value or throws if error */
-export function Decode<T extends TSchema, Static = StaticDecode<T>, Result extends Static = Static>(schema: T, value: unknown): Result
-/** Decodes a value or throws if error */
-export function Decode(...args: any[]): any {
-  const [schema, references, value] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], [], args[1]]
-  if (!Check(schema, references, value)) throw new TransformDecodeCheckError(schema, value, Errors(schema, references, value).First()!)
-  return HasTransform(schema, references) ? TransformDecode(schema, references, value) : value
-}
-/** `[Mutable]` Generates missing properties on a value using default schema annotations if available. This function does not check the value and returns an unknown type. You should Check the result before use. Default is a mutable operation. To avoid mutation, Clone the value first. */
-export function Default(schema: TSchema, references: TSchema[], value: unknown): unknown
-/** `[Mutable]` Generates missing properties on a value using default schema annotations if available. This function does not check the value and returns an unknown type. You should Check the result before use. Default is a mutable operation. To avoid mutation, Clone the value first. */
-export function Default(schema: TSchema, value: unknown): unknown
-/** `[Mutable]` Generates missing properties on a value using default schema annotations if available. This function does not check the value and returns an unknown type. You should Check the result before use. Default is a mutable operation. To avoid mutation, Clone the value first. */
-export function Default(...args: any[]): any {
-  return DefaultValue.apply(DefaultValue, args as any)
-}
-/** Encodes a value or throws if error */
-export function Encode<T extends TSchema, Static = StaticEncode<T>, Result extends Static = Static>(schema: T, references: TSchema[], value: unknown): Result
-/** Encodes a value or throws if error */
-export function Encode<T extends TSchema, Static = StaticEncode<T>, Result extends Static = Static>(schema: T, value: unknown): Result
-/** Encodes a value or throws if error */
-export function Encode(...args: any[]): any {
-  const [schema, references, value] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], [], args[1]]
-  const encoded = HasTransform(schema, references) ? TransformEncode(schema, references, value) : value
-  if (!Check(schema, references, encoded)) throw new TransformEncodeCheckError(schema, encoded, Errors(schema, references, encoded).First()!)
-  return encoded
-}
-/** Parses a value or throws an `AssertError` if invalid. */
-export function Parse<T extends TSchema, R = StaticDecode<T>>(schema: T, references: TSchema[], value: unknown): R
-/** Parses a value or throws an `AssertError` if invalid. */
-export function Parse<T extends TSchema, R = StaticDecode<T>>(schema: T, value: unknown): R
-/** Parses a value or throws an `AssertError` if invalid. */
-export function Parse(...args: any[]): unknown {
-  return ParseValue.apply(ParseValue, args as any)
-}
-/** Returns an iterator for each error in this value. */
-export function Errors<T extends TSchema>(schema: T, references: TSchema[], value: unknown): ValueErrorIterator
-/** Returns an iterator for each error in this value. */
-export function Errors<T extends TSchema>(schema: T, value: unknown): ValueErrorIterator
-/** Returns an iterator for each error in this value. */
-export function Errors(...args: any[]): any {
-  return ValueErrors.apply(ValueErrors, args as any)
-}
-/** Returns true if left and right values are structurally equal */
-export function Equal<T>(left: T, right: unknown): right is T {
-  return EqualValue(left, right)
-}
-/** Returns edits to transform the current value into the next value */
-export function Diff(current: unknown, next: unknown): Edit[] {
-  return DiffValue(current, next)
-}
-/** Returns a FNV1A-64 non cryptographic hash of the given value */
-export function Hash(value: unknown): bigint {
-  return HashValue(value)
-}
-/** Returns a new value with edits applied to the given value */
-export function Patch<T = any>(current: unknown, edits: Edit[]): T {
-  return PatchValue(current, edits) as T
-}
-/** `[Mutable]` Performs a deep mutable value assignment while retaining internal references. */
-export function Mutate(current: Mutable, next: Mutable): void {
-  MutateValue(current, next)
-}
+export { Assert } from '../assert/index'
+export { Cast } from '../cast/index'
+export { Check } from '../check/index'
+export { Clean } from '../clean/index'
+export { Clone } from '../clone/index'
+export { Convert } from '../convert/index'
+export { Create } from '../create/index'
+export { Decode } from '../decode/index'
+export { Default } from '../default/index'
+export { Diff, Patch, Edit } from '../delta/index'
+export { Encode } from '../encode/index'
+export { Equal } from '../equal/index'
+export { Hash } from '../hash/index'
+export { Mutate, type Mutable } from '../mutate/index'
+export { Parse } from '../parse/index'


### PR DESCRIPTION
Fixes #876

ESBuild *has no support* for tree-shaking of **re-exported namespaces**, which is what TypeBox is doing with its `Value` namespace.

By separating `Decode` and `Encode` into standalone modules, ESBuild can shake anything else not used in the `@sinclair/typebox/value` module.