### PR TITLE
Revision 0.34.12

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -1,4 +1,7 @@
 ### 0.34.0
+- [Revision 0.34.12](https://github.com/sinclairzx81/typebox/pull/1120)
+  - [1119](https://github.com/sinclairzx81/typebox/issues/1119) Fix for Mutate Object Comparison
+  - [1117](https://github.com/sinclairzx81/typebox/issues/1117) Re-Add Type.Recursive Documentation
 - [Revision 0.34.11](https://github.com/sinclairzx81/typebox/pull/1110)
   - Fix Compiler Emit for Deeply Referential Module Types
 - [Revision 0.34.10](https://github.com/sinclairzx81/typebox/pull/1107)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.11",
+  "version": "0.34.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.11",
+      "version": "0.34.12",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.11",
+  "version": "0.34.12",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/mutate/mutate.ts
+++ b/src/value/mutate/mutate.ts
@@ -32,6 +32,12 @@ import { Clone } from '../clone/index'
 import { TypeBoxError } from '../../type/error/index'
 
 // ------------------------------------------------------------------
+// IsStandardObject
+// ------------------------------------------------------------------
+function IsStandardObject(value: unknown): value is Record<PropertyKey, unknown> {
+  return IsObject(value) && !IsArray(value)
+}
+// ------------------------------------------------------------------
 // Errors
 // ------------------------------------------------------------------
 export class ValueMutateError extends TypeBoxError {
@@ -44,7 +50,7 @@ export class ValueMutateError extends TypeBoxError {
 // ------------------------------------------------------------------
 export type Mutable = { [key: string]: unknown } | unknown[]
 function ObjectType(root: Mutable, path: string, current: unknown, next: Record<string, unknown>) {
-  if (!IsObject(current)) {
+  if (!IsStandardObject(current)) {
     ValuePointer.Set(root, path, Clone(next))
   } else {
     const currentKeys = Object.getOwnPropertyNames(current)
@@ -90,7 +96,7 @@ function ValueType(root: Mutable, path: string, current: unknown, next: unknown)
 function Visit(root: Mutable, path: string, current: unknown, next: unknown) {
   if (IsArray(next)) return ArrayType(root, path, current, next)
   if (IsTypedArray(next)) return TypedArrayType(root, path, current, next)
-  if (IsObject(next)) return ObjectType(root, path, current, next)
+  if (IsStandardObject(next)) return ObjectType(root, path, current, next)
   if (IsValueType(next)) return ValueType(root, path, current, next)
 }
 // ------------------------------------------------------------------
@@ -102,8 +108,8 @@ function IsNonMutableValue(value: unknown): value is Mutable {
 function IsMismatchedValue(current: unknown, next: unknown) {
   // prettier-ignore
   return (
-    (IsObject(current) && IsArray(next)) || 
-    (IsArray(current) && IsObject(next))
+    (IsStandardObject(current) && IsArray(next)) || 
+    (IsArray(current) && IsStandardObject(next))
   )
 }
 // ------------------------------------------------------------------

--- a/test/runtime/value/mutate/mutate.ts
+++ b/test/runtime/value/mutate/mutate.ts
@@ -85,4 +85,32 @@ describe('value/mutate/Mutate', () => {
     Assert.NotEqual(A.x, X)
     Assert.IsEqual(A.x, [1, 2, 3])
   })
+  // ----------------------------------------------------------------
+  // https://github.com/sinclairzx81/typebox/issues/1119
+  // ----------------------------------------------------------------
+  it('Should mutate array 1', () => {
+    const A: unknown[] = []
+    Value.Mutate(A, [])
+    Assert.IsEqual(A, [])
+  })
+  it('Should mutate array 2', () => {
+    const A: unknown[] = []
+    Value.Mutate(A, [1])
+    Assert.IsEqual(A, [1])
+  })
+  it('Should mutate array 3', () => {
+    const A: unknown[] = [1, 2, 3]
+    Value.Mutate(A, [1, 2])
+    Assert.IsEqual(A, [1, 2])
+  })
+  it('Should mutate array 4', () => {
+    const A: unknown[] = [1, 2, 3]
+    Value.Mutate(A, [1, 2, 3, 4])
+    Assert.IsEqual(A, [1, 2, 3, 4])
+  })
+  it('Should mutate array 5', () => {
+    const A: unknown[] = [1, 2, 3]
+    Value.Mutate(A, [{}, {}, {}, [1, 2, 3]])
+    Assert.IsEqual(A, [{}, {}, {}, [1, 2, 3]])
+  })
 })


### PR DESCRIPTION
This PR applies a fix for Value.Mutate, reimplementing the StandardObject check local to the Mutate function. This PR also re-adds the Type.Recursive documentation as per user request.

Fixes https://github.com/sinclairzx81/typebox/issues/1119
Fixes https://github.com/sinclairzx81/typebox/issues/1117