### PR TITLE
Revision 0.34.3

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -1,8 +1,11 @@
 ### 0.34.0
-- [Revision 0.34.1](https://github.com/sinclairzx81/typebox/pull/1080)
-  - Implement Computed Type Deref in Modules
+
+- [Revision 0.34.3](https://github.com/sinclairzx81/typebox/pull/1083)
+  - Retain Array Elements on Value Default
 - [Revision 0.34.2](https://github.com/sinclairzx81/typebox/pull/1082)
   - Resolve import pathing issue introduced on 0.34.1
+- [Revision 0.34.1](https://github.com/sinclairzx81/typebox/pull/1080)
+  - Implement Computed Type Deref in Modules
 
 ## [0.34.0](https://www.npmjs.com/package/@sinclair/typebox/v/0.34.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.2",
+      "version": "0.34.3",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/default/default.ts
+++ b/src/value/default/default.ts
@@ -68,6 +68,14 @@ function HasDefaultProperty(schema: unknown): schema is TSchema {
 // Types
 // ------------------------------------------------------------------
 function FromArray(schema: TArray, references: TSchema[], value: unknown): any {
+  // if the value is an array, we attempt to initialize it's elements
+  if (IsArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      value[i] = Visit(schema.items, references, value[i])
+    }
+    return value
+  }
+  // ... otherwise use default initialization
   const defaulted = ValueOrDefault(schema, value)
   if (!IsArray(defaulted)) return defaulted
   for (let i = 0; i < defaulted.length; i++) {

--- a/test/runtime/value/default/array.ts
+++ b/test/runtime/value/default/array.ts
@@ -21,4 +21,30 @@ describe('value/default/Array', () => {
     const R = Value.Default(T, [1, undefined, 3])
     Assert.IsEqual(R, [1, 2, 3])
   })
+  // ----------------------------------------------------------------
+  // Elements
+  // ----------------------------------------------------------------
+  it('Should should retain array and only initialize undefined elements', () => {
+    const T = Type.Array(Type.Literal('hello', { default: 'hello' }))
+    const R = Value.Default(T, [1, undefined, 3])
+    Assert.IsEqual(R, [1, 'hello', 3])
+  })
+  // ----------------------------------------------------------------
+  // https://github.com/ubiquity-os-marketplace/command-start-stop/pull/86
+  // ----------------------------------------------------------------
+  it('Should retain arrays 1', () => {
+    const U = Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C'), Type.Literal('D')], { default: 'A' })
+    const T = Type.Array(U, { default: ['A', 'B', 'C', 'D'], uniqueItems: true })
+    Assert.IsEqual(Value.Default(T, undefined), ['A', 'B', 'C', 'D'])
+    Assert.IsEqual(Value.Default(T, []), [])
+    Assert.IsEqual(Value.Default(T, ['A']), ['A'])
+    // initialize undefined element
+    Assert.IsEqual(Value.Default(T, [undefined, 'B', 'C', 'D']), ['A', 'B', 'C', 'D'])
+  })
+  it('Should retain arrays 2', () => {
+    const U = Type.Union([Type.Literal('A'), Type.Literal('B'), Type.Literal('C'), Type.Literal('D')], { default: 'A' })
+    // undefined first element initialized by union default
+    const T = Type.Array(U, { default: [undefined, 'B', 'C', 'D'], uniqueItems: true })
+    Assert.IsEqual(Value.Default(T, undefined), ['A', 'B', 'C', 'D'])
+  })
 })


### PR DESCRIPTION
This PR applies a fix for Value.Default. The previous logic would overwrite existing Array elements on Default, which is incorrect behavior. This update retains the Array, but continues to apply interior defaults to any `undefined` elements.

Issue found via PR: https://github.com/ubiquity-os-marketplace/command-start-stop/pull/86