### PR TITLE
Fix: escape properties in regexp pattern generation

### DIFF
--- a/src/type/keyof/keyof-property-keys.ts
+++ b/src/type/keyof/keyof-property-keys.ts
@@ -164,11 +164,14 @@ export function KeyOfPropertyKeys<Type extends TSchema>(type: Type): TKeyOfPrope
 // KeyOfPattern
 // ----------------------------------------------------------------
 let includePatternProperties = false
+const escapeRegexSpecialChars = (value: unknown) => {
+  return `${value}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
 /** Returns a regular expression pattern derived from the given TSchema */
 export function KeyOfPattern(schema: TSchema): string {
   includePatternProperties = true
   const keys = KeyOfPropertyKeys(schema)
   includePatternProperties = false
-  const pattern = keys.map((key) => `(${key})`)
+  const pattern = keys.map((key) => `(${escapeRegexSpecialChars(key)})`)
   return `^(${pattern.join('|')})$`
 }


### PR DESCRIPTION
Hi,

In some scenarios properties with special chars (eg: $limit or $skip) are evaluated in the regexp pattern generated by KeyOfPattern.

it doesn't always happen because KeyOfPattern is not used in every cases, but it happen it the following case for example:

```ts
test('should pass but fail', () => {
    const value = { 
      $like: 'foo', 
      $not: { $like: 'bar' } 
    };

    const schema = t.Recursive((t1) => {
      return t.Intersect([
        t.Object({ 
          $or: t.Optional(t.Array(t1))
        }),
        t.Recursive(t2 => {
          return t.Object({ 
            $not: t.Optional(t2),
            $like: t.Optional(t.String()) 
          })
        })
      ], { unevaluatedProperties: false });
    });

    expect(Value.Errors(schema, value).First()).toEqual(undefined);
  });

  test('workaround pass', () => {
    const value = { 
      $like: 'foo', 
      $not: { $like: 'bar' } 
    };

    const schema2 = t.Recursive((t1) => {
      return t.Intersect([
        t.Object({ 
          ['\\$or']: t.Optional(t.Array(t1))
        }),
        t.Recursive(t2 => {
          return t.Object({ 
            ['\\$not']: t.Optional(t2),
            ['\\$like']: t.Optional(t.String()) 
          })
        })
      ], { unevaluatedProperties: false });
    });

    expect(Value.Errors(schema2, value).First()).toEqual(undefined);
  });
```

this PR just escape all properties to prevent regexp evaluation of special chars.
