### PR TITLE
Revision 0.34.7

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -1,4 +1,6 @@
 ### 0.34.0
+- [Revision 0.34.7](https://github.com/sinclairzx81/typebox/pull/1091)
+  - Revert Ref(Schema) Signature with Deprecation Notice
 - [Revision 0.34.6](https://github.com/sinclairzx81/typebox/pull/1090)
   - Add Computed To Type and Kind Guards (IsSchema)
 - [Revision 0.34.5](https://github.com/sinclairzx81/typebox/pull/1088)

--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -1,5 +1,5 @@
 ### 0.34.0
-- [Revision 0.34.7](https://github.com/sinclairzx81/typebox/pull/1091)
+- [Revision 0.34.7](https://github.com/sinclairzx81/typebox/pull/1093)
   - Revert Ref(Schema) Signature with Deprecation Notice
 - [Revision 0.34.6](https://github.com/sinclairzx81/typebox/pull/1090)
   - Add Computed To Type and Kind Guards (IsSchema)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.6",
+  "version": "0.34.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.6",
+      "version": "0.34.7",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.6",
+  "version": "0.34.7",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/readme.md
+++ b/readme.md
@@ -534,15 +534,7 @@ The following table lists the supported Json types. These types are fully compat
 │                                │                             │ }                              │
 │                                │                             │                                │
 ├────────────────────────────────┼─────────────────────────────┼────────────────────────────────┤
-│ const T = Type.Object({        │ type T = {                  │ const R = {                    │
-│    x: Type.Number(),           │   x: number,                │   $ref: 'T'                    │
-│    y: Type.Number()            │   y: number                 │ }                              │
-│ }, { $id: 'T' })               | }                           │                                │
-│                                │                             │                                │
-│ const R = Type.Ref(T)          │ type R = T                  │                                │
-│                                │                             │                                │
-│                                │                             │                                │
-│                                │                             │                                │
+│ const R = Type.Ref('T')        │ type R = unknown            │ const R = { $ref: 'T' }        │
 │                                │                             │                                │
 └────────────────────────────────┴─────────────────────────────┴────────────────────────────────┘
 ```

--- a/src/type/type/json.ts
+++ b/src/type/type/json.ts
@@ -57,7 +57,7 @@ import { Readonly, type TReadonlyWithFlag, type TReadonlyFromMappedResult } from
 import { ReadonlyOptional, type TReadonlyOptional } from '../readonly-optional/index'
 import { Record, type TRecordOrObject } from '../record/index'
 import { Recursive, type TRecursive, type TThis } from '../recursive/index'
-import { Ref, type TRef } from '../ref/index'
+import { Ref, type TRef, type TRefUnsafe } from '../ref/index'
 import { Required, type TRequired, type TRequiredFromMappedResult } from '../required/index'
 import { Rest, type TRest } from '../rest/index'
 import { type TSchema, type SchemaOptions } from '../schema/index'
@@ -259,9 +259,28 @@ export class JsonTypeBuilder {
   public Recursive<T extends TSchema>(callback: (thisType: TThis) => T, options?: SchemaOptions): TRecursive<T> {
     return Recursive(callback, options)
   }
-  /** `[Json]` Creates a Ref type. */
-  public Ref<Ref extends string>($ref: Ref, options?: SchemaOptions): TRef<Ref> {
-    return Ref($ref, options)
+
+  /** `[Json]` Creates a Ref type.*/
+  public Ref<Ref extends string>($ref: Ref, options?: SchemaOptions): TRef<Ref>
+  /**
+   * @deprecated `[Json]` Creates a Ref type. The referenced type MUST contain a $id. The Ref(TSchema) signature was
+   * deprecated on 0.34.0 in support of a new type referencing model (Module). Existing implementations using Ref(TSchema)
+   * can migrate using the following. The Ref(TSchema) validation behavior of Ref will be preserved how the construction
+   * of legacy Ref(TSchema) will require wrapping in TUnsafe (where TUnsafe is used for inference only)
+   *
+   * ```typescript
+   * const R = Type.Ref(T)
+   * ```
+   * to
+   *
+   * ```typescript
+   * const R = Type.Unsafe<Static<T>>(T.$id)
+   * ```
+   */
+  public Ref<Type extends TSchema>(type: Type, options?: SchemaOptions): TRefUnsafe<Type>
+  /** `[Json]` Creates a Ref type. The referenced type must contain a $id */
+  public Ref(...args: any[]): unknown {
+    return Ref(args[0] as string, args[1])
   }
   /** `[Json]` Constructs a type where all properties are required */
   public Required<MappedResult extends TMappedResult>(type: MappedResult, options?: SchemaOptions): TRequiredFromMappedResult<MappedResult>

--- a/test/runtime/compiler-ajv/ref.ts
+++ b/test/runtime/compiler-ajv/ref.ts
@@ -2,6 +2,18 @@ import { Type } from '@sinclair/typebox'
 import { Ok, Fail } from './validate'
 
 describe('compiler-ajv/Ref', () => {
+  // ----------------------------------------------------------------
+  // Deprecated
+  // ----------------------------------------------------------------
+  it('Should validate for Ref(Schema)', () => {
+    const T = Type.Number({ $id: 'T' })
+    const R = Type.Ref(T)
+    Ok(R, 1234, [T])
+    Fail(R, 'hello', [T])
+  })
+  // ----------------------------------------------------------------
+  // Standard
+  // ----------------------------------------------------------------
   it('Should should validate when referencing a type', () => {
     const T = Type.Object(
       {

--- a/test/runtime/compiler/ref.ts
+++ b/test/runtime/compiler/ref.ts
@@ -3,6 +3,18 @@ import { Ok, Fail } from './validate'
 import { Assert } from '../assert/index'
 
 describe('compiler/Ref', () => {
+  // ----------------------------------------------------------------
+  // Deprecated
+  // ----------------------------------------------------------------
+  it('Should validate for Ref(Schema)', () => {
+    const T = Type.Number({ $id: 'T' })
+    const R = Type.Ref(T)
+    Ok(R, 1234, [T])
+    Fail(R, 'hello', [T])
+  })
+  // ----------------------------------------------------------------
+  // Standard
+  // ----------------------------------------------------------------
   it('Should should validate when referencing a type', () => {
     const T = Type.Object(
       {

--- a/test/runtime/type/guard/kind/ref.ts
+++ b/test/runtime/type/guard/kind/ref.ts
@@ -3,6 +3,27 @@ import { Type } from '@sinclair/typebox'
 import { Assert } from '../../../assert/index'
 
 describe('guard/kind/TRef', () => {
+  // ----------------------------------------------------------------
+  // Deprecated
+  // ----------------------------------------------------------------
+  it('Should guard for Ref(Schema) 1', () => {
+    const T = Type.Number({ $id: 'T' })
+    const R = Type.Ref(T)
+    Assert.IsTrue(KindGuard.IsRef(R))
+    Assert.IsTrue(typeof R['$ref'] === 'string')
+  })
+  it('Should guard for Ref(Schema) 2', () => {
+    const T = Type.Number()
+    Assert.Throws(() => Type.Ref(T))
+  })
+  it('Should guard for Ref(Schema) 3', () => {
+    // @ts-ignore
+    const T = Type.Number({ $id: null })
+    Assert.Throws(() => Type.Ref(T))
+  })
+  // ----------------------------------------------------------------
+  // Standard
+  // ----------------------------------------------------------------
   it('Should guard for TRef', () => {
     const T = Type.Number({ $id: 'T' })
     const R = KindGuard.IsRef(Type.Ref(T))

--- a/test/runtime/type/guard/type/ref.ts
+++ b/test/runtime/type/guard/type/ref.ts
@@ -3,6 +3,27 @@ import { Type, CloneType } from '@sinclair/typebox'
 import { Assert } from '../../../assert/index'
 
 describe('guard/type/TRef', () => {
+  // ----------------------------------------------------------------
+  // Deprecated
+  // ----------------------------------------------------------------
+  it('Should guard for Ref(Schema) 1', () => {
+    const T = Type.Number({ $id: 'T' })
+    const R = Type.Ref(T)
+    Assert.IsTrue(TypeGuard.IsRef(R))
+    Assert.IsTrue(typeof R['$ref'] === 'string')
+  })
+  it('Should guard for Ref(Schema) 2', () => {
+    const T = Type.Number()
+    Assert.Throws(() => Type.Ref(T))
+  })
+  it('Should guard for Ref(Schema) 3', () => {
+    // @ts-ignore
+    const T = Type.Number({ $id: null })
+    Assert.Throws(() => Type.Ref(T))
+  })
+  // ----------------------------------------------------------------
+  // Standard
+  // ----------------------------------------------------------------
   it('Should guard for TRef', () => {
     const T = Type.Number({ $id: 'T' })
     const R = TypeGuard.IsRef(Type.Ref('T'))

--- a/test/runtime/value/check/ref.ts
+++ b/test/runtime/value/check/ref.ts
@@ -3,6 +3,18 @@ import { Type } from '@sinclair/typebox'
 import { Assert } from '../../assert/index'
 
 describe('value/check/Ref', () => {
+  // ----------------------------------------------------------------
+  // Deprecated
+  // ----------------------------------------------------------------
+  it('Should validate for Ref(Schema)', () => {
+    const T = Type.Number({ $id: 'T' })
+    const R = Type.Ref(T)
+    Assert.IsTrue(Value.Check(T, [T], 1234))
+    Assert.IsFalse(Value.Check(T, [T], 'hello'))
+  })
+  // ----------------------------------------------------------------
+  // Standard
+  // ----------------------------------------------------------------
   it('Should should validate when referencing a type', () => {
     const T = Type.Object(
       {


### PR DESCRIPTION
This PR reverts the Ref(Schema) signature with a deprecation notice. This to prevent some downstream tooling from breaking on the latest version. This signature will be retained for 0.34.x, but dropped on 0.35.0. 