### PR TITLE
fix: correctly score nested unions

### DIFF
--- a/src/value/cast/cast.ts
+++ b/src/value/cast/cast.ts
@@ -76,6 +76,11 @@ function ScoreUnion(schema: TSchema, references: TSchema[], value: any): number 
       const exists = keys.includes(key) ? point : 0
       return acc + (literal + checks + exists)
     }, 0)
+  } else if (schema[Kind] === "Union") {
+    const schemas = schema.anyOf.map((schema: TSchema) =>
+      Deref(schema, references)
+    )
+    return  Math.max(...schemas.map((schema: TSchema) => ScoreUnion(schema, references, value)))
   } else {
     return Check(schema, references, value) ? 1 : 0
   }
@@ -127,7 +132,7 @@ function FromArray(schema: TArray, references: TSchema[], value: any): any {
 function FromConstructor(schema: TConstructor, references: TSchema[], value: any): any {
   if (Check(schema, references, value)) return Create(schema, references)
   const required = new Set(schema.returns.required || [])
-  const result = function () {}
+  const result = function () { }
   for (const [key, property] of Object.entries(schema.returns.properties)) {
     if (!required.has(key) && value.prototype[key] === undefined) continue
     result.prototype[key] = Visit(property as TSchema, references, value.prototype[key])

--- a/test/runtime/value/cast/union.ts
+++ b/test/runtime/value/cast/union.ts
@@ -161,4 +161,190 @@ describe('value/cast/Union', () => {
     Assert.IsEqual(Value.Cast(RA, [A, B], { type: 'A' }), { type: 'A' })
     Assert.IsEqual(Value.Cast(RB, [A, B], { type: 'A' }), { type: 'A' })
   })
+
+  // ------------------------------------------------------------------------
+  // ref: https://github.com/sinclairzx81/typebox/issues/1268
+  // ------------------------------------------------------------------------
+  it('should correctly score nested union types #1', () => {
+    const A =
+      Type.Union([
+        Type.Union([
+          Type.Object({
+            type: Type.Literal('a'),
+            name: Type.String(),
+            in: Type.String(),
+          }),
+          Type.Object({
+            type: Type.Literal('b'),
+            description: Type.Optional(Type.String()),
+            nested: Type.Object({
+              a: Type.String(),
+              b: Type.Optional(Type.String()),
+            }),
+          }),
+        ]),
+        Type.Object({
+          $ref: Type.String(),
+          description: Type.Optional(Type.String()),
+        }),
+      ],
+
+      );
+
+    Assert.IsEqual(Value.Cast(A, {
+      type: 'b',
+      description: 'Hello World',
+      nested: {
+        b: 'hello',
+      },
+    }), {
+      type: 'b',
+      description: 'Hello World',
+      nested: { a: '', b: 'hello' },
+    });
+  });
+
+  it('should correctly score nested union types #2', () => {
+    const A = Type.Union([
+      Type.Union([
+        Type.Object({
+          prop1: Type.String(),
+          prop2: Type.String(),
+          prop3: Type.String(),
+        }),
+        Type.Object({
+          prop1: Type.String(),
+          prop4: Type.String(),
+          prop5: Type.String(),
+        })
+      ]),
+      Type.Union([
+        Type.Object({
+          prop6: Type.String(),
+          prop7: Type.String(),
+          prop8: Type.String(),
+        }),
+        Type.Object({
+          prop1: Type.String(),
+          prop9: Type.String(),
+          prop10: Type.String(),
+        }),
+      ]),
+    ])
+
+    // Picks the first union variant when the score is equal
+    Assert.IsEqual(Value.Cast(A, {
+      prop1: ''
+    }), {
+      prop1: '',
+      prop2: '',
+      prop3: '',
+    });
+
+    Assert.IsEqual(Value.Cast(A, {
+      prop1: '',
+      prop4: ''
+    }), {
+      prop1: '',
+      prop4: '',
+      prop5: '',
+    });
+
+    Assert.IsEqual(Value.Cast(A, {
+      prop6: '',
+    }), {
+      prop6: '',
+      prop7: '',
+      prop8: '',
+    });
+  });
+
+  it('should correctly score nested union types #3', () => {
+    const A = Type.Union([
+      Type.Object({
+        prop1: Type.String(),
+        prop2: Type.String(),
+        prop3: Type.String(),
+      }),
+      Type.Object({
+        prop4: Type.String(),
+        prop5: Type.String(),
+        prop6: Type.String(),
+      }),
+      Type.Union([
+        Type.Object({
+          prop4: Type.String(),
+          prop5: Type.String(),
+          prop6: Type.String(),
+        }),
+        Type.Object({
+          prop1: Type.String(),
+          prop2: Type.String(),
+          prop7: Type.String(),
+          prop8: Type.String(),
+        }),
+      ]),
+    ])
+
+    Assert.IsEqual(Value.Cast(A, {
+      prop1: '',
+      prop2: '',
+      prop7: ''
+    }), {
+      prop1: '',
+      prop2: '',
+      prop7: '',
+      prop8: '',
+    });
+  });
+
+  it('should correctly score nested union types #4', () => {
+    const A = Type.Union([
+      Type.Object({
+        prop1: Type.String(),
+        prop2: Type.String(),
+        prop3: Type.String(),
+      }),
+      Type.Union([
+        Type.Object({
+          prop4: Type.String(),
+          prop5: Type.String(),
+          prop6: Type.String(),
+        }),
+        Type.Union([
+          Type.Object({
+            prop1: Type.String(),
+            prop2: Type.String(),
+            prop7: Type.String(),
+            prop8: Type.String(),
+          }),
+          Type.Union([
+            Type.Object({
+              prop1: Type.String(),
+              prop2: Type.String(),
+              prop9: Type.String(),
+              prop10: Type.String(),
+            }),
+            Type.Object({
+              prop1: Type.String(),
+              prop2: Type.String(),
+              prop11: Type.String(),
+              prop12: Type.String(),
+            })
+          ])
+        ])
+      ]),
+    ])
+
+    Assert.IsEqual(Value.Cast(A, {
+      prop1: '',
+      prop2: '',
+      prop9: ''
+    }), {
+      prop1: '',
+      prop2: '',
+      prop9: '',
+      prop10: '',
+    });
+  })
 })


### PR DESCRIPTION
**✨ Summary**

This PR improves the type scoring system to properly handle nested union types, which were previously ignored by the scoring system

**Problem**

Currently, the scoring algorithm does not account for union types that are nested within other unions or types. This results in inaccurate or misleading scores when comparing complex type structures.

**Solution**

This PR introduces a recursive scoring mechanism that traverses and evaluates all nested union types. Each branch of the union is now scored independently and factored into the final score, improving the overall accuracy and reliability of the scoring system.

closes #1268