### PR TITLE
Ecosystem reference - typebox-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1705,6 +1705,7 @@ The following is a list of community packages that offer general tooling, extend
 | [sveltekit-superforms](https://github.com/ciscoheat/sveltekit-superforms)  | A comprehensive SvelteKit form library for server and client validation |
 | [ts2typebox](https://github.com/xddq/ts2typebox) | Creating TypeBox code from Typescript types |
 | [typebox-form-parser](https://github.com/jtlapp/typebox-form-parser) | Parses form and query data based on TypeBox schemas |
+| [typebox-cli](https://github.com/gsuess/typebox-cli) | Generate Schema with typebox from the CLI |
 
 <a name='benchmark'></a>
 


### PR DESCRIPTION
Adds new tool to the list of packages in the eco system.

See more about this tool here: https://github.com/gsuess/typebox-cli