### PR TITLE
Revision 0.34.26

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -4,6 +4,8 @@
 
 ### Revision Updates
 
+- [Revision 0.34.26](https://github.com/sinclairzx81/typebox/pull/1181)
+  - Internal: Use Parser Context Threading for Generic Arguments.
 - [Revision 0.34.25](https://github.com/sinclairzx81/typebox/pull/1176)
   - Evaluate Conditional Expression for Instatiated Object Types
 - [Revision 0.34.24](https://github.com/sinclairzx81/typebox/pull/1175)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.25",
+  "version": "0.34.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.25",
+      "version": "0.34.26",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.25",
+  "version": "0.34.26",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/src/parser/runtime/guard.ts
+++ b/src/parser/runtime/guard.ts
@@ -87,12 +87,12 @@ export function IsUnion(value: unknown): value is IUnion {
   return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Union' && HasPropertyKey(value, 'parsers') && IsArrayValue(value.parsers)
 }
 /** Returns true if the value is a Parser */
-// prettier-ignore
 export function IsParser(value: unknown) {
+  // prettier-ignore
   return (
     IsArray(value) || 
-    IsConst(value) ||
-    IsContext(value) ||
+    IsConst(value) || 
+    IsContext(value) || 
     IsIdent(value) || 
     IsNumber(value) || 
     IsOptional(value) || 

--- a/src/parser/runtime/guard.ts
+++ b/src/parser/runtime/guard.ts
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { IIdent, INumber, IRef, IString, IConst, ITuple, IUnion } from './types'
+import { IArray, IConst, IContext, IIdent, INumber, IOptional, IRef, IString, ITuple, IUnion } from './types'
 
 // ------------------------------------------------------------------
 // Value Guard
@@ -46,51 +46,47 @@ function IsArrayValue(value: unknown): value is unknown[] {
 // ------------------------------------------------------------------
 // Parser Guard
 // ------------------------------------------------------------------
-/** Returns true if the value is a Tuple Parser */
-// prettier-ignore
-export function IsTuple(value: unknown): value is ITuple {
-  return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Tuple' && HasPropertyKey(value, 'parsers') && IsArrayValue(value.parsers)
-}
-/** Returns true if the value is a Union Parser */
-// prettier-ignore
-export function IsUnion(value: unknown): value is IUnion {
-  return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Union' && HasPropertyKey(value, 'parsers') && IsArrayValue(value.parsers)
+/** Returns true if the value is a Array Parser */
+export function IsArray(value: unknown): value is IArray {
+  return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Array' && HasPropertyKey(value, 'parser') && IsObjectValue(value.parser)
 }
 /** Returns true if the value is a Const Parser */
-// prettier-ignore
 export function IsConst(value: unknown): value is IConst {
   return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Const' && HasPropertyKey(value, 'value') && typeof value.value === 'string'
 }
+/** Returns true if the value is a Context Parser */
+export function IsContext(value: unknown): value is IContext {
+  return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Context' && HasPropertyKey(value, 'left') && IsParser(value.left) && HasPropertyKey(value, 'right') && IsParser(value.right)
+}
 /** Returns true if the value is a Ident Parser */
-// prettier-ignore
 export function IsIdent(value: unknown): value is IIdent {
   return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Ident'
 }
 /** Returns true if the value is a Number Parser */
-// prettier-ignore
 export function IsNumber(value: unknown): value is INumber {
   return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Number'
 }
+/** Returns true if the value is a Optional Parser */
+export function IsOptional(value: unknown): value is IOptional {
+  return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Optional' && HasPropertyKey(value, 'parser') && IsObjectValue(value.parser)
+}
 /** Returns true if the value is a Ref Parser */
-// prettier-ignore
 export function IsRef(value: unknown): value is IRef {
   return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Ref' && HasPropertyKey(value, 'ref') && typeof value.ref === 'string'
 }
 /** Returns true if the value is a String Parser */
-// prettier-ignore
 export function IsString(value: unknown): value is IString {
   return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'String' && HasPropertyKey(value, 'options') && IsArrayValue(value.options)
 }
+/** Returns true if the value is a Tuple Parser */
+export function IsTuple(value: unknown): value is ITuple {
+  return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Tuple' && HasPropertyKey(value, 'parsers') && IsArrayValue(value.parsers)
+}
+/** Returns true if the value is a Union Parser */
+export function IsUnion(value: unknown): value is IUnion {
+  return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Union' && HasPropertyKey(value, 'parsers') && IsArrayValue(value.parsers)
+}
 /** Returns true if the value is a Parser */
-// prettier-ignore
 export function IsParser(value: unknown) {
-  return (
-    IsTuple(value) ||
-    IsUnion(value) ||
-    IsConst(value) ||
-    IsIdent(value) ||
-    IsNumber(value) ||
-    IsRef(value) ||
-    IsString(value)
-  )
+  return IsArray(value) || IsConst(value) || IsIdent(value) || IsNumber(value) || IsOptional(value) || IsRef(value) || IsString(value) || IsTuple(value) || IsUnion(value)
 }

--- a/src/parser/runtime/guard.ts
+++ b/src/parser/runtime/guard.ts
@@ -87,6 +87,18 @@ export function IsUnion(value: unknown): value is IUnion {
   return IsObjectValue(value) && HasPropertyKey(value, 'type') && value.type === 'Union' && HasPropertyKey(value, 'parsers') && IsArrayValue(value.parsers)
 }
 /** Returns true if the value is a Parser */
+// prettier-ignore
 export function IsParser(value: unknown) {
-  return IsArray(value) || IsConst(value) || IsIdent(value) || IsNumber(value) || IsOptional(value) || IsRef(value) || IsString(value) || IsTuple(value) || IsUnion(value)
+  return (
+    IsArray(value) || 
+    IsConst(value) ||
+    IsContext(value) ||
+    IsIdent(value) || 
+    IsNumber(value) || 
+    IsOptional(value) || 
+    IsRef(value) || 
+    IsString(value) || 
+    IsTuple(value) || 
+    IsUnion(value)
+  )
 }

--- a/src/parser/runtime/module.ts
+++ b/src/parser/runtime/module.ts
@@ -40,8 +40,8 @@ export class Module<Properties extends Types.IModuleProperties = Types.IModulePr
   /** Parses using one of the parsers defined on this instance */
   public Parse<Key extends keyof Properties>(key: Key, content: string): [] | [Types.StaticParser<Properties[Key]>, string]
   /** Parses using one of the parsers defined on this instance */
-  // prettier-ignore
   public Parse(...args: any[]): never {
+    // prettier-ignore
     const [key, content, context] = (
       args.length === 3 ? [args[0], args[1], args[2]] : 
       args.length === 2 ? [args[0], args[1], undefined] : 

--- a/src/parser/runtime/module.ts
+++ b/src/parser/runtime/module.ts
@@ -40,15 +40,13 @@ export class Module<Properties extends Types.IModuleProperties = Types.IModulePr
   /** Parses using one of the parsers defined on this instance */
   public Parse<Key extends keyof Properties>(key: Key, content: string): [] | [Types.StaticParser<Properties[Key]>, string]
   /** Parses using one of the parsers defined on this instance */
+  // prettier-ignore
   public Parse(...args: any[]): never {
-    const [key, content, context] =
-      args.length === 3
-        ? [args[0], args[1], args[2]]
-        : args.length === 2
-        ? [args[0], args[1], undefined]
-        : (() => {
-            throw Error('Invalid parse arguments')
-          })()
+    const [key, content, context] = (
+      args.length === 3 ? [args[0], args[1], args[2]] : 
+      args.length === 2 ? [args[0], args[1], undefined] : 
+      (() => { throw Error('Invalid parse arguments') })()
+    )
     return Parse(this.properties, this.properties[key], content, context) as never
   }
 }

--- a/src/parser/runtime/module.ts
+++ b/src/parser/runtime/module.ts
@@ -32,20 +32,23 @@ import { Parse } from './parse'
 // ------------------------------------------------------------------
 // Module
 // ------------------------------------------------------------------
-// prettier-ignore
 export class Module<Properties extends Types.IModuleProperties = Types.IModuleProperties> {
-  constructor(private readonly properties: Properties) { }
-  
+  constructor(private readonly properties: Properties) {}
+
   /** Parses using one of the parsers defined on this instance */
-  public Parse<Key extends keyof Properties>(key: Key, code: string, context: unknown): [] | [Types.StaticParser<Properties[Key]>, string]
+  public Parse<Key extends keyof Properties>(key: Key, content: string, context: unknown): [] | [Types.StaticParser<Properties[Key]>, string]
   /** Parses using one of the parsers defined on this instance */
-  public Parse<Key extends keyof Properties>(key: Key, code: string): [] | [Types.StaticParser<Properties[Key]>, string]
+  public Parse<Key extends keyof Properties>(key: Key, content: string): [] | [Types.StaticParser<Properties[Key]>, string]
   /** Parses using one of the parsers defined on this instance */
   public Parse(...args: any[]): never {
-    const [key, code, context] = 
-      args.length === 3 ? [args[0], args[1], args[2]] :
-      args.length === 2 ? [args[0], args[1], undefined] :
-      (() => { throw Error('Invalid parse arguments') })()
-    return Parse(this.properties[key], this.properties, code, context) as never
+    const [key, content, context] =
+      args.length === 3
+        ? [args[0], args[1], args[2]]
+        : args.length === 2
+        ? [args[0], args[1], undefined]
+        : (() => {
+            throw Error('Invalid parse arguments')
+          })()
+    return Parse(this.properties, this.properties[key], content, context) as never
   }
 }

--- a/src/parser/runtime/types.ts
+++ b/src/parser/runtime/types.ts
@@ -32,6 +32,9 @@ export type IModuleProperties = Record<PropertyKey, IParser>
 // Static
 // ------------------------------------------------------------------
 
+/** Force output static type evaluation for Arrays */
+export type StaticEnsure<T> = T extends infer R ? R : never
+
 /** Infers the Output Parameter for a Parser */
 export type StaticParser<Parser extends IParser> = Parser extends IParser<infer Output extends unknown> ? Output : unknown
 
@@ -44,10 +47,8 @@ export type IMapping<Input extends unknown = any, Output extends unknown = unkno
 export const Identity = (value: unknown) => value
 
 /** Maps the output as the given parameter T */
-export const As =
-  <T>(mapping: T): ((value: unknown) => T) =>
-  (_: unknown) =>
-    mapping
+// prettier-ignore
+export const As = <T>(mapping: T): ((value: unknown) => T) => (_: unknown) => mapping
 
 // ------------------------------------------------------------------
 // Parser
@@ -57,50 +58,59 @@ export interface IParser<Output extends unknown = unknown> {
   mapping: IMapping<any, Output>
 }
 // ------------------------------------------------------------------
-// Tuple
+// Context
 // ------------------------------------------------------------------
-export type TupleParameter<Parsers extends IParser[], Result extends unknown[] = []> = Parsers extends [infer L extends IParser, ...infer R extends IParser[]] ? TupleParameter<R, [...Result, StaticParser<L>]> : Result
-export interface ITuple<Output extends unknown = unknown> extends IParser<Output> {
-  type: 'Tuple'
-  parsers: IParser[]
+// prettier-ignore
+export type ContextParameter<_Left extends IParser, Right extends IParser> = (
+  StaticParser<Right>
+)
+export interface IContext<Output extends unknown = unknown> extends IParser<Output> {
+  type: 'Context'
+  left: IParser
+  right: IParser
 }
-/** Creates a Tuple parser */
-export function Tuple<Parsers extends IParser[], Mapping extends IMapping = IMapping<TupleParameter<Parsers>>>(parsers: [...Parsers], mapping: Mapping): ITuple<ReturnType<Mapping>>
-/** Creates a Tuple parser */
-export function Tuple<Parsers extends IParser[]>(parsers: [...Parsers]): ITuple<TupleParameter<Parsers>>
-export function Tuple(...args: unknown[]): never {
-  const [parsers, mapping] = args.length === 2 ? [args[0], args[1]] : [args[0], Identity]
-  return { type: 'Tuple', parsers, mapping } as never
+/** `[Context]` Creates a Context Parser */
+export function Context<Left extends IParser, Right extends IParser, Mapping extends IMapping = IMapping<ContextParameter<Left, Right>>>(left: Left, right: Right, mapping: Mapping): IContext<ReturnType<Mapping>>
+/** `[Context]` Creates a Context Parser */
+export function Context<Left extends IParser, Right extends IParser>(left: Left, right: Right): IContext<ContextParameter<Left, Right>>
+/** `[Context]` Creates a Context Parser */
+export function Context(...args: unknown[]): never {
+  const [left, right, mapping] = args.length === 3 ? [args[0], args[1], args[2]] : [args[0], args[1], Identity]
+  return { type: 'Context', left, right, mapping } as never
+}
+// ------------------------------------------------------------------
+// Array
+// ------------------------------------------------------------------
+// prettier-ignore
+export type ArrayParameter<Parser extends IParser> = StaticEnsure<
+  StaticParser<Parser>[]
+>
+export interface IArray<Output extends unknown = unknown> extends IParser<Output> {
+  type: 'Array'
+  parser: IParser
+}
+/** `[EBNF]` Creates an Array Parser */
+export function Array<Parser extends IParser, Mapping extends IMapping = IMapping<ArrayParameter<Parser>>>(parser: Parser, mapping: Mapping): IArray<ReturnType<Mapping>>
+/** `[EBNF]` Creates an Array Parser */
+export function Array<Parser extends IParser>(parser: Parser): IArray<ArrayParameter<Parser>>
+/** `[EBNF]` Creates an Array Parser */
+export function Array(...args: unknown[]): never {
+  const [parser, mapping] = args.length === 2 ? [args[0], args[1]] : [args[0], Identity]
+  return { type: 'Array', parser, mapping } as never
 }
 
 // ------------------------------------------------------------------
-// Union
-// ------------------------------------------------------------------
-export type UnionParameter<Parsers extends IParser[], Result extends unknown = never> = Parsers extends [infer L extends IParser, ...infer R extends IParser[]] ? UnionParameter<R, Result | StaticParser<L>> : Result
-export interface IUnion<Output extends unknown = unknown> extends IParser<Output> {
-  type: 'Union'
-  parsers: IParser[]
-}
-/** Creates a Union parser */
-export function Union<Parsers extends IParser[], Mapping extends IMapping = IMapping<UnionParameter<Parsers>>>(parsers: [...Parsers], mapping: Mapping): IUnion<ReturnType<Mapping>>
-/** Creates a Union parser */
-export function Union<Parsers extends IParser[]>(parsers: [...Parsers]): IUnion<UnionParameter<Parsers>>
-export function Union(...args: unknown[]): never {
-  const [parsers, mapping] = args.length === 2 ? [args[0], args[1]] : [args[0], Identity]
-  return { type: 'Union', parsers, mapping } as never
-}
-
-// ------------------------------------------------------------------
-// Token
+// Const
 // ------------------------------------------------------------------
 export interface IConst<Output extends unknown = unknown> extends IParser<Output> {
   type: 'Const'
   value: string
 }
-/** Creates a Const parser */
+/** `[TERM]` Creates a Const Parser */
 export function Const<Value extends string, Mapping extends IMapping<Value>>(value: Value, mapping: Mapping): IConst<ReturnType<Mapping>>
-/** Creates a Const parser */
+/** `[TERM]` Creates a Const Parser */
 export function Const<Value extends string>(value: Value): IConst<Value>
+/** `[TERM]` Creates a Const Parser */
 export function Const(...args: unknown[]): never {
   const [value, mapping] = args.length === 2 ? [args[0], args[1]] : [args[0], Identity]
   return { type: 'Const', value, mapping } as never
@@ -113,10 +123,11 @@ export interface IRef<Output extends unknown = unknown> extends IParser<Output> 
   type: 'Ref'
   ref: string
 }
-/** Creates a Ref parser */
+/** `[BNF]` Creates a Ref Parser. This Parser can only be used in the context of a Module */
 export function Ref<Type extends unknown, Mapping extends IMapping<Type>>(ref: string, mapping: Mapping): IRef<ReturnType<Mapping>>
-/** Creates a Ref parser */
+/** `[BNF]` Creates a Ref Parser. This Parser can only be used in the context of a Module */
 export function Ref<Type extends unknown>(ref: string): IRef<Type>
+/** `[BNF]` Creates a Ref Parser. This Parser can only be used in the context of a Module */
 export function Ref(...args: unknown[]): never {
   const [ref, mapping] = args.length === 2 ? [args[0], args[1]] : [args[0], Identity]
   return { type: 'Ref', ref, mapping } as never
@@ -129,10 +140,11 @@ export interface IString<Output extends unknown = unknown> extends IParser<Outpu
   type: 'String'
   options: string[]
 }
-/** Creates a String Parser. Options are an array of permissable quote characters */
+/** `[TERM]` Creates a String Parser. Options are an array of permissable quote characters */
 export function String<Mapping extends IMapping<string>>(options: string[], mapping: Mapping): IString<ReturnType<Mapping>>
-/** Creates a String Parser. Options are an array of permissable quote characters */
+/** `[TERM]` Creates a String Parser. Options are an array of permissable quote characters */
 export function String(options: string[]): IString<string>
+/** `[TERM]` Creates a String Parser. Options are an array of permissable quote characters */
 export function String(...params: unknown[]): never {
   const [options, mapping] = params.length === 2 ? [params[0], params[1]] : [params[0], Identity]
   return { type: 'String', options, mapping } as never
@@ -144,10 +156,11 @@ export function String(...params: unknown[]): never {
 export interface IIdent<Output extends unknown = unknown> extends IParser<Output> {
   type: 'Ident'
 }
-/** Creates an Ident parser */
+/** `[TERM]` Creates an Ident Parser where Ident matches any valid JavaScript identifier */
 export function Ident<Mapping extends IMapping<string>>(mapping: Mapping): IIdent<ReturnType<Mapping>>
-/** Creates an Ident parser */
+/** `[TERM]` Creates an Ident Parser where Ident matches any valid JavaScript identifier */
 export function Ident(): IIdent<string>
+/** `[TERM]` Creates an Ident Parser where Ident matches any valid JavaScript identifier */
 export function Ident(...params: unknown[]): never {
   const mapping = params.length === 1 ? params[0] : Identity
   return { type: 'Ident', mapping } as never
@@ -159,11 +172,79 @@ export function Ident(...params: unknown[]): never {
 export interface INumber<Output extends unknown = unknown> extends IParser<Output> {
   type: 'Number'
 }
-/** Creates a Number parser */
+/** `[TERM]` Creates an Number Parser */
 export function Number<Mapping extends IMapping<string>>(mapping: Mapping): INumber<ReturnType<Mapping>>
-/** Creates a Number parser */
+/** `[TERM]` Creates an Number Parser */
 export function Number(): INumber<string>
+/** `[TERM]` Creates an Number Parser */
 export function Number(...params: unknown[]): never {
   const mapping = params.length === 1 ? params[0] : Identity
   return { type: 'Number', mapping } as never
+}
+
+// ------------------------------------------------------------------
+// Optional
+// ------------------------------------------------------------------
+// prettier-ignore
+export type OptionalParameter<Parser extends IParser, Result extends unknown = [StaticParser<Parser>] | []> = (
+  Result
+)
+export interface IOptional<Output extends unknown = unknown> extends IParser<Output> {
+  type: 'Optional'
+  parser: IParser
+}
+/** `[EBNF]` Creates an Optional Parser */
+export function Optional<Parser extends IParser, Mapping extends IMapping = IMapping<OptionalParameter<Parser>>>(parser: Parser, mapping: Mapping): IOptional<ReturnType<Mapping>>
+/** `[EBNF]` Creates an Optional Parser */
+export function Optional<Parser extends IParser>(parser: Parser): IOptional<OptionalParameter<Parser>>
+/** `[EBNF]` Creates an Optional Parser */
+export function Optional(...args: unknown[]): never {
+  const [parser, mapping] = args.length === 2 ? [args[0], args[1]] : [args[0], Identity]
+  return { type: 'Optional', parser, mapping } as never
+}
+
+// ------------------------------------------------------------------
+// Tuple
+// ------------------------------------------------------------------
+// prettier-ignore
+export type TupleParameter<Parsers extends IParser[], Result extends unknown[] = []> = StaticEnsure<
+  Parsers extends [infer Left extends IParser, ...infer Right extends IParser[]] 
+    ? TupleParameter<Right, [...Result, StaticEnsure<StaticParser<Left>>]> 
+    : Result
+>
+export interface ITuple<Output extends unknown = unknown> extends IParser<Output> {
+  type: 'Tuple'
+  parsers: IParser[]
+}
+/** `[BNF]` Creates a Tuple Parser */
+export function Tuple<Parsers extends IParser[], Mapping extends IMapping = IMapping<TupleParameter<Parsers>>>(parsers: [...Parsers], mapping: Mapping): ITuple<ReturnType<Mapping>>
+/** `[BNF]` Creates a Tuple Parser */
+export function Tuple<Parsers extends IParser[]>(parsers: [...Parsers]): ITuple<TupleParameter<Parsers>>
+/** `[BNF]` Creates a Tuple Parser */
+export function Tuple(...args: unknown[]): never {
+  const [parsers, mapping] = args.length === 2 ? [args[0], args[1]] : [args[0], Identity]
+  return { type: 'Tuple', parsers, mapping } as never
+}
+
+// ------------------------------------------------------------------
+// Union
+// ------------------------------------------------------------------
+// prettier-ignore
+export type UnionParameter<Parsers extends IParser[], Result extends unknown = never> = StaticEnsure<
+  Parsers extends [infer Left extends IParser, ...infer Right extends IParser[]] 
+    ? UnionParameter<Right, Result | StaticParser<Left>> 
+    : Result
+>
+export interface IUnion<Output extends unknown = unknown> extends IParser<Output> {
+  type: 'Union'
+  parsers: IParser[]
+}
+/** `[BNF]` Creates a Union parser */
+export function Union<Parsers extends IParser[], Mapping extends IMapping = IMapping<UnionParameter<Parsers>>>(parsers: [...Parsers], mapping: Mapping): IUnion<ReturnType<Mapping>>
+/** `[BNF]` Creates a Union parser */
+export function Union<Parsers extends IParser[]>(parsers: [...Parsers]): IUnion<UnionParameter<Parsers>>
+/** `[BNF]` Creates a Union parser */
+export function Union(...args: unknown[]): never {
+  const [parsers, mapping] = args.length === 2 ? [args[0], args[1]] : [args[0], Identity]
+  return { type: 'Union', parsers, mapping } as never
 }

--- a/src/parser/static/types.ts
+++ b/src/parser/static/types.ts
@@ -1,6 +1,6 @@
 /*--------------------------------------------------------------------------
 
-@sinclair/typebox/parse
+@sinclair/parsebox
 
 The MIT License (MIT)
 
@@ -29,16 +29,25 @@ THE SOFTWARE.
 // ------------------------------------------------------------------
 // Mapping
 // ------------------------------------------------------------------
+/**
+ * `[ACTION]` Inference mapping base type. Used to specify semantic actions for
+ * Parser productions. This type is implemented as a higher-kinded type where
+ * productions are received on the `input` property with mapping assigned
+ * the `output` property. The parsing context is available on the `context`
+ * property.
+ */
 export interface IMapping {
   context: unknown
   input: unknown
   output: unknown
 }
-/** Maps input to output. This is the default Mapping */
+
+/** `[ACTION]` Default inference mapping. */
 export interface Identity extends IMapping {
   output: this['input']
 }
-/** Maps the output as the given parameter T */
+
+/** `[ACTION]` Maps the given argument `T` as the mapping output */
 export interface As<T> extends IMapping {
   output: T
 }
@@ -50,51 +59,85 @@ export interface IParser<Mapping extends IMapping = Identity> {
   type: string
   mapping: Mapping
 }
+
 // ------------------------------------------------------------------
-// Tuple
+// Context
 // ------------------------------------------------------------------
-/** Creates a Tuple Parser */
-export interface Tuple<Parsers extends IParser[] = [], Mapping extends IMapping = Identity> extends IParser<Mapping> {
-  type: 'Tuple'
-  parsers: [...Parsers]
+/** `[Context]` Creates a Context Parser */
+export interface Context<Left extends IParser = IParser, Right extends IParser = IParser, Mapping extends IMapping = Identity> extends IParser<Mapping> {
+  type: 'Context'
+  left: Left
+  right: Right
 }
+
 // ------------------------------------------------------------------
-// Union
+// Array
 // ------------------------------------------------------------------
-/** Creates a Union Parser */
-export interface Union<Parsers extends IParser[] = [], Mapping extends IMapping = Identity> extends IParser<Mapping> {
-  type: 'Union'
-  parsers: [...Parsers]
+/** `[EBNF]` Creates an Array Parser */
+export interface Array<Parser extends IParser = IParser, Mapping extends IMapping = Identity> extends IParser<Mapping> {
+  type: 'Array'
+  parser: Parser
 }
+
 // ------------------------------------------------------------------
 // Const
 // ------------------------------------------------------------------
-/** Creates a Const Parser */
+/** `[TERM]` Creates a Const Parser */
 export interface Const<Value extends string = string, Mapping extends IMapping = Identity> extends IParser<Mapping> {
   type: 'Const'
   value: Value
 }
-// ------------------------------------------------------------------
-// String
-// ------------------------------------------------------------------
-/** Creates a String Parser. Options are an array of permissable quote characters */
-export interface String<Options extends string[], Mapping extends IMapping = Identity> extends IParser<Mapping> {
-  type: 'String'
-  quote: Options
-}
+
 // ------------------------------------------------------------------
 // Ident
 // ------------------------------------------------------------------
-/** Creates an Ident Parser. */
+/** `[TERM]` Creates an Ident Parser. */
 // prettier-ignore
 export interface Ident<Mapping extends IMapping = Identity> extends IParser<Mapping> {
   type: 'Ident'
 }
+
 // ------------------------------------------------------------------
 // Number
 // ------------------------------------------------------------------
-/** Creates a Number Parser. */
+/** `[TERM]` Creates a Number Parser. */
 // prettier-ignore
 export interface Number<Mapping extends IMapping = Identity> extends IParser<Mapping> {
   type: 'Number'
+}
+
+// ------------------------------------------------------------------
+// Optional
+// ------------------------------------------------------------------
+/** `[EBNF]` Creates a Optional Parser */
+export interface Optional<Parser extends IParser = IParser, Mapping extends IMapping = Identity> extends IParser<Mapping> {
+  type: 'Optional'
+  parser: Parser
+}
+
+// ------------------------------------------------------------------
+// String
+// ------------------------------------------------------------------
+/** `[TERM]` Creates a String Parser. Options are an array of permissable quote characters */
+export interface String<Options extends string[], Mapping extends IMapping = Identity> extends IParser<Mapping> {
+  type: 'String'
+  quote: Options
+}
+
+// ------------------------------------------------------------------
+// Tuple
+// ------------------------------------------------------------------
+/** `[BNF]` Creates a Tuple Parser */
+export interface Tuple<Parsers extends IParser[] = [], Mapping extends IMapping = Identity> extends IParser<Mapping> {
+  type: 'Tuple'
+  parsers: [...Parsers]
+}
+
+// ------------------------------------------------------------------
+// Union
+// ------------------------------------------------------------------
+/** `[BNF]` Creates a Union Parser */
+export interface Union<Parsers extends IParser[] = [], Mapping extends IMapping = Identity> extends IParser<Mapping> {
+  type: 'Union'
+  parsers: [...Parsers]
 }

--- a/src/syntax/runtime.ts
+++ b/src/syntax/runtime.ts
@@ -88,15 +88,15 @@ const GenericArgumentList = Runtime.Union([
 // GenericArguments
 // ------------------------------------------------------------------
 // prettier-ignore
-const GenericArgumentsContext = (args: string[]) => {
+const GenericArgumentsContext = (args: string[], context: t.TProperties) => {
   return args.reduce((result, arg, index) => {
     return { ...result, [arg]: t.Argument(index) }
-  }, {})
+  }, context)
 }
 // prettier-ignore
-const GenericArgumentsMapping = (results: unknown[]) => {
+const GenericArgumentsMapping = (results: unknown[], context: t.TProperties) => {
   return results.length === 3
-    ? GenericArgumentsContext(results[1] as string[])
+    ? GenericArgumentsContext(results[1] as string[], context)
     : {}
 }
 // prettier-ignore
@@ -104,7 +104,7 @@ const GenericArguments = Runtime.Tuple([
   Runtime.Const(LAngle),
   Runtime.Ref('GenericArgumentList'),
   Runtime.Const(RAngle),
-], results => GenericArgumentsMapping(results))
+], (results, context) => GenericArgumentsMapping(results, context))
 // ------------------------------------------------------------------
 // GenericReference
 // ------------------------------------------------------------------
@@ -326,7 +326,11 @@ const Expr = Runtime.Tuple([
 // ------------------------------------------------------------------
 // Type
 // ------------------------------------------------------------------
-const Type = Runtime.Ref('Expr')
+// prettier-ignore
+const Type = Runtime.Union([
+  Runtime.Context(Runtime.Ref('GenericArguments'), Runtime.Ref('Expr')), 
+  Runtime.Ref('Expr')
+])
 // ------------------------------------------------------------------
 // Properties
 // ------------------------------------------------------------------
@@ -704,12 +708,12 @@ const Uint8Array = Runtime.Const('Uint8Array', Runtime.As(t.Uint8Array()))
 // prettier-ignore
 export const Module = new Runtime.Module({
   // ----------------------------------------------------------------
-  // Generic Arguments
+  // Generics
   // ----------------------------------------------------------------
   GenericArgumentList,
   GenericArguments,
   // ----------------------------------------------------------------
-  // Type Expressions
+  // Type
   // ----------------------------------------------------------------
   Literal,
   Keyword,
@@ -722,7 +726,7 @@ export const Module = new Runtime.Module({
   ExprTerm,
   ExprTail,
   Expr,
-  Type, // Alias for Expr
+  Type,
   PropertyKey,
   Readonly,
   Optional,

--- a/src/syntax/static.ts
+++ b/src/syntax/static.ts
@@ -165,23 +165,26 @@ type GenericArgumentList = Static.Union<[
 // GenericArguments
 // ------------------------------------------------------------------
 // prettier-ignore
-type GenericArgumentsContext<Args extends string[], Result extends t.TProperties = {}> = (
+type GenericArgumentsContext<Args extends string[], Context extends t.TProperties, Result extends t.TProperties = {}> = (
   Args extends [...infer Left extends string[], infer Right extends string]
-    ? GenericArgumentsContext<Left, Result & { [_ in Right]: t.TArgument<Left['length']> }>
-    : t.Evaluate<Result>
+    ? GenericArgumentsContext<Left, Context, Result & { [_ in Right]: t.TArgument<Left['length']> }>
+    : t.Evaluate<Result & Context>
 )
 // prettier-ignore
 interface GenericArgumentsMapping extends Static.IMapping {
   output: this['input'] extends [LAngle, infer Args extends string[], RAngle]
-    ? GenericArgumentsContext<Args>
+    ? this['context'] extends infer Context extends t.TProperties
+        ? GenericArgumentsContext<Args, Context>
+        : never
     : never
 }
 // prettier-ignore
-export type GenericArguments = Static.Tuple<[
+type GenericArguments = Static.Tuple<[
   Static.Const<LAngle>,
   GenericArgumentList,
   Static.Const<RAngle>,
 ], GenericArgumentsMapping>
+
 // ------------------------------------------------------------------
 // GenericReference
 // ------------------------------------------------------------------
@@ -426,7 +429,11 @@ type Expr = Static.Tuple<[
 // ------------------------------------------------------------------
 // Type
 // ------------------------------------------------------------------
-export type Type = Expr
+// prettier-ignore
+export type Type = Static.Union<[
+  Static.Context<GenericArguments, Expr>, 
+  Expr
+]>
 // ------------------------------------------------------------------
 // Properties
 // ------------------------------------------------------------------

--- a/src/syntax/syntax.ts
+++ b/src/syntax/syntax.ts
@@ -29,26 +29,8 @@ THE SOFTWARE.
 import * as t from '../type/index'
 import { Static } from '../parser/index'
 import { Module } from './runtime'
-import { Type, GenericArguments } from './static'
+import { Type } from './static'
 
-// ------------------------------------------------------------------
-// ParseSyntax: Two-Phase Parse
-// ------------------------------------------------------------------
-// prettier-ignore
-type TParseSyntax<Context extends Record<PropertyKey, t.TSchema>, Code extends string> = (
-  Static.Parse<GenericArguments, Code, {}> extends [infer Args extends t.TProperties, infer Rest extends string]
-    ? Static.Parse<Type, Rest, Context & Args>
-    : Static.Parse<Type, Code, Context>
-)
-// prettier-ignore
-function ParseSyntax<Context extends Record<PropertyKey, t.TSchema>, Code extends string>(context: Context, code: Code): [] | [t.TSchema, string] {
-  const results = Module.Parse('GenericArguments', code, {}) // [ArgumentContext, Rest]
-  return (
-    results.length === 2
-      ? Module.Parse('Type', results[1], { ...context, ...results[0] })
-      : Module.Parse('Type', code, context)
-  ) as never
-}
 // ------------------------------------------------------------------
 // NoInfer
 // ------------------------------------------------------------------
@@ -61,7 +43,7 @@ export function NoInfer<Code extends string>(code: Code, options?: t.SchemaOptio
 export function NoInfer(...args: any[]): t.TSchema {
   const withContext = typeof args[0] === 'string' ? false : true
   const [context, code, options] = withContext ? [args[0], args[1], args[2] || {}] : [{}, args[0], args[1] || {}]
-  const result = ParseSyntax(context, code)[0]
+  const result = Module.Parse('Type', code, context)[0]
   return t.KindGuard.IsSchema(result) 
     ? t.CloneType(result, options) 
     : t.Never(options)
@@ -70,7 +52,7 @@ export function NoInfer(...args: any[]): t.TSchema {
 /** `[Experimental]` Parses a TypeScript annotation into a TypeBox type */
 // prettier-ignore
 export type TSyntax<Context extends Record<PropertyKey, t.TSchema>, Code extends string> = (
-  TParseSyntax<Context, Code> extends [infer Type extends t.TSchema, string] ? Type : t.TNever
+  Static.Parse<Type, Code, Context> extends [infer Type extends t.TSchema, string] ? Type : t.TNever
 )
 /** `[Experimental]` Parses a TypeScript annotation into a TypeBox type */
 export function Syntax<Context extends Record<PropertyKey, t.TSchema>, Annotation extends string>(context: Context, annotation: Annotation, options?: t.SchemaOptions): TSyntax<Context, Annotation>


### PR DESCRIPTION
This PR is an internal update to leverage the new context threading functionality of ParseBox. 

The original implementation of syntax Generics required a 2-phase parse technique, with the first phase used to map Generic Arguments into a Context, followed by a subsequent phase to parse the type with that Context. The new ParseBox Context() threading function reduces 2-phases to 1 by allowing the parser to dynamically construct the Context interior to the parser.

```typescript
export type Type = Static.Union<[
  Static.Context<GenericArguments, Expr>,  // GenericArguments Result Mapped to Expr Context
  Expr
]>
```
This PR updates the syntax parsers accordingly.