### PR TITLE
Preserve exact type matches in union conversion

### DIFF
--- a/src/value/convert/convert.ts
+++ b/src/value/convert/convert.ts
@@ -243,6 +243,14 @@ function FromUndefined(schema: TUndefined, references: TSchema[], value: any): u
   return TryConvertUndefined(value)
 }
 function FromUnion(schema: TUnion, references: TSchema[], value: any): unknown {
+  // Check if original value already matches one of the union variants
+  for (const subschema of schema.anyOf) {
+    if (Check(subschema, references, value)) {
+      return value
+    }
+  }
+
+  // Attempt conversion for each variant
   for (const subschema of schema.anyOf) {
     const converted = Visit(subschema, references, Clone(value))
     if (!Check(subschema, references, converted)) continue


### PR DESCRIPTION
## Description

Fixes union type conversion issue where `Value.Parse()` unnecessarily converts values to the first matching type in a union, even when the input already matches one of the union types exactly.

## Problem

When using unions like `Type.Union([Type.String(), Type.Number()])`, numeric values were being converted to strings because the conversion logic would coerce to the first compatible type rather than preserving the original when it's already valid.

```typescript
// Before (broken)
const schema = Type.Union([Type.String(), Type.Number()])
Value.Parse(schema, 42) // Returns "42" (string) instead of 42 (number)

// After (fixed)  
Value.Parse(schema, 42) // Returns 42 (number), which correctly preserves type
```

Fixes #1281