### PR TITLE
feat: support recursive structures

### DIFF
--- a/test/runtime/value/clone/clone.ts
+++ b/test/runtime/value/clone/clone.ts
@@ -153,4 +153,10 @@ describe('value/clone/Clone', () => {
     const R = Value.Clone(V)
     Assert.IsEqual(R, V)
   })
+  it('Should handle circular references', () => {
+    const V = { a: 1, b: { c: 2 } } as any
+    V.b.d = V.b
+    const R = Value.Clone(V)
+    Assert.IsEqual(R, V)
+  })
 })


### PR DESCRIPTION
The current Clone function does not handle recursive (circular) structures. When an object references itself, the function runs into infinite recursion and throws a Maximum call stack size exceeded error.

See issue: #1300

```ts
const a = { x: 1 };
a.b = a;

Clone(a); // ❌ Fails with Maximum call stack error
```

This PR adds support for cloning recursive structures by detecting and handling circular references. Objects that reference themselves (directly or indirectly) can now be cloned safely without causing stack overflows.