### PR TITLE
Fix importing optional properties

### DIFF
--- a/src/type/module/compute.ts
+++ b/src/type/module/compute.ts
@@ -364,7 +364,7 @@ export type TFromType<ModuleProperties extends TProperties, Type extends TSchema
 // prettier-ignore
 export function FromType<ModuleProperties extends TProperties, Type extends TSchema>(moduleProperties: ModuleProperties, type: Type): TFromType<ModuleProperties, Type> {
   return (
-    // Modifier Unwrap
+    // Modifier Unwrap - Reapplied via CreateType Options
     KindGuard.IsOptional(type) ? CreateType(FromType(moduleProperties, Discard(type, [OptionalKind]) as TSchema) as never, type) :
     KindGuard.IsReadonly(type) ? CreateType(FromType(moduleProperties, Discard(type, [ReadonlyKind]) as TSchema) as never, type) :
     // Traveral

--- a/src/type/module/compute.ts
+++ b/src/type/module/compute.ts
@@ -42,6 +42,7 @@ import { Iterator, type TIterator } from '../iterator/index'
 import { KeyOf, type TKeyOf } from '../keyof/index'
 import { Object, type TObject, type TProperties } from '../object/index'
 import { Omit, type TOmit } from '../omit/index'
+import { type TOptional } from '../optional'
 import { Pick, type TPick } from '../pick/index'
 import { Never, type TNever } from '../never/index'
 import { Partial, TPartial } from '../partial/index'
@@ -340,6 +341,7 @@ function FromRest<ModuleProperties extends TProperties, Types extends TSchema[]>
 // ------------------------------------------------------------------
 // prettier-ignore
 export type TFromType<ModuleProperties extends TProperties, Type extends TSchema> = (
+  Type extends TOptional<infer Type extends TSchema> ? TOptional<TFromType<ModuleProperties, Type>> :
   Type extends TArray<infer Type extends TSchema> ? TFromArray<ModuleProperties, Type> :
   Type extends TAsyncIterator<infer Type extends TSchema> ? TFromAsyncIterator<ModuleProperties, Type> :
   Type extends TComputed<infer Target extends string, infer Parameters extends TSchema[]> ? TFromComputed<ModuleProperties, Target, Parameters> :

--- a/test/runtime/compiler-ajv/module.ts
+++ b/test/runtime/compiler-ajv/module.ts
@@ -75,4 +75,35 @@ describe('compiler-ajv/Module', () => {
     Ok(T, 'hello')
     Fail(T, 'world')
   })
+  // ----------------------------------------------------------------
+  // Modifiers
+  // ----------------------------------------------------------------
+  it('Should validate objects with property modifiers 1', () => {
+    const Module = Type.Module({
+      T: Type.Object({
+        x: Type.ReadonlyOptional(Type.Null()),
+        y: Type.Readonly(Type.Null()),
+        z: Type.Optional(Type.Null()),
+        w: Type.Null(),
+      }),
+    })
+    const T = Module.Import('T')
+    Ok(T, { x: null, y: null, w: null })
+    Ok(T, { y: null, w: null })
+    Fail(T, { x: 1, y: null, w: null })
+  })
+  it('Should validate objects with property modifiers 2', () => {
+    const Module = Type.Module({
+      T: Type.Object({
+        x: Type.ReadonlyOptional(Type.Array(Type.Null())),
+        y: Type.Readonly(Type.Array(Type.Null())),
+        z: Type.Optional(Type.Array(Type.Null())),
+        w: Type.Array(Type.Null()),
+      }),
+    })
+    const T = Module.Import('T')
+    Ok(T, { x: [null], y: [null], w: [null] })
+    Ok(T, { y: [null], w: [null] })
+    Fail(T, { x: [1], y: [null], w: [null] })
+  })
 })

--- a/test/runtime/compiler/module.ts
+++ b/test/runtime/compiler/module.ts
@@ -75,4 +75,35 @@ describe('compiler/Module', () => {
     Ok(T, 'hello')
     Fail(T, 'world')
   })
+  // ----------------------------------------------------------------
+  // Modifiers
+  // ----------------------------------------------------------------
+  it('Should validate objects with property modifiers 1', () => {
+    const Module = Type.Module({
+      T: Type.Object({
+        x: Type.ReadonlyOptional(Type.Null()),
+        y: Type.Readonly(Type.Null()),
+        z: Type.Optional(Type.Null()),
+        w: Type.Null(),
+      }),
+    })
+    const T = Module.Import('T')
+    Ok(T, { x: null, y: null, w: null })
+    Ok(T, { y: null, w: null })
+    Fail(T, { x: 1, y: null, w: null })
+  })
+  it('Should validate objects with property modifiers 2', () => {
+    const Module = Type.Module({
+      T: Type.Object({
+        x: Type.ReadonlyOptional(Type.Array(Type.Null())),
+        y: Type.Readonly(Type.Array(Type.Null())),
+        z: Type.Optional(Type.Array(Type.Null())),
+        w: Type.Array(Type.Null()),
+      }),
+    })
+    const T = Module.Import('T')
+    Ok(T, { x: [null], y: [null], w: [null] })
+    Ok(T, { y: [null], w: [null] })
+    Fail(T, { x: [1], y: [null], w: [null] })
+  })
 })

