### PR TITLE
fix: union scoring bias toward schemas with fewer properties

### DIFF
--- a/src/value/cast/cast.ts
+++ b/src/value/cast/cast.ts
@@ -57,23 +57,21 @@ export class ValueCastError extends TypeBoxError {
   }
 }
 // ------------------------------------------------------------------
-// The following will score a schema against a value. For objects,
-// the score is the tally of points awarded for each property of
-// the value. Property points are (1.0 / propertyCount) to prevent
-// large property counts biasing results. Properties that match
-// literal values are maximally awarded as literals are typically
-// used as union discriminator fields.
+// The following logic assigns a score to a schema based on how well it matches a given value.
+// For object types, the score is calculated by evaluating each property of the value against
+// the schema's properties. To avoid bias towards objects with many properties, each property
+// contributes equally to the total score. Properties that exactly match literal values receive
+// the highest possible score, as literals are often used as discriminators in union types.
 // ------------------------------------------------------------------
 function ScoreUnion(schema: TSchema, references: TSchema[], value: any): number {
   if (schema[Kind] === 'Object' && typeof value === 'object' && !IsNull(value)) {
     const object = schema as TObject
     const keys = Object.getOwnPropertyNames(value)
     const entries = Object.entries(object.properties)
-    const [point, max] = [1 / entries.length, entries.length]
     return entries.reduce((acc, [key, schema]) => {
-      const literal = schema[Kind] === 'Literal' && schema.const === value[key] ? max : 0
-      const checks = Check(schema, references, value[key]) ? point : 0
-      const exists = keys.includes(key) ? point : 0
+      const literal = schema[Kind] === 'Literal' && schema.const === value[key] ? 100 : 0
+      const checks = Check(schema, references, value[key]) ? 10 : 0
+      const exists = keys.includes(key) ? 1 : 0
       return acc + (literal + checks + exists)
     }, 0)
   } else if (schema[Kind] === 'Union') {

--- a/test/runtime/value/cast/union.ts
+++ b/test/runtime/value/cast/union.ts
@@ -362,4 +362,71 @@ describe('value/cast/Union', () => {
       },
     )
   })
+
+  it('should correctly score object unions with shared properties #1', () => {
+    const schema = Type.Union([
+      Type.Object({
+        summary: Type.Optional(Type.String()),
+        description: Type.Optional(Type.String()),
+        parameters: Type.Optional(Type.Array(Type.Any())),
+        responses: Type.Optional(Type.Record(Type.String(), Type.Any())),
+        requestBody: Type.Optional(Type.Any()),
+      }),
+      Type.Object({
+        $ref: Type.String(),
+        summary: Type.Optional(Type.String()),
+      }),
+    ])
+
+    Assert.IsEqual(
+      Value.Cast(schema, {
+        summary: 'Test Summary',
+        parameters: {},
+      }),
+      {
+        summary: 'Test Summary',
+        parameters: [],
+      },
+    )
+  })
+
+  it('should correctly score object unions with shared properties #2', () => {
+    const A = Type.Union([
+      Type.Object({
+        prop1: Type.String(),
+        prop2: Type.String(),
+        prop3: Type.String(),
+      }),
+      Type.Object({
+        prop1: Type.String(),
+        prop2: Type.String(),
+        prop4: Type.String(),
+        prop5: Type.String(),
+        prop6: Type.String(),
+        prop7: Type.String(),
+        prop8: Type.String(),
+        prop9: Type.String(),
+        prop10: Type.String(),
+      }),
+    ])
+
+    Assert.IsEqual(
+      Value.Cast(A, {
+        prop1: '',
+        prop2: '',
+        prop7: '',
+      }),
+      {
+        prop1: '',
+        prop2: '',
+        prop4: '',
+        prop5: '',
+        prop6: '',
+        prop7: '',
+        prop8: '',
+        prop9: '',
+        prop10: '',
+      },
+    )
+  })
 })

--- a/test/runtime/value/cast/union.ts
+++ b/test/runtime/value/cast/union.ts
@@ -363,6 +363,9 @@ describe('value/cast/Union', () => {
     )
   })
 
+  // ------------------------------------------------------------------------
+  // ref: https://github.com/sinclairzx81/typebox/issues/1292
+  // ------------------------------------------------------------------------
   it('should correctly score object unions with shared properties #1', () => {
     const schema = Type.Union([
       Type.Object({


### PR DESCRIPTION
**Problem**

When casting values against a union of object schemas, the scoring algorithm incorrectly favored schemas with fewer properties. This caused situations where partially matching simple schemas (e.g., $ref objects) were chosen over more accurate matches with richer schemas, leading to incorrect output.

See #1292 

**Solution**

- Updated union scoring to select the schema that best matches the provided properties, rather than favoring schemas with fewer properties.

- Implemented weighted scoring for object property matching:
   - Literal type matches now count as 10× more important in the score.
   - Properties that exist but have the wrong type now count as ¹⁄₁₀th the value of a valid match.