### PR TITLE
Revision 0.34.21

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -1,6 +1,8 @@
 ### 0.34.0
+- [Revision 0.34.21](https://github.com/sinclairzx81/typebox/pull/1168)
+  - Reimplement Computed Record Types
 - [Revision 0.34.20](https://github.com/sinclairzx81/typebox/pull/1167)
-  - Hotfix: Disable Computed Types on Record
+  - Hotfix: Disable Computed Record Types
 - [Revision 0.34.19](https://github.com/sinclairzx81/typebox/pull/1166)
   - Hotfix: Republished due to NPM error
 - [Revision 0.34.18](https://github.com/sinclairzx81/typebox/pull/1164)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.20",
+  "version": "0.34.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.20",
+      "version": "0.34.21",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.20",
+  "version": "0.34.21",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/type/module/compute.ts
+++ b/src/type/module/compute.ts
@@ -236,9 +236,9 @@ function FromObject<ModuleProperties extends TProperties, Properties extends TPr
 // Record
 //
 // Note: Varying Runtime and Static path here as we need to retain
-// constraints on the Record. This requires remapping the Record
-// in the Runtime path and where the Static path is a facade for
-// Record pattern.
+// constraints on the Record. This requires remapping the entire
+// Record in the Runtime path but where the Static path is merely
+// a facade for the patternProperties regular expression.
 // ------------------------------------------------------------------
 // prettier-ignore
 type TFromRecord<ModuleProperties extends TProperties, Key extends TSchema, Value extends TSchema,

--- a/src/type/record/record.ts
+++ b/src/type/record/record.ts
@@ -277,14 +277,13 @@ export function RecordPattern(record: TRecord): string {
 // ------------------------------------------------------------------
 /** Gets the Records Key Type */
 // prettier-ignore
-export type TRecordKey<Type extends TRecord> = (
-  Type extends TRecord<infer Key extends TSchema, TSchema> 
-    ? (
-      Key extends TNumber ? TNumber :
-      Key extends TString ? TString :
-      TString
-    ) : TString
-)
+export type TRecordKey<Type extends TRecord,
+  Result extends TSchema = Type extends TRecord<infer Key extends TSchema, TSchema> ? (
+    Key extends TNumber ? TNumber :
+    Key extends TString ? TString :
+    TString
+  ) : TString
+> = Result
 /** Gets the Records Key Type */
 // prettier-ignore
 export function RecordKey<Type extends TRecord>(type: Type): TRecordKey<Type> {
@@ -300,9 +299,13 @@ export function RecordKey<Type extends TRecord>(type: Type): TRecordKey<Type> {
 // ------------------------------------------------------------------
 /** Gets a Record Value Type */
 // prettier-ignore
-export type TRecordValue<Type extends TRecord> = (
-  Type extends TRecord<TSchema, infer Value extends TSchema> ? Value : TNever
-)
+export type TRecordValue<Type extends TRecord,
+  Result extends TSchema = (
+    Type extends TRecord<TSchema, infer Value extends TSchema> 
+      ? Value 
+      : TNever
+    )
+> = Result
 /** Gets a Record Value Type */
 // prettier-ignore
 export function RecordValue<Type extends TRecord>(type: Type): TRecordValue<Type> {

--- a/test/runtime/type/guard/kind/import.ts
+++ b/test/runtime/type/guard/kind/import.ts
@@ -151,17 +151,28 @@ describe('guard/kind/TImport', () => {
     Assert.IsTrue(KindGuard.IsRef(T.$defs['R'].patternProperties['^(.*)$']))
     Assert.IsTrue(T.$defs['R'].patternProperties['^(.*)$'].$ref === 'T')
   })
-  // it('Should compute for Record 2', () => {
-  //   const Module = Type.Module({
-  //     T: Type.Number(),
-  //     K: Type.Union([Type.Literal('x'), Type.Literal('y')]),
-  //     R: Type.Record(Type.Ref('K'), Type.Ref('T')),
-  //   })
-  //   const T = Module.Import('R')
-  //   Assert.IsTrue(KindGuard.IsObject(T.$defs['R']))
-  //   Assert.IsTrue(KindGuard.IsNumber(T.$defs['R'].properties.x))
-  //   Assert.IsTrue(KindGuard.IsNumber(T.$defs['R'].properties.x))
-  // })
+  it('Should compute for Record 2', () => {
+    const Module = Type.Module({
+      T: Type.Number(),
+      R: Type.Record(Type.Union([Type.Literal('x'), Type.Literal('y')]), Type.Ref('T')),
+    })
+    // Retain reference if not computed
+    const T = Module.Import('R')
+    Assert.IsTrue(KindGuard.IsObject(T.$defs['R']))
+    Assert.IsTrue(KindGuard.IsRef(T.$defs['R'].properties.x))
+    Assert.IsTrue(KindGuard.IsRef(T.$defs['R'].properties.y))
+  })
+  it('Should compute for Record 3', () => {
+    const Module = Type.Module({
+      T: Type.Object({ x: Type.Number() }),
+      R: Type.Record(Type.Union([Type.Literal('x'), Type.Literal('y')]), Type.Partial(Type.Ref('T'))),
+    })
+    // Dereference if computed
+    const T = Module.Import('R')
+    Assert.IsTrue(KindGuard.IsObject(T.$defs['R']))
+    Assert.IsTrue(KindGuard.IsObject(T.$defs['R'].properties.x))
+    Assert.IsTrue(KindGuard.IsObject(T.$defs['R'].properties.y))
+  })
   // ----------------------------------------------------------------
   // Computed: Required
   // ----------------------------------------------------------------

--- a/test/runtime/type/guard/type/import.ts
+++ b/test/runtime/type/guard/type/import.ts
@@ -151,17 +151,28 @@ describe('guard/type/TImport', () => {
     Assert.IsTrue(TypeGuard.IsRef(T.$defs['R'].patternProperties['^(.*)$']))
     Assert.IsTrue(T.$defs['R'].patternProperties['^(.*)$'].$ref === 'T')
   })
-  // it('Should compute for Record 2', () => {
-  //   const Module = Type.Module({
-  //     T: Type.Number(),
-  //     K: Type.Union([Type.Literal('x'), Type.Literal('y')]),
-  //     R: Type.Record(Type.Ref('K'), Type.Ref('T')),
-  //   })
-  //   const T = Module.Import('R')
-  //   Assert.IsTrue(TypeGuard.IsObject(T.$defs['R']))
-  //   Assert.IsTrue(TypeGuard.IsNumber(T.$defs['R'].properties.x))
-  //   Assert.IsTrue(TypeGuard.IsNumber(T.$defs['R'].properties.x))
-  // })
+  it('Should compute for Record 2', () => {
+    const Module = Type.Module({
+      T: Type.Number(),
+      R: Type.Record(Type.Union([Type.Literal('x'), Type.Literal('y')]), Type.Ref('T')),
+    })
+    // Retain reference if not computed
+    const T = Module.Import('R')
+    Assert.IsTrue(TypeGuard.IsObject(T.$defs['R']))
+    Assert.IsTrue(TypeGuard.IsRef(T.$defs['R'].properties.x))
+    Assert.IsTrue(TypeGuard.IsRef(T.$defs['R'].properties.y))
+  })
+  it('Should compute for Record 3', () => {
+    const Module = Type.Module({
+      T: Type.Object({ x: Type.Number() }),
+      R: Type.Record(Type.Union([Type.Literal('x'), Type.Literal('y')]), Type.Partial(Type.Ref('T'))),
+    })
+    // Dereference if computed
+    const T = Module.Import('R')
+    Assert.IsTrue(TypeGuard.IsObject(T.$defs['R']))
+    Assert.IsTrue(TypeGuard.IsObject(T.$defs['R'].properties.x))
+    Assert.IsTrue(TypeGuard.IsObject(T.$defs['R'].properties.y))
+  })
   // ----------------------------------------------------------------
   // Computed: Required
   // ----------------------------------------------------------------

--- a/test/static/import.ts
+++ b/test/static/import.ts
@@ -58,49 +58,16 @@ import { Type, Static } from '@sinclair/typebox'
 // ------------------------------------------------------------------
 // prettier-ignore
 {
-  // const T = Type.Module({
-  //   R: Type.Object({ x: Type.Number(), y: Type.Number() }),
-  //   T: Type.Record(Type.String(), Type.Partial(Type.Ref('R'))),
-  // }).Import('T')
+  const T = Type.Module({
+    R: Type.Object({ x: Type.Number(), y: Type.Number() }),
+    T: Type.Record(Type.String(), Type.Partial(Type.Ref('R'))),
+  }).Import('T')
 
-  // type T = Static<typeof T>
-  // Expect(T).ToStatic<{ 
-  //   [key: string]: { x?: number, y?: number } 
-  // }>()
+  type T = Static<typeof T>
+  Expect(T).ToStatic<{ 
+    [key: string]: { x?: number, y?: number } 
+  }>()
 }
-// ------------------------------------------------------------------
-// Record 3
-// ------------------------------------------------------------------
-// prettier-ignore
-{
-  // const T = Type.Module({
-  //   R: Type.Object({ x: Type.Number(), y: Type.Number() }),
-  //   K: Type.Number(),
-  //   T: Type.Record(Type.Ref('K'), Type.Partial(Type.Ref('R'))),
-  // }).Import('T')
-
-  // type T = Static<typeof T>
-  // Expect(T).ToStatic<{ 
-  //   [key: number]: { x?: number, y?: number } 
-  // }>()
-}
-// ------------------------------------------------------------------
-// Record 4
-// ------------------------------------------------------------------
-// prettier-ignore
-// {
-//   const T = Type.Module({
-//     R: Type.Object({ x: Type.Number(), y: Type.Number() }),
-//     K: Type.TemplateLiteral('${A|B|C}'),
-//     T: Type.Record(Type.Ref('K'), Type.Partial(Type.Ref('R'))),
-//   }).Import('T')
-//   type T = Static<typeof T>
-//   Expect(T).ToStatic<{
-//     A: { x?: number, y?: number },
-//     B: { x?: number, y?: number },
-//     C: { x?: number, y?: number }
-//   }>()
-// }
 // ------------------------------------------------------------------
 // Modifiers 1
 // ------------------------------------------------------------------


### PR DESCRIPTION
This PR reimplements Computed Record Type mapping, which was disabled in 0.34.20 due to compiler issues. The update moves the mapping logic out of the Record type and into the Computed module. The Record is now traversed like other normative types, whereas before, it was treated as a pseudo-Computed type (similar to Partial).

This PR only provides a solution for Record values, not keys. The issue with keys is that TypeBox needs to encode Record keys as string patternProperties, and dereferencing the key prior to encoding (treating Record as a computed type) is not feasible given the current complexity of Record mapping.


```typescript
const A = Type.Module({
  T: Type.Object({ x: Type.Number() }),
  R: Type.Record(Type.String(), Type.Ref('T')) // Non-Computed Record Value
})

// A Partial Wrapping a Reference Results in Computed Type Traversal

const B = Type.Module({
  T: Type.Object({ x: Type.Number() }),
  R: Type.Record(Type.String(), Type.Partial(Type.Ref('T'))) // Computed Record Value
})
```
