### PR TITLE
Revision 0.34.39

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Revision Updates
+- [Revision 0.34.39](https://github.com/sinclairzx81/typebox/pull/1296)
+  - Guard for Array in Object and Record conversion
 - [Revision 0.34.38](https://github.com/sinclairzx81/typebox/pull/1282)
   - Preserve exact type matches in Union conversion
 - [Revision 0.34.37](https://github.com/sinclairzx81/typebox/pull/1278)

--- a/hammer.mjs
+++ b/hammer.mjs
@@ -40,7 +40,7 @@ export async function test_typescript() {
     '5.2.2', '5.3.2', '5.3.3', '5.4.3', 
     '5.4.5', '5.5.2', '5.5.3', '5.5.4', 
     '5.6.2', '5.6.3', '5.7.2', '5.7.3', 
-    '5.8.2', 'next', 'latest'
+    '5.8.2', '5.8.3', 'next', 'latest'
   ]) {
     await shell(`npm install typescript@${version} --no-save`)
     await test_static()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.38",
+  "version": "0.34.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.38",
+      "version": "0.34.39",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ajv-formats": "^2.1.1",
         "mocha": "^11.1.0",
         "prettier": "^2.7.1",
-        "typescript": "^5.8.3"
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@andrewbranch/untar.js": {
@@ -1814,9 +1814,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3226,9 +3226,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.38",
+  "version": "0.34.39",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "ajv-formats": "^2.1.1",
     "mocha": "^11.1.0",
     "prettier": "^2.7.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/src/value/convert/convert.ts
+++ b/src/value/convert/convert.ts
@@ -200,7 +200,7 @@ function FromNumber(schema: TNumber, references: TSchema[], value: any): unknown
 }
 // prettier-ignore
 function FromObject(schema: TObject, references: TSchema[], value: any): unknown {
-  if(!IsObject(value)) return value
+  if(!IsObject(value) || IsArray(value)) return value
   for(const propertyKey of Object.getOwnPropertyNames(schema.properties)) {
     if(!HasPropertyKey(value, propertyKey)) continue
     value[propertyKey] = Visit(schema.properties[propertyKey], references, value[propertyKey])
@@ -208,7 +208,7 @@ function FromObject(schema: TObject, references: TSchema[], value: any): unknown
   return value
 }
 function FromRecord(schema: TRecord, references: TSchema[], value: any): unknown {
-  const isConvertable = IsObject(value)
+  const isConvertable = IsObject(value) && !IsArray(value)
   if (!isConvertable) return value
   const propertyKey = Object.getOwnPropertyNames(schema.patternProperties)[0]
   const property = schema.patternProperties[propertyKey]

--- a/test/runtime/value/convert/union.ts
+++ b/test/runtime/value/convert/union.ts
@@ -94,4 +94,9 @@ describe('value/convert/Union', () => {
     const converted = Value.Convert(T, [{ type: 'A', values: 1 }])
     Assert.IsEqual(converted, [{ type: 'A', values: 1 }])
   })
+  it('Should guard against Array conversion in Record', () => {
+    const T = Type.Union([Type.Record(Type.String({ pattern: '^values$' }), Type.Union([Type.String(), Type.Number()])), Type.Record(Type.String({ pattern: '^type$' }), Type.Union([Type.String(), Type.Number()]))])
+    const converted = Value.Convert(T, [{ type: 'A', values: 1 }])
+    Assert.IsEqual(converted, [{ type: 'A', values: 1 }])
+  })
 })

--- a/test/runtime/value/convert/union.ts
+++ b/test/runtime/value/convert/union.ts
@@ -77,4 +77,21 @@ describe('value/convert/Union', () => {
     Assert.IsEqual((A as any).data[0].key2, 42)
     Assert.IsEqual((B as any).data[0].key2, 42)
   })
+  // ----------------------------------------------------------------
+  // https://github.com/sinclairzx81/typebox/issues/1295
+  // ----------------------------------------------------------------
+  it('Should guard against Array conversion in Object', () => {
+    const T = Type.Union([
+      Type.Object({
+        type: Type.Literal('A'),
+        values: Type.Union([Type.String(), Type.Number()]),
+      }),
+      Type.Object({
+        type: Type.Literal('B'),
+        values: Type.String(),
+      }),
+    ])
+    const converted = Value.Convert(T, [{ type: 'A', values: 1 }])
+    Assert.IsEqual(converted, [{ type: 'A', values: 1 }])
+  })
 })


### PR DESCRIPTION
This PR adds an Array Guard in Convert when applying Object and Record conversions. We must reject Array when applying conversions for these types as schema properties may indirectly access Array members. 

This problem was noted at the following issue.

Fixes: https://github.com/sinclairzx81/typebox/issues/1295