### PR TITLE
Revision 0.34.13

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -1,4 +1,6 @@
 ### 0.34.0
+- [Revision 0.34.13](https://github.com/sinclairzx81/typebox/pull/1124)
+  - Pre emptive fix for TypeScript 5.8.0-nightly to resolve symbol narrowing on Convert.
 - [Revision 0.34.12](https://github.com/sinclairzx81/typebox/pull/1120)
   - [1119](https://github.com/sinclairzx81/typebox/issues/1119) Fix for Mutate Object Comparison
   - [1117](https://github.com/sinclairzx81/typebox/issues/1117) Re-Add Type.Recursive Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.12",
+  "version": "0.34.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.12",
+      "version": "0.34.13",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.12",
+  "version": "0.34.13",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/value/convert/convert.ts
+++ b/src/value/convert/convert.ts
@@ -58,11 +58,6 @@ import type { TUndefined } from '../../type/undefined/index'
 import { IsArray, IsObject, IsDate, IsUndefined, IsString, IsNumber, IsBoolean, IsBigInt, IsSymbol, HasPropertyKey } from '../guard/index'
 
 // ------------------------------------------------------------------
-// TypeGuard
-// ------------------------------------------------------------------
-import { IsOptional } from '../../type/guard/kind'
-
-// ------------------------------------------------------------------
 // Conversions
 // ------------------------------------------------------------------
 function IsStringNumeric(value: unknown): value is string {
@@ -124,7 +119,7 @@ function TryConvertBigInt(value: unknown) {
   return IsStringNumeric(value) ? BigInt(truncateInteger(value)) : IsNumber(value) ? BigInt(Math.trunc(value)) : IsValueFalse(value) ? BigInt(0) : IsValueTrue(value) ? BigInt(1) : value
 }
 function TryConvertString(value: unknown) {
-  return IsValueToString(value) ? value.toString() : IsSymbol(value) && value.description !== undefined ? value.description.toString() : value
+  return IsSymbol(value) && value.description !== undefined ? value.description.toString() : IsValueToString(value) ? value.toString() : value
 }
 function TryConvertNumber(value: unknown) {
   return IsStringNumeric(value) ? parseFloat(value) : IsValueTrue(value) ? 1 : IsValueFalse(value) ? 0 : value


### PR DESCRIPTION
This PR is a pre emptive fix for TypeScript 5.8.0-nightly where narrowing for Symbols was breaking on Convert.