### PR TITLE
Revision 0.34.14

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -1,4 +1,6 @@
 ### 0.34.0
+- [Revision 0.34.14](https://github.com/sinclairzx81/typebox/pull/1140)
+  - [1139](https://github.com/sinclairzx81/typebox/issues/1139) Update TypeCompiler Check for Promise (use instanceof Promise over Thenable check)
 - [Revision 0.34.13](https://github.com/sinclairzx81/typebox/pull/1124)
   - Pre emptive fix for TypeScript 5.8.0-nightly to resolve symbol narrowing on Convert.
 - [Revision 0.34.12](https://github.com/sinclairzx81/typebox/pull/1120)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.13",
+  "version": "0.34.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.13",
+      "version": "0.34.14",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.13",
+  "version": "0.34.14",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -384,7 +384,7 @@ export namespace TypeCompiler {
     }
   }
   function* FromPromise(schema: TPromise, references: TSchema[], value: string): IterableIterator<string> {
-    yield `(typeof value === 'object' && typeof ${value}.then === 'function')`
+    yield `${value} instanceof Promise`
   }
   function* FromRecord(schema: TRecord, references: TSchema[], value: string): IterableIterator<string> {
     yield Policy.IsRecordLike(value)

--- a/src/value/guard/guard.ts
+++ b/src/value/guard/guard.ts
@@ -50,18 +50,18 @@ export type TypedArrayType =
 // --------------------------------------------------------------------------
 /** Returns true if this value is an async iterator */
 export function IsAsyncIterator(value: unknown): value is AsyncIterableIterator<any> {
-  return IsObject(value) && Symbol.asyncIterator in value
+  return IsObject(value) && globalThis.Symbol.asyncIterator in value
 }
 /** Returns true if this value is an iterator */
 export function IsIterator(value: unknown): value is IterableIterator<any> {
-  return IsObject(value) && Symbol.iterator in value
+  return IsObject(value) && globalThis.Symbol.iterator in value
 }
 // --------------------------------------------------------------------------
 // Object Instances
 // --------------------------------------------------------------------------
 /** Returns true if this value is not an instance of a class */
 export function IsStandardObject(value: unknown): value is ObjectType {
-  return IsObject(value) && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)
+  return IsObject(value) && (globalThis.Object.getPrototypeOf(value) === Object.prototype || globalThis.Object.getPrototypeOf(value) === null)
 }
 /** Returns true if this value is an instance of a class */
 export function IsInstanceObject(value: unknown): value is ObjectType {
@@ -72,11 +72,11 @@ export function IsInstanceObject(value: unknown): value is ObjectType {
 // --------------------------------------------------------------------------
 /** Returns true if this value is a Promise */
 export function IsPromise(value: unknown): value is Promise<unknown> {
-  return value instanceof Promise
+  return value instanceof globalThis.Promise
 }
 /** Returns true if this value is a Date */
 export function IsDate(value: unknown): value is Date {
-  return value instanceof Date && Number.isFinite(value.getTime())
+  return value instanceof Date && globalThis.Number.isFinite(value.getTime())
 }
 /** Returns true if this value is an instance of Map<K, T> */
 export function IsMap(value: unknown): value is Map<unknown, unknown> {
@@ -92,7 +92,7 @@ export function IsRegExp(value: unknown): value is RegExp {
 }
 /** Returns true if this value is a typed array */
 export function IsTypedArray(value: unknown): value is TypedArrayType {
-  return ArrayBuffer.isView(value)
+  return globalThis.ArrayBuffer.isView(value)
 }
 /** Returns true if the value is a Int8Array */
 export function IsInt8Array(value: unknown): value is Int8Array {
@@ -154,7 +154,7 @@ export function IsObject(value: unknown): value is ObjectType {
 }
 /** Returns true if this value is an array, but not a typed array */
 export function IsArray(value: unknown): value is ArrayType {
-  return Array.isArray(value) && !ArrayBuffer.isView(value)
+  return globalThis.Array.isArray(value) && !globalThis.ArrayBuffer.isView(value)
 }
 /** Returns true if this value is an undefined */
 export function IsUndefined(value: unknown): value is undefined {
@@ -174,7 +174,7 @@ export function IsNumber(value: unknown): value is number {
 }
 /** Returns true if this value is an integer */
 export function IsInteger(value: unknown): value is number {
-  return Number.isInteger(value)
+  return globalThis.Number.isInteger(value)
 }
 /** Returns true if this value is bigint */
 export function IsBigInt(value: unknown): value is bigint {


### PR DESCRIPTION
This PR updates the TypeCompiler Promise check. 

The updated check uses `instanceof Promise` vs only checking the `then` property. This is technically more correct as checking the `.then` property in isolation would only assert the value is a `PromiseLike<T>`. Additionally, this update aligns the compiler check to the `instanceof` check already implemented for Value.Check.

Reference  https://github.com/sinclairzx81/typebox/issues/1139







