### PR TITLE
Revision 0.34.11

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -1,4 +1,6 @@
 ### 0.34.0
+- [Revision 0.34.11](https://github.com/sinclairzx81/typebox/pull/1110)
+  - Fix Compiler Emit for Deeply Referential Module Types
 - [Revision 0.34.10](https://github.com/sinclairzx81/typebox/pull/1107)
   - Fix Declaration Emit for Index and Mapped Types
   - Fix Record Inference Presentation when Embedded in Modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.10",
+  "version": "0.34.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.10",
+      "version": "0.34.11",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.10",
+  "version": "0.34.11",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -301,8 +301,7 @@ export namespace TypeCompiler {
     const members = globalThis.Object.getOwnPropertyNames(schema.$defs).reduce((result, key) => {
       return [...result, schema.$defs[key as never] as TSchema]
     }, [] as TSchema[])
-    const ref = Ref(schema.$ref)
-    yield* Visit(ref, [...references, ...members], value)
+    yield* Visit(Ref(schema.$ref), [...references, ...members], value)
   }
   function* FromInteger(schema: TInteger, references: TSchema[], value: string): IterableIterator<string> {
     yield `Number.isInteger(${value})`

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -59,7 +59,7 @@ import type { TNumber } from '../type/number/index'
 import type { TObject } from '../type/object/index'
 import type { TPromise } from '../type/promise/index'
 import type { TRecord } from '../type/record/index'
-import type { TRef } from '../type/ref/index'
+import { Ref, type TRef } from '../type/ref/index'
 import type { TRegExp } from '../type/regexp/index'
 import type { TTemplateLiteral } from '../type/template-literal/index'
 import type { TThis } from '../type/recursive/index'
@@ -298,11 +298,11 @@ export namespace TypeCompiler {
     yield `(typeof ${value} === 'function')`
   }
   function* FromImport(schema: TImport, references: TSchema[], value: string): IterableIterator<string> {
-    const interior = globalThis.Object.getOwnPropertyNames(schema.$defs).reduce((result, key) => {
+    const members = globalThis.Object.getOwnPropertyNames(schema.$defs).reduce((result, key) => {
       return [...result, schema.$defs[key as never] as TSchema]
     }, [] as TSchema[])
-    const target = { [Kind]: 'Ref', $ref: schema.$ref } as never
-    yield* Visit(target, [...references, ...interior], value)
+    const ref = Ref(schema.$ref)
+    yield* Visit(ref, [...references, ...members], value)
   }
   function* FromInteger(schema: TInteger, references: TSchema[], value: string): IterableIterator<string> {
     yield `Number.isInteger(${value})`

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -97,14 +97,6 @@ export class TypeCheck<T extends TSchema> {
   public Code(): string {
     return this.code
   }
-  /** Returns an iterator for each error in this value. */
-  public Errors(value: unknown): ValueErrorIterator {
-    return Errors(this.schema, this.references, value)
-  }
-  /** Returns true if the value matches the compiled type. */
-  public Check(value: unknown): value is Static<T> {
-    return this.checkFunc(value)
-  }
   /** Returns the schema type used to validate */
   public Schema(): T {
     return this.schema
@@ -113,13 +105,21 @@ export class TypeCheck<T extends TSchema> {
   public References(): TSchema[] {
     return this.references
   }
+  /** Returns an iterator for each error in this value. */
+  public Errors(value: unknown): ValueErrorIterator {
+    return Errors(this.schema, this.references, value)
+  }
+  /** Returns true if the value matches the compiled type. */
+  public Check(value: unknown): value is Static<T> {
+    return this.checkFunc(value)
+  }
   /** Decodes a value or throws if error */
   public Decode<Static = StaticDecode<T>, Result extends Static = Static>(value: unknown): Result {
     if (!this.checkFunc(value)) throw new TransformDecodeCheckError(this.schema, value, this.Errors(value).First()!)
     return (this.hasTransform ? TransformDecode(this.schema, this.references, value) : value) as never
   }
   /** Encodes a value or throws if error */
-  public Encode<Static = StaticDecode<T>, Result extends Static = Static>(value: unknown): Result {
+  public Encode<Static = StaticEncode<T>, Result extends Static = Static>(value: unknown): Result {
     const encoded = this.hasTransform ? TransformEncode(this.schema, this.references, value) : value
     if (!this.checkFunc(encoded)) throw new TransformEncodeCheckError(this.schema, value, this.Errors(value).First()!)
     return encoded as never

--- a/test/runtime/compiler-ajv/module.ts
+++ b/test/runtime/compiler-ajv/module.ts
@@ -106,4 +106,39 @@ describe('compiler-ajv/Module', () => {
     Ok(T, { y: [null], w: [null] })
     Fail(T, { x: [1], y: [null], w: [null] })
   })
+  // ----------------------------------------------------------------
+  // https://github.com/sinclairzx81/typebox/issues/1109
+  // ----------------------------------------------------------------
+  it('Should validate deep referential 1', () => {
+    const Module = Type.Module({
+      A: Type.Union([Type.Literal('Foo'), Type.Literal('Bar')]),
+      B: Type.Ref('A'),
+      C: Type.Object({ ref: Type.Ref('B') }),
+      D: Type.Union([Type.Ref('B'), Type.Ref('C')]),
+    })
+    Ok(Module.Import('A') as never, 'Foo')
+    Ok(Module.Import('A') as never, 'Bar')
+    Ok(Module.Import('B') as never, 'Foo')
+    Ok(Module.Import('B') as never, 'Bar')
+    Ok(Module.Import('C') as never, { ref: 'Foo' })
+    Ok(Module.Import('C') as never, { ref: 'Bar' })
+    Ok(Module.Import('D') as never, 'Foo')
+    Ok(Module.Import('D') as never, 'Bar')
+    Ok(Module.Import('D') as never, { ref: 'Foo' })
+    Ok(Module.Import('D') as never, { ref: 'Bar' })
+  })
+  it('Should validate deep referential 2', () => {
+    const Module = Type.Module({
+      A: Type.Literal('Foo'),
+      B: Type.Ref('A'),
+      C: Type.Ref('B'),
+      D: Type.Ref('C'),
+      E: Type.Ref('D'),
+    })
+    Ok(Module.Import('A'), 'Foo')
+    Ok(Module.Import('B'), 'Foo')
+    Ok(Module.Import('C'), 'Foo')
+    Ok(Module.Import('D'), 'Foo')
+    Ok(Module.Import('E'), 'Foo')
+  })
 })

--- a/test/runtime/compiler/module.ts
+++ b/test/runtime/compiler/module.ts
@@ -106,4 +106,39 @@ describe('compiler/Module', () => {
     Ok(T, { y: [null], w: [null] })
     Fail(T, { x: [1], y: [null], w: [null] })
   })
+  // ----------------------------------------------------------------
+  // https://github.com/sinclairzx81/typebox/issues/1109
+  // ----------------------------------------------------------------
+  it('Should validate deep referential 1', () => {
+    const Module = Type.Module({
+      A: Type.Union([Type.Literal('Foo'), Type.Literal('Bar')]),
+      B: Type.Ref('A'),
+      C: Type.Object({ ref: Type.Ref('B') }),
+      D: Type.Union([Type.Ref('B'), Type.Ref('C')]),
+    })
+    Ok(Module.Import('A') as never, 'Foo')
+    Ok(Module.Import('A') as never, 'Bar')
+    Ok(Module.Import('B') as never, 'Foo')
+    Ok(Module.Import('B') as never, 'Bar')
+    Ok(Module.Import('C') as never, { ref: 'Foo' })
+    Ok(Module.Import('C') as never, { ref: 'Bar' })
+    Ok(Module.Import('D') as never, 'Foo')
+    Ok(Module.Import('D') as never, 'Bar')
+    Ok(Module.Import('D') as never, { ref: 'Foo' })
+    Ok(Module.Import('D') as never, { ref: 'Bar' })
+  })
+  it('Should validate deep referential 2', () => {
+    const Module = Type.Module({
+      A: Type.Literal('Foo'),
+      B: Type.Ref('A'),
+      C: Type.Ref('B'),
+      D: Type.Ref('C'),
+      E: Type.Ref('D'),
+    })
+    Ok(Module.Import('A'), 'Foo')
+    Ok(Module.Import('B'), 'Foo')
+    Ok(Module.Import('C'), 'Foo')
+    Ok(Module.Import('D'), 'Foo')
+    Ok(Module.Import('E'), 'Foo')
+  })
 })

--- a/test/runtime/value/check/module.ts
+++ b/test/runtime/value/check/module.ts
@@ -108,4 +108,39 @@ describe('value/check/Module', () => {
     Assert.IsTrue(Value.Check(T, { y: [null], w: [null] }))
     Assert.IsFalse(Value.Check(T, { x: [1], y: [null], w: [null] }))
   })
+  // ----------------------------------------------------------------
+  // https://github.com/sinclairzx81/typebox/issues/1109
+  // ----------------------------------------------------------------
+  it('Should validate deep referential 1', () => {
+    const Module = Type.Module({
+      A: Type.Union([Type.Literal('Foo'), Type.Literal('Bar')]),
+      B: Type.Ref('A'),
+      C: Type.Object({ ref: Type.Ref('B') }),
+      D: Type.Union([Type.Ref('B'), Type.Ref('C')]),
+    })
+    Assert.IsTrue(Value.Check(Module.Import('A') as never, 'Foo'))
+    Assert.IsTrue(Value.Check(Module.Import('A') as never, 'Bar'))
+    Assert.IsTrue(Value.Check(Module.Import('B') as never, 'Foo'))
+    Assert.IsTrue(Value.Check(Module.Import('B') as never, 'Bar'))
+    Assert.IsTrue(Value.Check(Module.Import('C') as never, { ref: 'Foo' }))
+    Assert.IsTrue(Value.Check(Module.Import('C') as never, { ref: 'Bar' }))
+    Assert.IsTrue(Value.Check(Module.Import('D') as never, 'Foo'))
+    Assert.IsTrue(Value.Check(Module.Import('D') as never, 'Bar'))
+    Assert.IsTrue(Value.Check(Module.Import('D') as never, { ref: 'Foo' }))
+    Assert.IsTrue(Value.Check(Module.Import('D') as never, { ref: 'Bar' }))
+  })
+  it('Should validate deep referential 2', () => {
+    const Module = Type.Module({
+      A: Type.Literal('Foo'),
+      B: Type.Ref('A'),
+      C: Type.Ref('B'),
+      D: Type.Ref('C'),
+      E: Type.Ref('D'),
+    })
+    Assert.IsTrue(Value.Check(Module.Import('A'), 'Foo'))
+    Assert.IsTrue(Value.Check(Module.Import('B'), 'Foo'))
+    Assert.IsTrue(Value.Check(Module.Import('C'), 'Foo'))
+    Assert.IsTrue(Value.Check(Module.Import('D'), 'Foo'))
+    Assert.IsTrue(Value.Check(Module.Import('E'), 'Foo'))
+  })
 })


### PR DESCRIPTION
This PR applies a compiler fix for deeply referential module types. The following would be an example of this.

```typescript
// E -> D -> C -> B -> A
```
```typescript
it('Should validate deep referential 2', () => {
  const Module = Type.Module({
    A: Type.Literal('Foo'),
    B: Type.Ref('A'),
    C: Type.Ref('B'),
    D: Type.Ref('C'),
    E: Type.Ref('D'),
  })
  Ok(Module.Import('A'), 'Foo')
  Ok(Module.Import('B'), 'Foo')
  Ok(Module.Import('C'), 'Foo')
  Ok(Module.Import('D'), 'Foo')
  Ok(Module.Import('E'), 'Foo')
})
```

Related Issue: https://github.com/sinclairzx81/typebox/issues/1109