### PR TITLE
Revision 0.34.6

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -1,4 +1,6 @@
 ### 0.34.0
+- [Revision 0.34.6](https://github.com/sinclairzx81/typebox/pull/1090)
+  - Add Computed To Type and Kind Guards (IsSchema)
 - [Revision 0.34.5](https://github.com/sinclairzx81/typebox/pull/1088)
   - Record Types no longer TCompute for TRef Value Type (Modules)
 - [Revision 0.34.4](https://github.com/sinclairzx81/typebox/pull/1085)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.5",
+  "version": "0.34.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.5",
+      "version": "0.34.6",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.5",
+  "version": "0.34.6",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/type/guard/kind.ts
+++ b/src/type/guard/kind.ts
@@ -265,6 +265,7 @@ export function IsSchema(value: unknown): value is TSchema {
     IsBoolean(value) ||
     IsBigInt(value) ||
     IsAsyncIterator(value) ||
+    IsComputed(value) ||
     IsConstructor(value) ||
     IsDate(value) ||
     IsFunction(value) ||

--- a/src/type/guard/type.ts
+++ b/src/type/guard/type.ts
@@ -221,7 +221,13 @@ export function IsBoolean(value: unknown): value is TBoolean {
 }
 /** Returns true if the given value is TComputed */
 export function IsComputed(value: unknown): value is TComputed {
-  return IsKindOf(value, 'Computed') && ValueGuard.IsString(value.target) && ValueGuard.IsArray(value.parameters) //&& value.parameters.every((schema) => IsSchema(schema))
+  // prettier-ignore
+  return (
+    IsKindOf(value, 'Computed') && 
+    ValueGuard.IsString(value.target) && 
+    ValueGuard.IsArray(value.parameters) && 
+    value.parameters.every((schema) => IsSchema(schema))
+  )
 }
 /** Returns true if the given value is TConstructor */
 export function IsConstructor(value: unknown): value is TConstructor {

--- a/src/type/guard/type.ts
+++ b/src/type/guard/type.ts
@@ -221,7 +221,7 @@ export function IsBoolean(value: unknown): value is TBoolean {
 }
 /** Returns true if the given value is TComputed */
 export function IsComputed(value: unknown): value is TComputed {
-  return IsKindOf(value, 'Computed') && IsString(value.target) && ValueGuard.IsArray(value.parameters) && value.parameters.every((schema) => IsSchema(schema))
+  return IsKindOf(value, 'Computed') && ValueGuard.IsString(value.target) && ValueGuard.IsArray(value.parameters) //&& value.parameters.every((schema) => IsSchema(schema))
 }
 /** Returns true if the given value is TConstructor */
 export function IsConstructor(value: unknown): value is TConstructor {
@@ -606,6 +606,7 @@ export function IsSchema(value: unknown): value is TSchema {
       IsBoolean(value) ||
       IsBigInt(value) ||
       IsAsyncIterator(value) ||
+      IsComputed(value) ||
       IsConstructor(value) ||
       IsDate(value) ||
       IsFunction(value) ||

--- a/src/type/module/compute.ts
+++ b/src/type/module/compute.ts
@@ -36,7 +36,7 @@ import { TComputed } from '../computed/index'
 import { Constructor, type TConstructor } from '../constructor/index'
 import { Index, type TIndex } from '../indexed/index'
 import { TEnum, TEnumRecord } from '../enum/index'
-import { Function, type TFunction } from '../function/index'
+import { Function as FunctionType, type TFunction } from '../function/index'
 import { Intersect, type TIntersect, type TIntersectEvaluated } from '../intersect/index'
 import { Iterator, type TIterator } from '../iterator/index'
 import { KeyOf, type TKeyOf } from '../keyof/index'
@@ -261,7 +261,7 @@ function FromFunction<ModuleProperties extends TProperties, Parameters extends T
   parameters: [...Parameters],
   returnType: ReturnType,
 ): TFromFunction<ModuleProperties, Parameters, ReturnType> {
-  return Function(FromRest(moduleProperties, parameters as never), FromType(moduleProperties, returnType) as never) as never
+  return FunctionType(FromRest(moduleProperties, parameters as never), FromType(moduleProperties, returnType) as never) as never
 }
 // ------------------------------------------------------------------
 // Tuple

--- a/test/runtime/type/guard/kind/computed.ts
+++ b/test/runtime/type/guard/kind/computed.ts
@@ -4,6 +4,14 @@ import { Assert } from '../../../assert/index'
 
 describe('guard/kind/TComputed', () => {
   // ----------------------------------------------------------------
+  // Schema
+  // ----------------------------------------------------------------
+  it('Should guard for Schema', () => {
+    const T = Type.Partial(Type.Ref('A'))
+    Assert.IsTrue(KindGuard.IsComputed(T))
+    Assert.IsTrue(KindGuard.IsSchema(T))
+  })
+  // ----------------------------------------------------------------
   // Record
   // ----------------------------------------------------------------
   it('Should guard for Record 1', () => {

--- a/test/runtime/type/guard/type/computed.ts
+++ b/test/runtime/type/guard/type/computed.ts
@@ -1,28 +1,36 @@
-import { KindGuard } from '@sinclair/typebox'
+import { TypeGuard } from '@sinclair/typebox'
 import { Type } from '@sinclair/typebox'
 import { Assert } from '../../../assert/index'
 
 describe('guard/type/TComputed', () => {
   // ----------------------------------------------------------------
+  // Schema
+  // ----------------------------------------------------------------
+  it('Should guard for Schema', () => {
+    const T = Type.Partial(Type.Ref('A'))
+    Assert.IsTrue(TypeGuard.IsComputed(T))
+    Assert.IsTrue(TypeGuard.IsSchema(T))
+  })
+  // ----------------------------------------------------------------
   // Record
   // ----------------------------------------------------------------
   it('Should guard for Record 1', () => {
     const T = Type.Record(Type.String(), Type.String())
-    Assert.IsTrue(KindGuard.IsRecord(T))
+    Assert.IsTrue(TypeGuard.IsRecord(T))
   })
   // TRecord<TRecordKey, TRef<...>> is not computed.
   it('Should guard for Record 3', () => {
     const T = Type.Record(Type.String(), Type.Ref('A'))
-    Assert.IsTrue(KindGuard.IsRecord(T))
+    Assert.IsTrue(TypeGuard.IsRecord(T))
   })
   // TRecord<TRecordKey, TComputed<..., [TRef<...>]> is computed due to interior computed.
   it('Should guard for Record 3', () => {
     const T = Type.Record(Type.String(), Type.Partial(Type.Ref('A')))
-    Assert.IsTrue(KindGuard.IsComputed(T))
+    Assert.IsTrue(TypeGuard.IsComputed(T))
   })
   // TRecord<TRef<...>, TSchema> is computed as schematics may be transformed to TObject if finite
   it('Should guard for Record 4', () => {
     const T = Type.Record(Type.Ref('A'), Type.String())
-    Assert.IsTrue(KindGuard.IsComputed(T))
+    Assert.IsTrue(TypeGuard.IsComputed(T))
   })
 })


### PR DESCRIPTION
This PR applies missing Kind and Type Guard checks for TComputed (IsSchema). It also corrects the `IsString` check which was failing for IsComputed on the TypeGuard.