--- a/test/runtime/type/guard/kind/import.ts
+++ b/test/runtime/type/guard/kind/import.ts
@@ -190,4 +190,91 @@ describe('guard/kind/TImport', () => {
     Assert.IsTrue(T.$defs['R'].anyOf[0].const === 'x')
     Assert.IsTrue(T.$defs['R'].anyOf[1].const === 'y')
   })
+  // ----------------------------------------------------------------
+  // Modifiers: 1
+  // ----------------------------------------------------------------
+  it('Should compute for Modifiers 1', () => {
+    const Module = Type.Module({
+      T: Type.Object({
+        x: Type.ReadonlyOptional(Type.Null()),
+        y: Type.Readonly(Type.Null()),
+        z: Type.Optional(Type.Null()),
+        w: Type.Null(),
+      }),
+    })
+    const T = Module.Import('T')
+    const R = T.$defs[T.$ref]
+    Assert.IsTrue(KindGuard.IsObject(R))
+
+    Assert.IsTrue(KindGuard.IsNull(R.properties.x))
+    Assert.IsTrue(KindGuard.IsReadonly(R.properties.x))
+    Assert.IsTrue(KindGuard.IsOptional(R.properties.x))
+
+    Assert.IsTrue(KindGuard.IsNull(R.properties.y))
+    Assert.IsTrue(KindGuard.IsReadonly(R.properties.y))
+    Assert.IsFalse(KindGuard.IsOptional(R.properties.y))
+
+    Assert.IsTrue(KindGuard.IsNull(R.properties.z))
+    Assert.IsTrue(KindGuard.IsOptional(R.properties.z))
+    Assert.IsFalse(KindGuard.IsReadonly(R.properties.z))
+
+    Assert.IsTrue(KindGuard.IsNull(R.properties.w))
+    Assert.IsFalse(KindGuard.IsOptional(R.properties.w))
+    Assert.IsFalse(KindGuard.IsReadonly(R.properties.w))
+  })
+  // ----------------------------------------------------------------
+  // Modifiers: 2
+  // ----------------------------------------------------------------
+  it('Should compute for Modifiers 2', () => {
+    const Module = Type.Module({
+      T: Type.Object({
+        x: Type.ReadonlyOptional(Type.Array(Type.Null())),
+        y: Type.Readonly(Type.Array(Type.Null())),
+        z: Type.Optional(Type.Array(Type.Null())),
+        w: Type.Array(Type.Null()),
+      }),
+    })
+    const T = Module.Import('T')
+    const R = T.$defs[T.$ref]
+    Assert.IsTrue(KindGuard.IsObject(R))
+
+    Assert.IsTrue(KindGuard.IsArray(R.properties.x))
+    Assert.IsTrue(KindGuard.IsNull(R.properties.x.items))
+    Assert.IsTrue(KindGuard.IsReadonly(R.properties.x))
+    Assert.IsTrue(KindGuard.IsOptional(R.properties.x))
+
+    Assert.IsTrue(KindGuard.IsArray(R.properties.y))
+    Assert.IsTrue(KindGuard.IsNull(R.properties.y.items))
+    Assert.IsTrue(KindGuard.IsReadonly(R.properties.y))
+    Assert.IsFalse(KindGuard.IsOptional(R.properties.y))
+
+    Assert.IsTrue(KindGuard.IsArray(R.properties.z))
+    Assert.IsTrue(KindGuard.IsNull(R.properties.z.items))
+    Assert.IsTrue(KindGuard.IsOptional(R.properties.z))
+    Assert.IsFalse(KindGuard.IsReadonly(R.properties.z))
+
+    Assert.IsTrue(KindGuard.IsArray(R.properties.w))
+    Assert.IsTrue(KindGuard.IsNull(R.properties.w.items))
+    Assert.IsFalse(KindGuard.IsOptional(R.properties.w))
+    Assert.IsFalse(KindGuard.IsReadonly(R.properties.w))
+  })
+  // ----------------------------------------------------------------
+  // Modifiers: 3
+  // ----------------------------------------------------------------
+  it('Should compute for Modifiers 3', () => {
+    const Module = Type.Module({
+      T: Type.Object({
+        x: Type.Array(Type.Null()),
+      }),
+      // Computed Partial
+      U: Type.Partial(Type.Ref('T')),
+    })
+    const T = Module.Import('U')
+    const R = T.$defs[T.$ref]
+    Assert.IsTrue(KindGuard.IsObject(R))
+
+    Assert.IsTrue(KindGuard.IsArray(R.properties.x))
+    Assert.IsTrue(KindGuard.IsNull(R.properties.x.items))
+    Assert.IsTrue(KindGuard.IsOptional(R.properties.x))
+  })
 })

