### PR TITLE
feat: add the list of union type members in union type errors

### DIFF
--- a/src/errors/function.ts
+++ b/src/errors/function.ts
@@ -156,7 +156,9 @@ export function DefaultErrorFunction(error: ErrorFunctionParameter) {
     case ValueErrorType.Undefined:
       return 'Expected undefined'
     case ValueErrorType.Union:
-      return 'Expected union value'
+      const unionMembers = error.schema?.anyOf?.map((el: {type: string}) => el.type);
+      const unionMembersSuffix = unionMembers?.length ? ` (${unionMembers?.join(' | ')})` : '';
+      return 'Expected union value' + unionMembersSuffix;
     case ValueErrorType.Void:
       return 'Expected void'
     case ValueErrorType.Kind:


### PR DESCRIPTION
Praise: This lib is so great, I define a type once and use it both to validate the incoming API calls and confidently process these calls knowing that the type I rely on matches exactly the actual data slipping through validation. Many many thanks

The problem: The only issue I have so far with the usage of this lib is that it does not detail the members of a failed Union type validation. This is not informative enough for my FE peers to fix their payload just by looking at the returned validation error messages.

The solution: The relevant schema is already available in the scope of `DefaultErrorFunction`, all we need to do is to add the types on top of the generic `Expected union value` message, and that's what I do here.

Tests: For some weird reason, tests are failing if I run them in VSCode's `JavaScript Debug Terminal`. It makes it difficult to add new tests. However, in a regular terminal no test fails, so I think we're good.

Thank you.