### PR TITLE
Fix: escape properties in regexp pattern generation 2

### DIFF
--- a/test/runtime/compiler/intersect.ts
+++ b/test/runtime/compiler/intersect.ts
@@ -222,4 +222,11 @@ describe('compiler/Intersect', () => {
     )
     Fail(T, { x: 1, y: 2, 0: '', z: 1 })
   })
+
+  it('Should intersect two objects with special characters in their properties', () => {
+    const A = Type.Object({ $x: Type.Number() })
+    const B = Type.Object({ $y: Type.Number() })
+    const T = Type.Intersect([A, B], { unevaluatedProperties: false })
+    Ok(T, { $x: 1, $y: 1 })
+  })
 })


### PR DESCRIPTION
resurection of https://github.com/sinclairzx81/typebox/pull/1231

issue: https://github.com/sinclairzx81/typebox/issues/1245

simpler reproduction:

```ts
import { Type } from '@sinclair/typebox'
import { Value } from '@sinclair/typebox/value'

const A = Type.Object({ $x: Type.Number() })
const B = Type.Object({ $y: Type.Number() })
const T = Type.Intersect([A, B], { unevaluatedProperties: false })

// should be undefined
Value.Errors(T, { $x: 1, $y: 1 }).First()
```