--- a/test/runtime/type/guard/type/import.ts
+++ b/test/runtime/type/guard/type/import.ts
@@ -144,8 +144,6 @@ describe('guard/type/TImport', () => {
       R: Type.Record(Type.String(), Type.Ref('T')),
     })
     const T = Module.Import('R')
-
-    console.dir(T, { depth: 100 })
     Assert.IsTrue(TypeGuard.IsRecord(T.$defs['R']))
     // note: TRecord<TSchema, TRef<...>> are not computed. Only the Key is
     // computed as TypeBox needs to make a deferred call to transform from
@@ -191,5 +189,92 @@ describe('guard/type/TImport', () => {
     Assert.IsTrue(TypeGuard.IsLiteral(T.$defs['R'].anyOf[1]))
     Assert.IsTrue(T.$defs['R'].anyOf[0].const === 'x')
     Assert.IsTrue(T.$defs['R'].anyOf[1].const === 'y')
+  })
+  // ----------------------------------------------------------------
+  // Modifiers: 1
+  // ----------------------------------------------------------------
+  it('Should compute for Modifiers 1', () => {
+    const Module = Type.Module({
+      T: Type.Object({
+        x: Type.ReadonlyOptional(Type.Null()),
+        y: Type.Readonly(Type.Null()),
+        z: Type.Optional(Type.Null()),
+        w: Type.Null(),
+      }),
+    })
+    const T = Module.Import('T')
+    const R = T.$defs[T.$ref]
+    Assert.IsTrue(TypeGuard.IsObject(R))
+
+    Assert.IsTrue(TypeGuard.IsNull(R.properties.x))
+    Assert.IsTrue(TypeGuard.IsReadonly(R.properties.x))
+    Assert.IsTrue(TypeGuard.IsOptional(R.properties.x))
+
+    Assert.IsTrue(TypeGuard.IsNull(R.properties.y))
+    Assert.IsTrue(TypeGuard.IsReadonly(R.properties.y))
+    Assert.IsFalse(TypeGuard.IsOptional(R.properties.y))
+
+    Assert.IsTrue(TypeGuard.IsNull(R.properties.z))
+    Assert.IsTrue(TypeGuard.IsOptional(R.properties.z))
+    Assert.IsFalse(TypeGuard.IsReadonly(R.properties.z))
+
+    Assert.IsTrue(TypeGuard.IsNull(R.properties.w))
+    Assert.IsFalse(TypeGuard.IsOptional(R.properties.w))
+    Assert.IsFalse(TypeGuard.IsReadonly(R.properties.w))
+  })
+  // ----------------------------------------------------------------
+  // Modifiers: 2
+  // ----------------------------------------------------------------
+  it('Should compute for Modifiers 2', () => {
+    const Module = Type.Module({
+      T: Type.Object({
+        x: Type.ReadonlyOptional(Type.Array(Type.Null())),
+        y: Type.Readonly(Type.Array(Type.Null())),
+        z: Type.Optional(Type.Array(Type.Null())),
+        w: Type.Array(Type.Null()),
+      }),
+    })
+    const T = Module.Import('T')
+    const R = T.$defs[T.$ref]
+    Assert.IsTrue(TypeGuard.IsObject(R))
+
+    Assert.IsTrue(TypeGuard.IsArray(R.properties.x))
+    Assert.IsTrue(TypeGuard.IsNull(R.properties.x.items))
+    Assert.IsTrue(TypeGuard.IsReadonly(R.properties.x))
+    Assert.IsTrue(TypeGuard.IsOptional(R.properties.x))
+
+    Assert.IsTrue(TypeGuard.IsArray(R.properties.y))
+    Assert.IsTrue(TypeGuard.IsNull(R.properties.y.items))
+    Assert.IsTrue(TypeGuard.IsReadonly(R.properties.y))
+    Assert.IsFalse(TypeGuard.IsOptional(R.properties.y))
+
+    Assert.IsTrue(TypeGuard.IsArray(R.properties.z))
+    Assert.IsTrue(TypeGuard.IsNull(R.properties.z.items))
+    Assert.IsTrue(TypeGuard.IsOptional(R.properties.z))
+    Assert.IsFalse(TypeGuard.IsReadonly(R.properties.z))
+
+    Assert.IsTrue(TypeGuard.IsArray(R.properties.w))
+    Assert.IsTrue(TypeGuard.IsNull(R.properties.w.items))
+    Assert.IsFalse(TypeGuard.IsOptional(R.properties.w))
+    Assert.IsFalse(TypeGuard.IsReadonly(R.properties.w))
+  })
+  // ----------------------------------------------------------------
+  // Modifiers: 3
+  // ----------------------------------------------------------------
+  it('Should compute for Modifiers 3', () => {
+    const Module = Type.Module({
+      T: Type.Object({
+        x: Type.Array(Type.Null()),
+      }),
+      // Computed Partial
+      U: Type.Partial(Type.Ref('T')),
+    })
+    const T = Module.Import('U')
+    const R = T.$defs[T.$ref]
+    Assert.IsTrue(TypeGuard.IsObject(R))
+
+    Assert.IsTrue(TypeGuard.IsArray(R.properties.x))
+    Assert.IsTrue(TypeGuard.IsNull(R.properties.x.items))
+    Assert.IsTrue(TypeGuard.IsOptional(R.properties.x))
   })
 })

