### PR TITLE
Revision 0.33.21

### DIFF
--- a/changelog/0.33.0.md
+++ b/changelog/0.33.0.md
@@ -1,4 +1,6 @@
 ### 0.33.0
+- [Revision 0.33.21](https://github.com/sinclairzx81/typebox/pull/1064)
+  - [1063](https://github.com/sinclairzx81/typebox/issues/1063) Hotfix to resolve variable shadowing on Object (Parser Runtime)
 - [Revision 0.33.20](https://github.com/sinclairzx81/typebox/pull/1062)
   - Add TypeScript Parsing Infrastructure. Add Parse API to top level import.
 - [Revision 0.33.19](https://github.com/sinclairzx81/typebox/pull/1061)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.33.20",
+  "version": "0.33.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.33.20",
+      "version": "0.33.21",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.33.20",
+  "version": "0.33.21",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/parse/runtime.ts
+++ b/src/parse/runtime.ts
@@ -322,7 +322,7 @@ const ObjectMapping = (values: Record<string, Types.TSchema>[]) => Types.Object(
   return { ...properties, ...record }
 }, {} as Types.TProperties))
 // prettier-ignore
-const Object = Runtime.Tuple([
+const _Object = Runtime.Tuple([
   Runtime.Const(LBrace),
   Runtime.Ref<Record<string, Types.TSchema>[]>('Properties'),
   Runtime.Const(RBrace)
@@ -644,7 +644,7 @@ export const Module = new Runtime.Module({
   Property,
   PropertyDelimiter,
   Properties,
-  Object,
+  Object: _Object,
   Elements,
   Tuple,
   Parameter,


### PR DESCRIPTION
This PR applies a 0.33.21 hot fix for a combinator named Object shadowing the globalThis.Object object in CommonJS. Renamed to _Object.

Fixes: https://github.com/sinclairzx81/typebox/issues/1063