### PR TITLE
Revert "Fix: escape properties in regexp pattern generation"

### DIFF
--- a/src/type/keyof/keyof-property-keys.ts
+++ b/src/type/keyof/keyof-property-keys.ts
@@ -164,14 +164,11 @@ export function KeyOfPropertyKeys<Type extends TSchema>(type: Type): TKeyOfPrope
 // KeyOfPattern
 // ----------------------------------------------------------------
 let includePatternProperties = false
-const escapeRegexSpecialChars = (value: unknown) => {
-  return `${value}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
 /** Returns a regular expression pattern derived from the given TSchema */
 export function KeyOfPattern(schema: TSchema): string {
   includePatternProperties = true
   const keys = KeyOfPropertyKeys(schema)
   includePatternProperties = false
-  const pattern = keys.map((key) => `(${escapeRegexSpecialChars(key)})`)
+  const pattern = keys.map((key) => `(${key})`)
   return `^(${pattern.join('|')})$`
 }


### PR DESCRIPTION
Reverts sinclairzx81/typebox#1231

This PR causes issues for the TypeCompiler and Value Check modules where the KeyOfPattern is used to construct regular expression patterns used for Intersection checks. 