### PR TITLE
Revision 0.34.22

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -1,4 +1,6 @@
 ### 0.34.0
+- [Revision 0.34.22](https://github.com/sinclairzx81/typebox/pull/1171)
+  - Intrinsic Types Number, String, Boolean, etc Passthrough on Required and Partial Mapping
 - [Revision 0.34.21](https://github.com/sinclairzx81/typebox/pull/1168)
   - Reimplement Computed Record Types
 - [Revision 0.34.20](https://github.com/sinclairzx81/typebox/pull/1167)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.21",
+  "version": "0.34.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.21",
+      "version": "0.34.22",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.21",
+  "version": "0.34.22",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/type/partial/partial.ts
+++ b/src/type/partial/partial.ts
@@ -135,8 +135,8 @@ function PartialResolve<Type extends TSchema>(type: Type): TPartial<Type> {
     KindGuard.IsUnion(type) ? Union(FromRest(type.anyOf)) :
     KindGuard.IsObject(type) ? FromObject(type) :
     // Intrinsic
-    KindGuard.IsBoolean(type) ? type :
     KindGuard.IsBigInt(type) ? type :
+    KindGuard.IsBoolean(type) ? type :
     KindGuard.IsInteger(type) ? type :
     KindGuard.IsNumber(type) ? type :
     KindGuard.IsNull(type) ? type :
@@ -160,8 +160,8 @@ export type TPartial<Type extends TSchema> = (
   Type extends TUnion<infer Types extends TSchema[]> ? TUnion<TFromRest<Types>> :
   Type extends TObject<infer Properties extends TProperties> ? TFromObject<TObject<Properties>> :
   // Intrinsic
-  Type extends TBoolean ? Type :
   Type extends TBigInt ? Type :
+  Type extends TBoolean ? Type :
   Type extends TInteger ? Type :
   Type extends TNumber ? Type :
   Type extends TNull ? Type :

--- a/src/type/partial/partial.ts
+++ b/src/type/partial/partial.ts
@@ -42,10 +42,11 @@ import { type TRef, Ref } from '../ref/index'
 import { type TBigInt } from '../bigint/index'
 import { type TBoolean } from '../boolean/index'
 import { type TInteger } from '../integer/index'
+import { type TLiteral } from '../literal/index'
+import { type TNull } from '../null/index'
 import { type TNumber } from '../number/index'
 import { type TString } from '../string/index'
 import { type TSymbol } from '../symbol/index'
-import { type TNull } from '../null/index'
 import { type TUndefined } from '../undefined/index'
 
 import { Discard } from '../discard/index'
@@ -138,8 +139,9 @@ function PartialResolve<Type extends TSchema>(type: Type): TPartial<Type> {
     KindGuard.IsBigInt(type) ? type :
     KindGuard.IsBoolean(type) ? type :
     KindGuard.IsInteger(type) ? type :
-    KindGuard.IsNumber(type) ? type :
+    KindGuard.IsLiteral(type) ? type :
     KindGuard.IsNull(type) ? type :
+    KindGuard.IsNumber(type) ? type :
     KindGuard.IsString(type) ? type :
     KindGuard.IsSymbol(type) ? type :
     KindGuard.IsUndefined(type) ? type :
@@ -163,8 +165,9 @@ export type TPartial<Type extends TSchema> = (
   Type extends TBigInt ? Type :
   Type extends TBoolean ? Type :
   Type extends TInteger ? Type :
-  Type extends TNumber ? Type :
+  Type extends TLiteral ? Type :
   Type extends TNull ? Type :
+  Type extends TNumber ? Type :
   Type extends TString ? Type :
   Type extends TSymbol ? Type :
   Type extends TUndefined ? Type :

--- a/src/type/partial/partial.ts
+++ b/src/type/partial/partial.ts
@@ -39,14 +39,23 @@ import { type TObject, type TProperties, Object } from '../object/index'
 import { type TIntersect, Intersect } from '../intersect/index'
 import { type TUnion, Union } from '../union/index'
 import { type TRef, Ref } from '../ref/index'
+import { type TBigInt } from '../bigint/index'
+import { type TBoolean } from '../boolean/index'
+import { type TInteger } from '../integer/index'
+import { type TNumber } from '../number/index'
+import { type TString } from '../string/index'
+import { type TSymbol } from '../symbol/index'
+import { type TNull } from '../null/index'
+import { type TUndefined } from '../undefined/index'
+
 import { Discard } from '../discard/index'
 import { TransformKind } from '../symbols/index'
 import { PartialFromMappedResult, type TPartialFromMappedResult } from './partial-from-mapped-result'
 
 // ------------------------------------------------------------------
-// TypeGuard
+// KindGuard
 // ------------------------------------------------------------------
-import { IsMappedResult, IsIntersect, IsUnion, IsObject, IsRef, IsComputed } from '../guard/kind'
+import * as KindGuard from '../guard/kind'
 
 // ------------------------------------------------------------------
 // FromComputed
@@ -95,9 +104,9 @@ type TFromObject<Type extends TObject, Properties extends TProperties = Type['pr
   TFromProperties<Properties>
 )>>
 // prettier-ignore
-function FromObject<Type extends TObject>(T: Type): TFromObject<Type> {
-  const options = Discard(T, [TransformKind, '$id', 'required', 'properties'])
-  const properties = FromProperties(T['properties'])
+function FromObject<Type extends TObject>(type: Type): TFromObject<Type> {
+  const options = Discard(type, [TransformKind, '$id', 'required', 'properties'])
+  const properties = FromProperties(type['properties'])
   return Object(properties, options) as never
 }
 // ------------------------------------------------------------------
@@ -119,11 +128,22 @@ function FromRest<Types extends TSchema[]>(types: [...Types]): TFromRest<Types> 
 // prettier-ignore
 function PartialResolve<Type extends TSchema>(type: Type): TPartial<Type> {
   return (
-    IsComputed(type) ? FromComputed(type.target, type.parameters) :
-    IsRef(type) ? FromRef(type.$ref) :
-    IsIntersect(type) ? Intersect(FromRest(type.allOf)) :
-    IsUnion(type) ? Union(FromRest(type.anyOf)) :
-    IsObject(type) ? FromObject(type) :
+    // Mappable
+    KindGuard.IsComputed(type) ? FromComputed(type.target, type.parameters) :
+    KindGuard.IsRef(type) ? FromRef(type.$ref) :
+    KindGuard.IsIntersect(type) ? Intersect(FromRest(type.allOf)) :
+    KindGuard.IsUnion(type) ? Union(FromRest(type.anyOf)) :
+    KindGuard.IsObject(type) ? FromObject(type) :
+    // Intrinsic
+    KindGuard.IsBoolean(type) ? type :
+    KindGuard.IsBigInt(type) ? type :
+    KindGuard.IsInteger(type) ? type :
+    KindGuard.IsNumber(type) ? type :
+    KindGuard.IsNull(type) ? type :
+    KindGuard.IsString(type) ? type :
+    KindGuard.IsSymbol(type) ? type :
+    KindGuard.IsUndefined(type) ? type :
+    // Passthrough
     Object({})
   ) as never
 }
@@ -131,13 +151,24 @@ function PartialResolve<Type extends TSchema>(type: Type): TPartial<Type> {
 // TPartial
 // ------------------------------------------------------------------
 // prettier-ignore
-export type TPartial<T extends TSchema> = (
-  T extends TRecursive<infer Type extends TSchema> ? TRecursive<TPartial<Type>> :
-  T extends TComputed<infer Target extends string, infer Parameters extends TSchema[]> ? TFromComputed<Target, Parameters> :
-  T extends TRef<infer Ref extends string> ? TFromRef<Ref> :
-  T extends TIntersect<infer Types extends TSchema[]> ? TIntersect<TFromRest<Types>> :
-  T extends TUnion<infer Types extends TSchema[]> ? TUnion<TFromRest<Types>> :
-  T extends TObject<infer Properties extends TProperties> ? TFromObject<TObject<Properties>> :
+export type TPartial<Type extends TSchema> = (
+  // Mappable
+  Type extends TRecursive<infer Type extends TSchema> ? TRecursive<TPartial<Type>> :
+  Type extends TComputed<infer Target extends string, infer Parameters extends TSchema[]> ? TFromComputed<Target, Parameters> :
+  Type extends TRef<infer Ref extends string> ? TFromRef<Ref> :
+  Type extends TIntersect<infer Types extends TSchema[]> ? TIntersect<TFromRest<Types>> :
+  Type extends TUnion<infer Types extends TSchema[]> ? TUnion<TFromRest<Types>> :
+  Type extends TObject<infer Properties extends TProperties> ? TFromObject<TObject<Properties>> :
+  // Intrinsic
+  Type extends TBoolean ? Type :
+  Type extends TBigInt ? Type :
+  Type extends TInteger ? Type :
+  Type extends TNumber ? Type :
+  Type extends TNull ? Type :
+  Type extends TString ? Type :
+  Type extends TSymbol ? Type :
+  Type extends TUndefined ? Type :
+  // Passthrough
   TObject<{}>
 )
 /** `[Json]` Constructs a type where all properties are optional */
@@ -145,8 +176,8 @@ export function Partial<MappedResult extends TMappedResult>(type: MappedResult, 
 /** `[Json]` Constructs a type where all properties are optional */
 export function Partial<Type extends TSchema>(type: Type, options?: SchemaOptions): TPartial<Type>
 /** `[Json]` Constructs a type where all properties are optional */
-export function Partial(type: TSchema, options?: SchemaOptions): any {
-  if (IsMappedResult(type)) {
+export function Partial(type: TSchema, options?: SchemaOptions): unknown {
+  if (KindGuard.IsMappedResult(type)) {
     return PartialFromMappedResult(type, options)
   } else {
     // special: mapping types require overridable options

--- a/src/type/required/required.ts
+++ b/src/type/required/required.ts
@@ -39,6 +39,14 @@ import { type TObject, type TProperties, Object } from '../object/index'
 import { type TIntersect, Intersect } from '../intersect/index'
 import { type TUnion, Union } from '../union/index'
 import { type TRef, Ref } from '../ref/index'
+import { type TBigInt } from '../bigint/index'
+import { type TBoolean } from '../boolean/index'
+import { type TInteger } from '../integer/index'
+import { type TNumber } from '../number/index'
+import { type TString } from '../string/index'
+import { type TSymbol } from '../symbol/index'
+import { type TNull } from '../null/index'
+import { type TUndefined } from '../undefined/index'
 import { OptionalKind, TransformKind } from '../symbols/index'
 import { Discard } from '../discard/index'
 import { RequiredFromMappedResult, type TRequiredFromMappedResult } from './required-from-mapped-result'
@@ -46,7 +54,7 @@ import { RequiredFromMappedResult, type TRequiredFromMappedResult } from './requ
 // ------------------------------------------------------------------
 // TypeGuard
 // ------------------------------------------------------------------
-import { IsMappedResult, IsIntersect, IsUnion, IsObject, IsRef, IsComputed } from '../guard/kind'
+import * as KindGuard from '../guard/kind'
 
 // ------------------------------------------------------------------
 // FromComputed
@@ -119,11 +127,22 @@ function FromRest<Types extends TSchema[]>(types: [...Types]) : TFromRest<Types>
 // prettier-ignore
 function RequiredResolve<Type extends TSchema>(type: Type): TRequired<Type> {
   return (
-    IsComputed(type) ? FromComputed(type.target, type.parameters) :
-    IsRef(type) ? FromRef(type.$ref) :
-    IsIntersect(type) ? Intersect(FromRest(type.allOf)) :
-    IsUnion(type) ?  Union(FromRest(type.anyOf)) :
-    IsObject(type) ? FromObject(type) :
+    // Mappable
+    KindGuard.IsComputed(type) ? FromComputed(type.target, type.parameters) :
+    KindGuard.IsRef(type) ? FromRef(type.$ref) :
+    KindGuard.IsIntersect(type) ? Intersect(FromRest(type.allOf)) :
+    KindGuard.IsUnion(type) ?  Union(FromRest(type.anyOf)) :
+    KindGuard.IsObject(type) ? FromObject(type) :
+    // Intrinsic
+    KindGuard.IsBoolean(type) ? type :
+    KindGuard.IsBigInt(type) ? type :
+    KindGuard.IsInteger(type) ? type :
+    KindGuard.IsNumber(type) ? type :
+    KindGuard.IsNull(type) ? type :
+    KindGuard.IsString(type) ? type :
+    KindGuard.IsSymbol(type) ? type :
+    KindGuard.IsUndefined(type) ? type :
+    // Passthrough
     Object({})
   ) as never
 }
@@ -132,12 +151,23 @@ function RequiredResolve<Type extends TSchema>(type: Type): TRequired<Type> {
 // ------------------------------------------------------------------
 // prettier-ignore
 export type TRequired<Type extends TSchema> = (
+  // Mappable
   Type extends TRecursive<infer Type extends TSchema> ? TRecursive<TRequired<Type>> :
   Type extends TComputed<infer Target extends string, infer Parameters extends TSchema[]> ? TFromComputed<Target, Parameters> :
   Type extends TRef<infer Ref extends string> ? TFromRef<Ref> :
   Type extends TIntersect<infer Types extends TSchema[]> ? TIntersect<TFromRest<Types>> :
   Type extends TUnion<infer Types extends TSchema[]> ? TUnion<TFromRest<Types>> :
   Type extends TObject<infer Properties extends TProperties> ? TFromObject<TObject<Properties>> :
+  // Intrinsic
+  Type extends TBoolean ? Type :
+  Type extends TBigInt ? Type :
+  Type extends TInteger ? Type :
+  Type extends TNumber ? Type :
+  Type extends TNull ? Type :
+  Type extends TString ? Type :
+  Type extends TSymbol ? Type :
+  Type extends TUndefined ? Type :
+  // Passthrough
   TObject<{}>
 )
 /** `[Json]` Constructs a type where all properties are required */
@@ -146,7 +176,7 @@ export function Required<MappedResult extends TMappedResult>(type: MappedResult,
 export function Required<Type extends TSchema>(type: Type, options?: SchemaOptions): TRequired<Type>
 /** `[Json]` Constructs a type where all properties are required */
 export function Required<Type extends TSchema>(type: Type, options?: SchemaOptions): never {
-  if (IsMappedResult(type)) {
+  if (KindGuard.IsMappedResult(type)) {
     return RequiredFromMappedResult(type, options) as never
   } else {
     // special: mapping types require overridable options

--- a/src/type/required/required.ts
+++ b/src/type/required/required.ts
@@ -134,8 +134,8 @@ function RequiredResolve<Type extends TSchema>(type: Type): TRequired<Type> {
     KindGuard.IsUnion(type) ?  Union(FromRest(type.anyOf)) :
     KindGuard.IsObject(type) ? FromObject(type) :
     // Intrinsic
-    KindGuard.IsBoolean(type) ? type :
     KindGuard.IsBigInt(type) ? type :
+    KindGuard.IsBoolean(type) ? type :
     KindGuard.IsInteger(type) ? type :
     KindGuard.IsNumber(type) ? type :
     KindGuard.IsNull(type) ? type :
@@ -159,8 +159,8 @@ export type TRequired<Type extends TSchema> = (
   Type extends TUnion<infer Types extends TSchema[]> ? TUnion<TFromRest<Types>> :
   Type extends TObject<infer Properties extends TProperties> ? TFromObject<TObject<Properties>> :
   // Intrinsic
-  Type extends TBoolean ? Type :
   Type extends TBigInt ? Type :
+  Type extends TBoolean ? Type :
   Type extends TInteger ? Type :
   Type extends TNumber ? Type :
   Type extends TNull ? Type :

--- a/src/type/required/required.ts
+++ b/src/type/required/required.ts
@@ -42,11 +42,13 @@ import { type TRef, Ref } from '../ref/index'
 import { type TBigInt } from '../bigint/index'
 import { type TBoolean } from '../boolean/index'
 import { type TInteger } from '../integer/index'
+import { type TLiteral } from '../literal/index'
+import { type TNull } from '../null/index'
 import { type TNumber } from '../number/index'
 import { type TString } from '../string/index'
 import { type TSymbol } from '../symbol/index'
-import { type TNull } from '../null/index'
 import { type TUndefined } from '../undefined/index'
+
 import { OptionalKind, TransformKind } from '../symbols/index'
 import { Discard } from '../discard/index'
 import { RequiredFromMappedResult, type TRequiredFromMappedResult } from './required-from-mapped-result'
@@ -137,8 +139,9 @@ function RequiredResolve<Type extends TSchema>(type: Type): TRequired<Type> {
     KindGuard.IsBigInt(type) ? type :
     KindGuard.IsBoolean(type) ? type :
     KindGuard.IsInteger(type) ? type :
-    KindGuard.IsNumber(type) ? type :
+    KindGuard.IsLiteral(type) ? type :
     KindGuard.IsNull(type) ? type :
+    KindGuard.IsNumber(type) ? type :
     KindGuard.IsString(type) ? type :
     KindGuard.IsSymbol(type) ? type :
     KindGuard.IsUndefined(type) ? type :
@@ -162,8 +165,9 @@ export type TRequired<Type extends TSchema> = (
   Type extends TBigInt ? Type :
   Type extends TBoolean ? Type :
   Type extends TInteger ? Type :
-  Type extends TNumber ? Type :
+  Type extends TLiteral ? Type :
   Type extends TNull ? Type :
+  Type extends TNumber ? Type :
   Type extends TString ? Type :
   Type extends TSymbol ? Type :
   Type extends TUndefined ? Type :

--- a/test/runtime/type/guard/kind/partial.ts
+++ b/test/runtime/type/guard/kind/partial.ts
@@ -64,4 +64,36 @@ describe('guard/kind/TPartial', () => {
     const R = Type.Partial(S)
     Assert.IsFalse(TransformKind in R)
   })
+  // ------------------------------------------------------------------
+  // Intrinsic Passthough
+  // https://github.com/sinclairzx81/typebox/issues/1169
+  // ------------------------------------------------------------------
+  it('Should pass through on intrinsic types on union 1', () => {
+    const T = Type.Partial(
+      Type.Union([
+        Type.Number(),
+        Type.Object({
+          x: Type.Number(),
+        }),
+      ]),
+    )
+    Assert.IsTrue(KindGuard.IsUnion(T))
+    Assert.IsTrue(KindGuard.IsNumber(T.anyOf[0]))
+    Assert.IsTrue(KindGuard.IsObject(T.anyOf[1]))
+    Assert.IsTrue(KindGuard.IsOptional(T.anyOf[1].properties.x))
+  })
+  it('Should pass through on intrinsic types on union 2', () => {
+    const T = Type.Partial(
+      Type.Union([
+        Type.Literal(1),
+        Type.Object({
+          x: Type.Number(),
+        }),
+      ]),
+    )
+    Assert.IsTrue(KindGuard.IsUnion(T))
+    Assert.IsTrue(KindGuard.IsLiteral(T.anyOf[0]))
+    Assert.IsTrue(KindGuard.IsObject(T.anyOf[1]))
+    Assert.IsTrue(KindGuard.IsOptional(T.anyOf[1].properties.x))
+  })
 })

--- a/test/runtime/type/guard/kind/required.ts
+++ b/test/runtime/type/guard/kind/required.ts
@@ -61,4 +61,36 @@ describe('guard/kind/TRequired', () => {
     const R = Type.Required(S)
     Assert.IsFalse(TransformKind in R)
   })
+  // ------------------------------------------------------------------
+  // Intrinsic Passthough
+  // https://github.com/sinclairzx81/typebox/issues/1169
+  // ------------------------------------------------------------------
+  it('Should pass through on intrinsic types on union', () => {
+    const T = Type.Required(
+      Type.Union([
+        Type.Number(),
+        Type.Object({
+          x: Type.Optional(Type.Number()),
+        }),
+      ]),
+    )
+    Assert.IsTrue(KindGuard.IsUnion(T))
+    Assert.IsTrue(KindGuard.IsNumber(T.anyOf[0]))
+    Assert.IsTrue(KindGuard.IsObject(T.anyOf[1]))
+    Assert.IsFalse(KindGuard.IsOptional(T.anyOf[1].properties.x))
+  })
+  it('Should pass through on intrinsic types on union', () => {
+    const T = Type.Required(
+      Type.Union([
+        Type.Literal(1),
+        Type.Object({
+          x: Type.Optional(Type.Number()),
+        }),
+      ]),
+    )
+    Assert.IsTrue(KindGuard.IsUnion(T))
+    Assert.IsTrue(KindGuard.IsLiteral(T.anyOf[0]))
+    Assert.IsTrue(KindGuard.IsObject(T.anyOf[1]))
+    Assert.IsFalse(KindGuard.IsOptional(T.anyOf[1].properties.x))
+  })
 })

--- a/test/runtime/type/guard/kind/required.ts
+++ b/test/runtime/type/guard/kind/required.ts
@@ -65,7 +65,7 @@ describe('guard/kind/TRequired', () => {
   // Intrinsic Passthough
   // https://github.com/sinclairzx81/typebox/issues/1169
   // ------------------------------------------------------------------
-  it('Should pass through on intrinsic types on union', () => {
+  it('Should pass through on intrinsic types on union 1', () => {
     const T = Type.Required(
       Type.Union([
         Type.Number(),
@@ -79,7 +79,7 @@ describe('guard/kind/TRequired', () => {
     Assert.IsTrue(KindGuard.IsObject(T.anyOf[1]))
     Assert.IsFalse(KindGuard.IsOptional(T.anyOf[1].properties.x))
   })
-  it('Should pass through on intrinsic types on union', () => {
+  it('Should pass through on intrinsic types on union 2', () => {
     const T = Type.Required(
       Type.Union([
         Type.Literal(1),

--- a/test/runtime/type/guard/type/partial.ts
+++ b/test/runtime/type/guard/type/partial.ts
@@ -73,4 +73,22 @@ describe('guard/type/TPartial', () => {
     Assert.IsEqual(A.title, 'A')
     Assert.IsEqual(B.title, 'B')
   })
+  // ------------------------------------------------------------------
+  // Intrinsic Passthough
+  // https://github.com/sinclairzx81/typebox/issues/1169
+  // ------------------------------------------------------------------
+  it('Should pass through on intrinsic types on union', () => {
+    const T = Type.Partial(
+      Type.Union([
+        Type.Number(),
+        Type.Object({
+          x: Type.Number(),
+        }),
+      ]),
+    )
+    Assert.IsTrue(TypeGuard.IsUnion(T))
+    Assert.IsTrue(TypeGuard.IsNumber(T.anyOf[0]))
+    Assert.IsTrue(TypeGuard.IsObject(T.anyOf[1]))
+    Assert.IsTrue(TypeGuard.IsOptional(T.anyOf[1].properties.x))
+  })
 })

--- a/test/runtime/type/guard/type/partial.ts
+++ b/test/runtime/type/guard/type/partial.ts
@@ -77,7 +77,7 @@ describe('guard/type/TPartial', () => {
   // Intrinsic Passthough
   // https://github.com/sinclairzx81/typebox/issues/1169
   // ------------------------------------------------------------------
-  it('Should pass through on intrinsic types on union', () => {
+  it('Should pass through on intrinsic types on union 1', () => {
     const T = Type.Partial(
       Type.Union([
         Type.Number(),
@@ -88,6 +88,20 @@ describe('guard/type/TPartial', () => {
     )
     Assert.IsTrue(TypeGuard.IsUnion(T))
     Assert.IsTrue(TypeGuard.IsNumber(T.anyOf[0]))
+    Assert.IsTrue(TypeGuard.IsObject(T.anyOf[1]))
+    Assert.IsTrue(TypeGuard.IsOptional(T.anyOf[1].properties.x))
+  })
+  it('Should pass through on intrinsic types on union 2', () => {
+    const T = Type.Partial(
+      Type.Union([
+        Type.Literal(1),
+        Type.Object({
+          x: Type.Number(),
+        }),
+      ]),
+    )
+    Assert.IsTrue(TypeGuard.IsUnion(T))
+    Assert.IsTrue(TypeGuard.IsLiteral(T.anyOf[0]))
     Assert.IsTrue(TypeGuard.IsObject(T.anyOf[1]))
     Assert.IsTrue(TypeGuard.IsOptional(T.anyOf[1].properties.x))
   })

--- a/test/runtime/type/guard/type/required.ts
+++ b/test/runtime/type/guard/type/required.ts
@@ -70,4 +70,22 @@ describe('guard/type/TRequired', () => {
     Assert.IsEqual(A.title, 'A')
     Assert.IsEqual(B.title, 'B')
   })
+  // ------------------------------------------------------------------
+  // Intrinsic Passthough
+  // https://github.com/sinclairzx81/typebox/issues/1169
+  // ------------------------------------------------------------------
+  it('Should pass through on intrinsic types on union', () => {
+    const T = Type.Required(
+      Type.Union([
+        Type.Number(),
+        Type.Object({
+          x: Type.Optional(Type.Number()),
+        }),
+      ]),
+    )
+    Assert.IsTrue(TypeGuard.IsUnion(T))
+    Assert.IsTrue(TypeGuard.IsNumber(T.anyOf[0]))
+    Assert.IsTrue(TypeGuard.IsObject(T.anyOf[1]))
+    Assert.IsFalse(TypeGuard.IsOptional(T.anyOf[1].properties.x))
+  })
 })

--- a/test/runtime/type/guard/type/required.ts
+++ b/test/runtime/type/guard/type/required.ts
@@ -74,7 +74,7 @@ describe('guard/type/TRequired', () => {
   // Intrinsic Passthough
   // https://github.com/sinclairzx81/typebox/issues/1169
   // ------------------------------------------------------------------
-  it('Should pass through on intrinsic types on union', () => {
+  it('Should pass through on intrinsic types on union 1', () => {
     const T = Type.Required(
       Type.Union([
         Type.Number(),
@@ -88,7 +88,7 @@ describe('guard/type/TRequired', () => {
     Assert.IsTrue(TypeGuard.IsObject(T.anyOf[1]))
     Assert.IsFalse(TypeGuard.IsOptional(T.anyOf[1].properties.x))
   })
-  it('Should pass through on intrinsic types on union', () => {
+  it('Should pass through on intrinsic types on union 2', () => {
     const T = Type.Required(
       Type.Union([
         Type.Literal(1),

--- a/test/runtime/type/guard/type/required.ts
+++ b/test/runtime/type/guard/type/required.ts
@@ -88,4 +88,18 @@ describe('guard/type/TRequired', () => {
     Assert.IsTrue(TypeGuard.IsObject(T.anyOf[1]))
     Assert.IsFalse(TypeGuard.IsOptional(T.anyOf[1].properties.x))
   })
+  it('Should pass through on intrinsic types on union', () => {
+    const T = Type.Required(
+      Type.Union([
+        Type.Literal(1),
+        Type.Object({
+          x: Type.Optional(Type.Number()),
+        }),
+      ]),
+    )
+    Assert.IsTrue(TypeGuard.IsUnion(T))
+    Assert.IsTrue(TypeGuard.IsLiteral(T.anyOf[0]))
+    Assert.IsTrue(TypeGuard.IsObject(T.anyOf[1]))
+    Assert.IsFalse(TypeGuard.IsOptional(T.anyOf[1].properties.x))
+  })
 })

--- a/test/static/partial.ts
+++ b/test/static/partial.ts
@@ -96,3 +96,10 @@ import * as Types from '@sinclair/typebox'
   })]))
   Expect(T).ToStatic<number | { x?: number }>
 }
+// prettier-ignore
+{
+  const T = Type.Partial(Type.Union([Type.Literal(1), Type.Object({
+    x: Type.Number()
+  })]))
+  Expect(T).ToStatic<1 | { x?: number }>
+}

--- a/test/static/partial.ts
+++ b/test/static/partial.ts
@@ -85,3 +85,14 @@ import * as Types from '@sinclair/typebox'
     d: Types.TOptional<Types.TNumber>
   }> = Type.Partial(T)
 }
+// ------------------------------------------------------------------
+// Intrinsic Passthough
+// https://github.com/sinclairzx81/typebox/issues/1169
+// ------------------------------------------------------------------
+// prettier-ignore
+{
+  const T = Type.Partial(Type.Union([Type.Number(), Type.Object({
+    x: Type.Number()
+  })]))
+  Expect(T).ToStatic<number | { x?: number }>
+}

--- a/test/static/required.ts
+++ b/test/static/required.ts
@@ -98,3 +98,10 @@ import * as Types from '@sinclair/typebox'
   })]))
   Expect(T).ToStatic<number | { x: number }>
 }
+// prettier-ignore
+{
+  const T = Type.Required(Type.Union([Type.Literal(1), Type.Object({
+    x: Type.Optional(Type.Number())
+  })]))
+  Expect(T).ToStatic<1 | { x: number }>
+}

--- a/test/static/required.ts
+++ b/test/static/required.ts
@@ -87,3 +87,14 @@ import * as Types from '@sinclair/typebox'
     d: Types.TNumber
   }> = Type.Required(T)
 }
+// ------------------------------------------------------------------
+// Intrinsic Passthough
+// https://github.com/sinclairzx81/typebox/issues/1169
+// ------------------------------------------------------------------
+// prettier-ignore
+{
+  const T = Type.Required(Type.Union([Type.Number(), Type.Object({
+    x: Type.Optional(Type.Number())
+  })]))
+  Expect(T).ToStatic<number | { x: number }>
+}


### PR DESCRIPTION
This PR adds a mapping passthrough for intrinsic types (string, number, boolean, etc) on Partial and Required when mapping through Union and Intersect types. This mapping is inline with TypeScript Partial and Required mapping types. 

```typescript
import { Syntax } from '@sinclair/typebox/syntax'
import { Static } from '@sinclair/typebox'

const T = Syntax('number | { x: number }')
const A = Syntax({ T }, 'Partial<T>')
const B = Syntax({ A }, 'Required<A>')

type T = Static<typeof T>   // number | { x: number; }
type A = Static<typeof A>   // number | { x?: number | undefined; }
type B = Static<typeof B>   // number | { x: number; }
```

Non-Intrinsic types such as Date, Uint8Array, Function and Constructor will continue to map as empty `{}` Object types.

```typescript
const T = Syntax('Date | { x: number }')
const A = Syntax({ T }, 'Partial<T>')

type T = Static<typeof T>   // Date | { x: number; }
type A = Static<typeof A>   // {} | { x?: number | undefined; }
```

Fixes: https://github.com/sinclairzx81/typebox/issues/1169