### PR TITLE
Fix: use var

### DIFF
--- a/src/type/object/object.ts
+++ b/src/type/object/object.ts
@@ -98,4 +98,4 @@ function _Object<T extends TProperties>(properties: T, options?: ObjectOptions):
 }
 
 /** `[Json]` Creates an Object type */
-export const Object = _Object
+export var Object = _Object


### PR DESCRIPTION
This PR addresses issue https://github.com/sinclairzx81/typebox/issues/1055 to make TypeBox compatible with Babel.