--- a/test/runtime/value/check/module.ts
+++ b/test/runtime/value/check/module.ts
@@ -77,4 +77,17 @@ describe('value/check/Module', () => {
     Assert.IsTrue(Value.Check(T, 'hello'))
     Assert.IsFalse(Value.Check(T, 'world'))
   })
+  it('Should validate objects with optional properties', () => {
+    const Module = Type.Module({
+      A: Type.Object({
+        x: Type.Optional(Type.Number()),
+        y: Type.Optional(Type.Array(Type.Number())),
+        a: Type.String(),
+      }),
+    })
+    const T = Module.Import('A')
+    Assert.IsTrue(Value.Check(T, { a: '1' }))
+    Assert.IsTrue(Value.Check(T, { a: '1', x: 5, y: [4] }))
+    Assert.IsFalse(Value.Check(T, { a: '1', y: 'hello' }))
+  })
 })

--- a/test/runtime/value/check/module.ts
+++ b/test/runtime/value/check/module.ts
@@ -77,17 +77,35 @@ describe('value/check/Module', () => {
     Assert.IsTrue(Value.Check(T, 'hello'))
     Assert.IsFalse(Value.Check(T, 'world'))
   })
-  it('Should validate objects with optional properties', () => {
+  // ----------------------------------------------------------------
+  // Modifiers
+  // ----------------------------------------------------------------
+  it('Should validate objects with property modifiers 1', () => {
     const Module = Type.Module({
-      A: Type.Object({
-        x: Type.Optional(Type.Number()),
-        y: Type.Optional(Type.Array(Type.Number())),
-        a: Type.String(),
+      T: Type.Object({
+        x: Type.ReadonlyOptional(Type.Null()),
+        y: Type.Readonly(Type.Null()),
+        z: Type.Optional(Type.Null()),
+        w: Type.Null(),
       }),
     })
-    const T = Module.Import('A')
-    Assert.IsTrue(Value.Check(T, { a: '1' }))
-    Assert.IsTrue(Value.Check(T, { a: '1', x: 5, y: [4] }))
-    Assert.IsFalse(Value.Check(T, { a: '1', y: 'hello' }))
+    const T = Module.Import('T')
+    Assert.IsTrue(Value.Check(T, { x: null, y: null, w: null }))
+    Assert.IsTrue(Value.Check(T, { y: null, w: null }))
+    Assert.IsFalse(Value.Check(T, { x: 1, y: null, w: null }))
+  })
+  it('Should validate objects with property modifiers 2', () => {
+    const Module = Type.Module({
+      T: Type.Object({
+        x: Type.ReadonlyOptional(Type.Array(Type.Null())),
+        y: Type.Readonly(Type.Array(Type.Null())),
+        z: Type.Optional(Type.Array(Type.Null())),
+        w: Type.Array(Type.Null()),
+      }),
+    })
+    const T = Module.Import('T')
+    Assert.IsTrue(Value.Check(T, { x: [null], y: [null], w: [null] }))
+    Assert.IsTrue(Value.Check(T, { y: [null], w: [null] }))
+    Assert.IsFalse(Value.Check(T, { x: [1], y: [null], w: [null] }))
   })
 })

--- a/test/static/import.ts
+++ b/test/static/import.ts
@@ -102,13 +102,64 @@ import { Type, Static } from '@sinclair/typebox'
   }>()
 }
 // ------------------------------------------------------------------
