### PR TITLE
docs: add `typebox-schema-faker` to the ecosystem

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1738,6 +1738,7 @@ The following is a list of community packages that offer general tooling, extend
 | [ts2typebox](https://github.com/xddq/ts2typebox) | Creating TypeBox code from Typescript types |
 | [typebox-cli](https://github.com/gsuess/typebox-cli) | Generate Schema with TypeBox from the CLI |
 | [typebox-form-parser](https://github.com/jtlapp/typebox-form-parser) | Parses form and query data based on TypeBox schemas |
+| [typebox-schema-faker](https://github.com/iam-medvedev/typebox-schema-faker) | Generate fake data from TypeBox schemas for testing, prototyping and development |
 
 
 <a name='benchmark'></a>


### PR DESCRIPTION
Added a link to a plugin that allows you to create fake data based on TypeBox schemas.