### PR TITLE
Fix inference of Ref inside Recursive inside Module

### DIFF
--- a/src/type/module/infer.ts
+++ b/src/type/module/infer.ts
@@ -43,6 +43,7 @@ import { TRef } from '../ref/index'
 import { TTuple } from '../tuple/index'
 import { TUnion } from '../union/index'
 import { Static } from '../static/index'
+import { TRecursive } from '../recursive/index'
 
 // ------------------------------------------------------------------
 // Array
@@ -160,6 +161,7 @@ type TInfer<ModuleProperties extends TProperties, Type extends TSchema> = (
   Type extends TTuple<infer Types extends TSchema[]> ? TInferTuple<ModuleProperties, Types> :
   Type extends TEnum<infer _ extends TEnumRecord> ? Static<Type> : // intercept enum before union
   Type extends TUnion<infer Types extends TSchema[]> ? TInferUnion<ModuleProperties, Types> :
+  Type extends TRecursive<infer Schema extends TSchema> ? TInfer<ModuleProperties, Schema> :
   Static<Type>
 )
 // ------------------------------------------------------------------

--- a/test/static/import.ts
+++ b/test/static/import.ts
@@ -130,3 +130,26 @@ import { Type, Static } from '@sinclair/typebox'
     x?: null[],
   }>()
 }
+// ------------------------------------------------------------------
+// Ref inside Recursive
+// ------------------------------------------------------------------
+// prettier-ignore
+{
+  const Module = Type.Module({
+    T: Type.Recursive((_) =>
+      Type.Object({
+        M: Type.Ref("U"),
+      })
+    ),
+    U: Type.Union([
+      Type.Literal("A"),
+      Type.Literal("B")
+    ]),
+  });
+
+  const T = Module.Import("T");
+  type T = Static<typeof T>;
+  Expect(T).ToStatic<{
+    M: 'A'|'B'
+  }>();
+}


### PR DESCRIPTION

```typescript
  const Module = Type.Module({
    T: Type.Recursive((_) =>
      Type.Object({
        M: Type.Ref("U"),
      })
    ),
    U: Type.Union([
      Type.Literal("A"),
      Type.Literal("B")
    ]),
  });

  const T = Module.Import("T");
  type T = Static<typeof T>;  //  <- it was inferring as `{  M: unknown  }` now `{ M: 'A'|'B'} `

```

