### PR TITLE
Revision 0.34.20

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -1,5 +1,5 @@
 ### 0.34.0
-- [Revision 0.34.20](https://github.com/sinclairzx81/typebox/pull/1166)
+- [Revision 0.34.20](https://github.com/sinclairzx81/typebox/pull/1167)
   - Hotfix: Disable Computed Types on Record
 - [Revision 0.34.19](https://github.com/sinclairzx81/typebox/pull/1166)
   - Hotfix: Republished due to NPM error

--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -1,4 +1,8 @@
 ### 0.34.0
+- [Revision 0.34.20](https://github.com/sinclairzx81/typebox/pull/1166)
+  - Hotfix: Disable Computed Types on Record
+- [Revision 0.34.19](https://github.com/sinclairzx81/typebox/pull/1166)
+  - Hotfix: Republished due to NPM error
 - [Revision 0.34.18](https://github.com/sinclairzx81/typebox/pull/1164)
   - Hotfix: Internal Remap Imports
 - [Revision 0.34.17](https://github.com/sinclairzx81/typebox/pull/1162)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.19",
+  "version": "0.34.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.19",
+      "version": "0.34.20",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.19",
+  "version": "0.34.20",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/type/record/record.ts
+++ b/src/type/record/record.ts
@@ -33,14 +33,12 @@ import type { Static } from '../static/index'
 import type { Evaluate, Ensure, Assert } from '../helpers/index'
 import { type TAny } from '../any/index'
 import { type TBoolean } from '../boolean/index'
-import { type TComputed, Computed } from '../computed/index'
 import { type TEnumRecord, type TEnum } from '../enum/index'
 import { type TInteger } from '../integer/index'
 import { type TLiteral, type TLiteralValue } from '../literal/index'
 import { type TNever, Never } from '../never/index'
 import { type TNumber, Number } from '../number/index'
 import { type TObject, type TProperties, type TAdditionalProperties, type ObjectOptions, Object } from '../object/index'
-import { type TRef, Ref } from '../ref/index'
 import { type TRegExp } from '../regexp/index'
 import { type TString, String } from '../string/index'
 import { type TUnion, Union } from '../union/index'
@@ -233,9 +231,6 @@ export interface TRecord<Key extends TSchema = TSchema, Type extends TSchema = T
 // ------------------------------------------------------------------
 // prettier-ignore
 export type TRecordOrObject<Key extends TSchema, Type extends TSchema> = (
-  Type extends TComputed<infer Target extends string, infer Parameters extends TSchema[]> ? TComputed<'Record', [Key, TComputed<Target, Parameters>]> :
-  Key extends TComputed<infer Target extends string, infer Parameters extends TSchema[]> ? TComputed<'Record', [TComputed<Target, Parameters>, Type]> :
-  Key extends TRef<infer Ref extends string> ? TComputed<'Record', [TRef<Ref>, Type]> :
   Key extends TTemplateLiteral ? TFromTemplateLiteralKey<Key, Type> :  
   Key extends TEnum<infer Enum extends TEnumRecord> ? TFromEnumKey<Enum, Type> : // (Special: Ensure resolve Enum before Union)
   Key extends TUnion<infer Types extends TSchema[]> ? TFromUnionKey<Types, Type> :
@@ -256,9 +251,6 @@ export type TRecordOrObject<Key extends TSchema, Type extends TSchema> = (
 export function Record<Key extends TSchema, Type extends TSchema>(key: Key, type: Type, options: ObjectOptions = {}): TRecordOrObject<Key, Type> {
   // prettier-ignore
   return (
-    IsComputed(type) ? Computed('Record', [key, Computed(type.target, type.parameters)], options) :
-    IsComputed(key) ? Computed('Record', [Computed(type.target, type.parameters), type], options) :
-    IsRef(key) ? Computed('Record', [Ref(key.$ref), type]) :
     IsUnion(key) ? FromUnionKey(key.anyOf, type, options) :
     IsTemplateLiteral(key) ? FromTemplateLiteralKey(key, type, options) :
     IsLiteral(key) ? FromLiteralKey(key.const, type, options) :

--- a/test/runtime/type/guard/kind/computed.ts
+++ b/test/runtime/type/guard/kind/computed.ts
@@ -18,19 +18,19 @@ describe('guard/kind/TComputed', () => {
     const T = Type.Record(Type.String(), Type.String())
     Assert.IsTrue(KindGuard.IsRecord(T))
   })
-  // TRecord<TRecordKey, TRef<...>> is not computed.
-  it('Should guard for Record 3', () => {
-    const T = Type.Record(Type.String(), Type.Ref('A'))
-    Assert.IsTrue(KindGuard.IsRecord(T))
-  })
-  // TRecord<TRecordKey, TComputed<..., [TRef<...>]> is computed due to interior computed.
-  it('Should guard for Record 3', () => {
-    const T = Type.Record(Type.String(), Type.Partial(Type.Ref('A')))
-    Assert.IsTrue(KindGuard.IsComputed(T))
-  })
-  // TRecord<TRef<...>, TSchema> is computed as schematics may be transformed to TObject if finite
-  it('Should guard for Record 4', () => {
-    const T = Type.Record(Type.Ref('A'), Type.String())
-    Assert.IsTrue(KindGuard.IsComputed(T))
-  })
+  // // TRecord<TRecordKey, TRef<...>> is not computed.
+  // it('Should guard for Record 3', () => {
+  //   const T = Type.Record(Type.String(), Type.Ref('A'))
+  //   Assert.IsTrue(KindGuard.IsRecord(T))
+  // })
+  // // TRecord<TRecordKey, TComputed<..., [TRef<...>]> is computed due to interior computed.
+  // it('Should guard for Record 3', () => {
+  //   const T = Type.Record(Type.String(), Type.Partial(Type.Ref('A')))
+  //   Assert.IsTrue(KindGuard.IsComputed(T))
+  // })
+  // // TRecord<TRef<...>, TSchema> is computed as schematics may be transformed to TObject if finite
+  // it('Should guard for Record 4', () => {
+  //   const T = Type.Record(Type.Ref('A'), Type.String())
+  //   Assert.IsTrue(KindGuard.IsComputed(T))
+  // })
 })

--- a/test/runtime/type/guard/kind/computed.ts
+++ b/test/runtime/type/guard/kind/computed.ts
@@ -18,19 +18,16 @@ describe('guard/kind/TComputed', () => {
     const T = Type.Record(Type.String(), Type.String())
     Assert.IsTrue(KindGuard.IsRecord(T))
   })
-  // // TRecord<TRecordKey, TRef<...>> is not computed.
-  // it('Should guard for Record 3', () => {
-  //   const T = Type.Record(Type.String(), Type.Ref('A'))
-  //   Assert.IsTrue(KindGuard.IsRecord(T))
-  // })
-  // // TRecord<TRecordKey, TComputed<..., [TRef<...>]> is computed due to interior computed.
-  // it('Should guard for Record 3', () => {
-  //   const T = Type.Record(Type.String(), Type.Partial(Type.Ref('A')))
-  //   Assert.IsTrue(KindGuard.IsComputed(T))
-  // })
-  // // TRecord<TRef<...>, TSchema> is computed as schematics may be transformed to TObject if finite
-  // it('Should guard for Record 4', () => {
-  //   const T = Type.Record(Type.Ref('A'), Type.String())
-  //   Assert.IsTrue(KindGuard.IsComputed(T))
-  // })
+  it('Should guard for Record 3', () => {
+    const T = Type.Record(Type.String(), Type.Ref('A'))
+    Assert.IsTrue(KindGuard.IsRecord(T))
+  })
+  it('Should guard for Record 3', () => {
+    const T = Type.Record(Type.String(), Type.Partial(Type.Ref('A')))
+    Assert.IsTrue(KindGuard.IsRecord(T))
+  })
+  it('Should guard for Record 4', () => {
+    const T = Type.Record(Type.Ref('A'), Type.String())
+    Assert.IsTrue(KindGuard.IsNever(T))
+  })
 })

--- a/test/runtime/type/guard/kind/import.ts
+++ b/test/runtime/type/guard/kind/import.ts
@@ -151,17 +151,17 @@ describe('guard/kind/TImport', () => {
     Assert.IsTrue(KindGuard.IsRef(T.$defs['R'].patternProperties['^(.*)$']))
     Assert.IsTrue(T.$defs['R'].patternProperties['^(.*)$'].$ref === 'T')
   })
-  it('Should compute for Record 2', () => {
-    const Module = Type.Module({
-      T: Type.Number(),
-      K: Type.Union([Type.Literal('x'), Type.Literal('y')]),
-      R: Type.Record(Type.Ref('K'), Type.Ref('T')),
-    })
-    const T = Module.Import('R')
-    Assert.IsTrue(KindGuard.IsObject(T.$defs['R']))
-    Assert.IsTrue(KindGuard.IsNumber(T.$defs['R'].properties.x))
-    Assert.IsTrue(KindGuard.IsNumber(T.$defs['R'].properties.x))
-  })
+  // it('Should compute for Record 2', () => {
+  //   const Module = Type.Module({
+  //     T: Type.Number(),
+  //     K: Type.Union([Type.Literal('x'), Type.Literal('y')]),
+  //     R: Type.Record(Type.Ref('K'), Type.Ref('T')),
+  //   })
+  //   const T = Module.Import('R')
+  //   Assert.IsTrue(KindGuard.IsObject(T.$defs['R']))
+  //   Assert.IsTrue(KindGuard.IsNumber(T.$defs['R'].properties.x))
+  //   Assert.IsTrue(KindGuard.IsNumber(T.$defs['R'].properties.x))
+  // })
   // ----------------------------------------------------------------
   // Computed: Required
   // ----------------------------------------------------------------

--- a/test/runtime/type/guard/type/computed.ts
+++ b/test/runtime/type/guard/type/computed.ts
@@ -18,19 +18,19 @@ describe('guard/type/TComputed', () => {
     const T = Type.Record(Type.String(), Type.String())
     Assert.IsTrue(TypeGuard.IsRecord(T))
   })
-  // TRecord<TRecordKey, TRef<...>> is not computed.
-  it('Should guard for Record 3', () => {
-    const T = Type.Record(Type.String(), Type.Ref('A'))
-    Assert.IsTrue(TypeGuard.IsRecord(T))
-  })
-  // TRecord<TRecordKey, TComputed<..., [TRef<...>]> is computed due to interior computed.
-  it('Should guard for Record 3', () => {
-    const T = Type.Record(Type.String(), Type.Partial(Type.Ref('A')))
-    Assert.IsTrue(TypeGuard.IsComputed(T))
-  })
-  // TRecord<TRef<...>, TSchema> is computed as schematics may be transformed to TObject if finite
-  it('Should guard for Record 4', () => {
-    const T = Type.Record(Type.Ref('A'), Type.String())
-    Assert.IsTrue(TypeGuard.IsComputed(T))
-  })
+  // // TRecord<TRecordKey, TRef<...>> is not computed.
+  // it('Should guard for Record 3', () => {
+  //   const T = Type.Record(Type.String(), Type.Ref('A'))
+  //   Assert.IsTrue(TypeGuard.IsRecord(T))
+  // })
+  // // TRecord<TRecordKey, TComputed<..., [TRef<...>]> is computed due to interior computed.
+  // it('Should guard for Record 3', () => {
+  //   const T = Type.Record(Type.String(), Type.Partial(Type.Ref('A')))
+  //   Assert.IsTrue(TypeGuard.IsComputed(T))
+  // })
+  // // TRecord<TRef<...>, TSchema> is computed as schematics may be transformed to TObject if finite
+  // it('Should guard for Record 4', () => {
+  //   const T = Type.Record(Type.Ref('A'), Type.String())
+  //   Assert.IsTrue(TypeGuard.IsComputed(T))
+  // })
 })

--- a/test/runtime/type/guard/type/computed.ts
+++ b/test/runtime/type/guard/type/computed.ts
@@ -18,19 +18,16 @@ describe('guard/type/TComputed', () => {
     const T = Type.Record(Type.String(), Type.String())
     Assert.IsTrue(TypeGuard.IsRecord(T))
   })
-  // // TRecord<TRecordKey, TRef<...>> is not computed.
-  // it('Should guard for Record 3', () => {
-  //   const T = Type.Record(Type.String(), Type.Ref('A'))
-  //   Assert.IsTrue(TypeGuard.IsRecord(T))
-  // })
-  // // TRecord<TRecordKey, TComputed<..., [TRef<...>]> is computed due to interior computed.
-  // it('Should guard for Record 3', () => {
-  //   const T = Type.Record(Type.String(), Type.Partial(Type.Ref('A')))
-  //   Assert.IsTrue(TypeGuard.IsComputed(T))
-  // })
-  // // TRecord<TRef<...>, TSchema> is computed as schematics may be transformed to TObject if finite
-  // it('Should guard for Record 4', () => {
-  //   const T = Type.Record(Type.Ref('A'), Type.String())
-  //   Assert.IsTrue(TypeGuard.IsComputed(T))
-  // })
+  it('Should guard for Record 3', () => {
+    const T = Type.Record(Type.String(), Type.Ref('A'))
+    Assert.IsTrue(TypeGuard.IsRecord(T))
+  })
+  it('Should guard for Record 3', () => {
+    const T = Type.Record(Type.String(), Type.Partial(Type.Ref('A')))
+    Assert.IsTrue(TypeGuard.IsRecord(T))
+  })
+  it('Should guard for Record 4', () => {
+    const T = Type.Record(Type.Ref('A'), Type.String())
+    Assert.IsTrue(TypeGuard.IsNever(T))
+  })
 })

--- a/test/runtime/type/guard/type/import.ts
+++ b/test/runtime/type/guard/type/import.ts
@@ -151,17 +151,17 @@ describe('guard/type/TImport', () => {
     Assert.IsTrue(TypeGuard.IsRef(T.$defs['R'].patternProperties['^(.*)$']))
     Assert.IsTrue(T.$defs['R'].patternProperties['^(.*)$'].$ref === 'T')
   })
-  it('Should compute for Record 2', () => {
-    const Module = Type.Module({
-      T: Type.Number(),
-      K: Type.Union([Type.Literal('x'), Type.Literal('y')]),
-      R: Type.Record(Type.Ref('K'), Type.Ref('T')),
-    })
-    const T = Module.Import('R')
-    Assert.IsTrue(TypeGuard.IsObject(T.$defs['R']))
-    Assert.IsTrue(TypeGuard.IsNumber(T.$defs['R'].properties.x))
-    Assert.IsTrue(TypeGuard.IsNumber(T.$defs['R'].properties.x))
-  })
+  // it('Should compute for Record 2', () => {
+  //   const Module = Type.Module({
+  //     T: Type.Number(),
+  //     K: Type.Union([Type.Literal('x'), Type.Literal('y')]),
+  //     R: Type.Record(Type.Ref('K'), Type.Ref('T')),
+  //   })
+  //   const T = Module.Import('R')
+  //   Assert.IsTrue(TypeGuard.IsObject(T.$defs['R']))
+  //   Assert.IsTrue(TypeGuard.IsNumber(T.$defs['R'].properties.x))
+  //   Assert.IsTrue(TypeGuard.IsNumber(T.$defs['R'].properties.x))
+  // })
   // ----------------------------------------------------------------
   // Computed: Required
   // ----------------------------------------------------------------

--- a/test/static/import.ts
+++ b/test/static/import.ts
@@ -58,49 +58,49 @@ import { Type, Static } from '@sinclair/typebox'
 // ------------------------------------------------------------------
 // prettier-ignore
 {
-  const T = Type.Module({
-    R: Type.Object({ x: Type.Number(), y: Type.Number() }),
-    T: Type.Record(Type.String(), Type.Partial(Type.Ref('R'))),
-  }).Import('T')
+  // const T = Type.Module({
+  //   R: Type.Object({ x: Type.Number(), y: Type.Number() }),
+  //   T: Type.Record(Type.String(), Type.Partial(Type.Ref('R'))),
+  // }).Import('T')
 
-  type T = Static<typeof T>
-  Expect(T).ToStatic<{ 
-    [key: string]: { x?: number, y?: number } 
-  }>()
+  // type T = Static<typeof T>
+  // Expect(T).ToStatic<{ 
+  //   [key: string]: { x?: number, y?: number } 
+  // }>()
 }
 // ------------------------------------------------------------------
 // Record 3
 // ------------------------------------------------------------------
 // prettier-ignore
 {
-  const T = Type.Module({
-    R: Type.Object({ x: Type.Number(), y: Type.Number() }),
-    K: Type.Number(),
-    T: Type.Record(Type.Ref('K'), Type.Partial(Type.Ref('R'))),
-  }).Import('T')
+  // const T = Type.Module({
+  //   R: Type.Object({ x: Type.Number(), y: Type.Number() }),
+  //   K: Type.Number(),
+  //   T: Type.Record(Type.Ref('K'), Type.Partial(Type.Ref('R'))),
+  // }).Import('T')
 
-  type T = Static<typeof T>
-  Expect(T).ToStatic<{ 
-    [key: number]: { x?: number, y?: number } 
-  }>()
+  // type T = Static<typeof T>
+  // Expect(T).ToStatic<{ 
+  //   [key: number]: { x?: number, y?: number } 
+  // }>()
 }
 // ------------------------------------------------------------------
 // Record 4
 // ------------------------------------------------------------------
 // prettier-ignore
-{
-  const T = Type.Module({
-    R: Type.Object({ x: Type.Number(), y: Type.Number() }),
-    K: Type.TemplateLiteral('${A|B|C}'),
-    T: Type.Record(Type.Ref('K'), Type.Partial(Type.Ref('R'))),
-  }).Import('T')
-  type T = Static<typeof T>
-  Expect(T).ToStatic<{ 
-    A: { x?: number, y?: number },
-    B: { x?: number, y?: number },
-    C: { x?: number, y?: number } 
-  }>()
-}
+// {
+//   const T = Type.Module({
+//     R: Type.Object({ x: Type.Number(), y: Type.Number() }),
+//     K: Type.TemplateLiteral('${A|B|C}'),
+//     T: Type.Record(Type.Ref('K'), Type.Partial(Type.Ref('R'))),
+//   }).Import('T')
+//   type T = Static<typeof T>
+//   Expect(T).ToStatic<{
+//     A: { x?: number, y?: number },
+//     B: { x?: number, y?: number },
+//     C: { x?: number, y?: number }
+//   }>()
+// }
 // ------------------------------------------------------------------
 // Modifiers 1
 // ------------------------------------------------------------------


### PR DESCRIPTION
This PR applies a Hotfix for Computed Record types. This actioned based on a comment on the following discussion thread

https://github.com/sinclairzx81/typebox/discussions/1071#discussioncomment-12173952

This PR effectively disables Computed Records outright. It's noted that the current type mapping logic for Record is too overly complex, and where the Computed parameters passed for either the Key or Value results in memory exhaustion for the TS compiler under some configurations. It's generally better to remove this logic than risk compiler faults due to the complexity.

A reimplementation of the Record type is required to support deferred computed parameters. Consider reverting back to overloaded method signatures as the TS compiler seems better equipped to handle inference when narrowing to specific signatures.