-// Object 1
+// Modifiers 1
 // ------------------------------------------------------------------
 // prettier-ignore
 {
-  const T = Type.Module({
-    R: Type.Object({ x: Type.Optional(Type.Number()), a: Type.Optional(Type.Array(Type.Number())) }),
-  }).Import('R')
+  const Module = Type.Module({
+    T: Type.Object({
+      x: Type.ReadonlyOptional(Type.Null()), 
+      y: Type.Readonly(Type.Null()),
+      z: Type.Optional(Type.Null()),
+      w: Type.Null()
+    })
+  })
+  const T = Module.Import('T')
   type T = Static<typeof T>
-  Expect(T).ToStatic<{ x?: number, a?: number[] }>()
+  Expect(T).ToStatic<{ 
+    readonly x?: null,
+    readonly y: null,
+    z?: null,
+    w: null
+  }>()
+}
+// ------------------------------------------------------------------
+// Modifiers 2
+// ------------------------------------------------------------------
+// prettier-ignore
+{
+  const Module = Type.Module({
+    T: Type.Object({
+      x: Type.ReadonlyOptional(Type.Array(Type.Null())), 
+      y: Type.Readonly(Type.Array(Type.Null())),
+      z: Type.Optional(Type.Array(Type.Null())),
+      w: Type.Array(Type.Null())
+    })
+  })
+  const T = Module.Import('T')
+  type T = Static<typeof T>
+  Expect(T).ToStatic<{ 
+    readonly x?: null[],
+    readonly y: null[],
+    z?:null[],
+    w: null[]
+  }>()
+}
+// ------------------------------------------------------------------
+// Modifiers 3
+// ------------------------------------------------------------------
+// prettier-ignore
+{
+  const Module = Type.Module({
+    T: Type.Object({
+      x: Type.Array(Type.Null())
+    }),
+    // Computed Partial
+    U: Type.Partial(Type.Ref('T'))
+  })
+  const T = Module.Import('U')
+  type T = Static<typeof T>
+  Expect(T).ToStatic<{ 
+    x?: null[],
+  }>()
 }

--- a/test/static/import.ts
+++ b/test/static/import.ts
@@ -101,3 +101,14 @@ import { Type, Static } from '@sinclair/typebox'
     C: { x?: number, y?: number } 
   }>()
 }
+// ------------------------------------------------------------------
+// Object 1
+// ------------------------------------------------------------------
+// prettier-ignore
+{
+  const T = Type.Module({
+    R: Type.Object({ x: Type.Optional(Type.Number()), a: Type.Optional(Type.Array(Type.Number())) }),
+  }).Import('R')
+  type T = Static<typeof T>
+  Expect(T).ToStatic<{ x?: number, a?: number[] }>()
+}


### PR DESCRIPTION
Module types look like a great idea to simplify some of our recursive schemas.

I tried them out and noticed a problem with optional object properties:
When importing an object schema, the optional status is lost for all properties with the more complex types handled in `TFromType`.
This does not happen at run time as `[OptionalKind]` is carried over in the spread op in `CreateType`.
I added type and run time tests to verify my assumptions.

Hats off for building something so complex with such clean and readable code!