### PR TITLE
feat: `Value.Cast` support for recursive structures

### DIFF
--- a/src/value/check/check.ts
+++ b/src/value/check/check.ts
@@ -109,7 +109,7 @@ function FromAny(schema: TAny, references: TSchema[], value: any): boolean {
 function FromArgument(schema: TArgument, references: TSchema[], value: any): boolean {
   return true
 }
-function FromArray(schema: TArray, references: TSchema[], value: any): boolean {
+function FromArray(schema: TArray, references: TSchema[], value: any, cache: WeakSet<object>): boolean {
   if (!IsArray(value)) return false
   if (IsDefined<number>(schema.minItems) && !(value.length >= schema.minItems)) {
     return false
@@ -117,7 +117,9 @@ function FromArray(schema: TArray, references: TSchema[], value: any): boolean {
   if (IsDefined<number>(schema.maxItems) && !(value.length <= schema.maxItems)) {
     return false
   }
-  if (!value.every((value) => Visit(schema.items, references, value))) {
+  if (cache.has(value)) return true
+  cache.add(value)
+  if (!value.every((value) => Visit(schema.items, references, value, cache))) {
     return false
   }
   // prettier-ignore
@@ -129,7 +131,7 @@ function FromArray(schema: TArray, references: TSchema[], value: any): boolean {
     return true // exit
   }
   const containsSchema = IsDefined<TSchema>(schema.contains) ? schema.contains : Never()
-  const containsCount = value.reduce((acc: number, value) => (Visit(containsSchema, references, value) ? acc + 1 : acc), 0)
+  const containsCount = value.reduce((acc: number, value) => (Visit(containsSchema, references, value, cache) ? acc + 1 : acc), 0)
   if (containsCount === 0) {
     return false
   }
@@ -166,8 +168,8 @@ function FromBigInt(schema: TBigInt, references: TSchema[], value: any): boolean
 function FromBoolean(schema: TBoolean, references: TSchema[], value: any): boolean {
   return IsBoolean(value)
 }
-function FromConstructor(schema: TConstructor, references: TSchema[], value: any): boolean {
-  return Visit(schema.returns, references, value.prototype)
+function FromConstructor(schema: TConstructor, references: TSchema[], value: any, cache: WeakSet<object>): boolean {
+  return Visit(schema.returns, references, value.prototype, cache)
 }
 function FromDate(schema: TDate, references: TSchema[], value: any): boolean {
   if (!IsDate(value)) return false
@@ -191,10 +193,10 @@ function FromDate(schema: TDate, references: TSchema[], value: any): boolean {
 function FromFunction(schema: TFunction, references: TSchema[], value: any): boolean {
   return IsFunction(value)
 }
-function FromImport(schema: TImport, references: TSchema[], value: any): boolean {
+function FromImport(schema: TImport, references: TSchema[], value: any, cache: WeakSet<object>): boolean {
   const definitions = globalThis.Object.values(schema.$defs) as TSchema[]
   const target = schema.$defs[schema.$ref] as TSchema
-  return Visit(target, [...references, ...definitions], value)
+  return Visit(target, [...references, ...definitions], value, cache)
 }
 function FromInteger(schema: TInteger, references: TSchema[], value: any): boolean {
   if (!IsInteger(value)) {
@@ -217,15 +219,15 @@ function FromInteger(schema: TInteger, references: TSchema[], value: any): boole
   }
   return true
 }
-function FromIntersect(schema: TIntersect, references: TSchema[], value: any): boolean {
-  const check1 = schema.allOf.every((schema) => Visit(schema, references, value))
+function FromIntersect(schema: TIntersect, references: TSchema[], value: any, cache: WeakSet<object>): boolean {
+  const check1 = schema.allOf.every((schema) => Visit(schema, references, value, cache))
   if (schema.unevaluatedProperties === false) {
     const keyPattern = new RegExp(KeyOfPattern(schema))
     const check2 = Object.getOwnPropertyNames(value).every((key) => keyPattern.test(key))
     return check1 && check2
   } else if (IsSchema(schema.unevaluatedProperties)) {
     const keyCheck = new RegExp(KeyOfPattern(schema))
-    const check2 = Object.getOwnPropertyNames(value).every((key) => keyCheck.test(key) || Visit(schema.unevaluatedProperties as TSchema, references, value[key]))
+    const check2 = Object.getOwnPropertyNames(value).every((key) => keyCheck.test(key) || Visit(schema.unevaluatedProperties as TSchema, references, value[key], cache))
     return check1 && check2
   } else {
     return check1
@@ -240,8 +242,8 @@ function FromLiteral(schema: TLiteral, references: TSchema[], value: any): boole
 function FromNever(schema: TNever, references: TSchema[], value: any): boolean {
   return false
 }
-function FromNot(schema: TNot, references: TSchema[], value: any): boolean {
-  return !Visit(schema.not, references, value)
+function FromNot(schema: TNot, references: TSchema[], value: any, cache: WeakSet<object>): boolean {
+  return !Visit(schema.not, references, value, cache)
 }
 function FromNull(schema: TNull, references: TSchema[], value: any): boolean {
   return IsNull(value)
@@ -265,7 +267,7 @@ function FromNumber(schema: TNumber, references: TSchema[], value: any): boolean
   }
   return true
 }
-function FromObject(schema: TObject, references: TSchema[], value: any): boolean {
+function FromObject(schema: TObject, references: TSchema[], value: any, cache: WeakSet<object>): boolean {
   if (!TypeSystemPolicy.IsObjectLike(value)) return false
   if (IsDefined<number>(schema.minProperties) && !(Object.getOwnPropertyNames(value).length >= schema.minProperties)) {
     return false
@@ -277,14 +279,14 @@ function FromObject(schema: TObject, references: TSchema[], value: any): boolean
   for (const knownKey of knownKeys) {
     const property = schema.properties[knownKey]
     if (schema.required && schema.required.includes(knownKey)) {
-      if (!Visit(property, references, value[knownKey])) {
+      if (!Visit(property, references, value[knownKey], cache)) {
         return false
       }
       if ((ExtendsUndefinedCheck(property) || IsAnyOrUnknown(property)) && !(knownKey in value)) {
         return false
       }
     } else {
-      if (TypeSystemPolicy.IsExactOptionalProperty(value, knownKey) && !Visit(property, references, value[knownKey])) {
+      if (TypeSystemPolicy.IsExactOptionalProperty(value, knownKey) && !Visit(property, references, value[knownKey], cache)) {
         return false
       }
     }
@@ -299,7 +301,7 @@ function FromObject(schema: TObject, references: TSchema[], value: any): boolean
     }
   } else if (typeof schema.additionalProperties === 'object') {
     const valueKeys = Object.getOwnPropertyNames(value)
-    return valueKeys.every((key) => knownKeys.includes(key) || Visit(schema.additionalProperties as TSchema, references, value[key]))
+    return valueKeys.every((key) => knownKeys.includes(key) || Visit(schema.additionalProperties as TSchema, references, value[key], cache))
   } else {
     return true
   }
@@ -307,7 +309,7 @@ function FromObject(schema: TObject, references: TSchema[], value: any): boolean
 function FromPromise(schema: TPromise, references: TSchema[], value: any): boolean {
   return IsPromise(value)
 }
-function FromRecord(schema: TRecord, references: TSchema[], value: any): boolean {
+function FromRecord(schema: TRecord, references: TSchema[], value: any, cache: WeakSet<object>): boolean {
   if (!TypeSystemPolicy.IsRecordLike(value)) {
     return false
   }
@@ -321,11 +323,11 @@ function FromRecord(schema: TRecord, references: TSchema[], value: any): boolean
   const regex = new RegExp(patternKey)
   // prettier-ignore
   const check1 = Object.entries(value).every(([key, value]) => {
-    return (regex.test(key)) ? Visit(patternSchema, references, value) : true
+    return (regex.test(key)) ? Visit(patternSchema, references, value, cache) : true
   })
   // prettier-ignore
   const check2 = typeof schema.additionalProperties === 'object' ? Object.entries(value).every(([key, value]) => {
-    return (!regex.test(key)) ? Visit(schema.additionalProperties as TSchema, references, value) : true
+    return (!regex.test(key)) ? Visit(schema.additionalProperties as TSchema, references, value, cache) : true
   }) : true
   const check3 =
     schema.additionalProperties === false
@@ -335,8 +337,8 @@ function FromRecord(schema: TRecord, references: TSchema[], value: any): boolean
       : true
   return check1 && check2 && check3
 }
-function FromRef(schema: TRef, references: TSchema[], value: any): boolean {
-  return Visit(Deref(schema, references), references, value)
+function FromRef(schema: TRef, references: TSchema[], value: any, cache: WeakSet<object>): boolean {
+  return Visit(Deref(schema, references), references, value, cache)
 }
 function FromRegExp(schema: TRegExp, references: TSchema[], value: any): boolean {
   const regex = new RegExp(schema.source, schema.flags)
@@ -375,10 +377,10 @@ function FromSymbol(schema: TSymbol, references: TSchema[], value: any): boolean
 function FromTemplateLiteral(schema: TTemplateLiteral, references: TSchema[], value: any): boolean {
   return IsString(value) && new RegExp(schema.pattern).test(value)
 }
-function FromThis(schema: TThis, references: TSchema[], value: any): boolean {
-  return Visit(Deref(schema, references), references, value)
+function FromThis(schema: TThis, references: TSchema[], value: any, cache: WeakSet<object>): boolean {
+  return Visit(Deref(schema, references), references, value, cache)
 }
-function FromTuple(schema: TTuple<any[]>, references: TSchema[], value: any): boolean {
+function FromTuple(schema: TTuple<any[]>, references: TSchema[], value: any, cache: WeakSet<object>): boolean {
   if (!IsArray(value)) {
     return false
   }
@@ -392,15 +394,15 @@ function FromTuple(schema: TTuple<any[]>, references: TSchema[], value: any): bo
     return true
   }
   for (let i = 0; i < schema.items.length; i++) {
-    if (!Visit(schema.items[i], references, value[i])) return false
+    if (!Visit(schema.items[i], references, value[i], cache)) return false
   }
   return true
 }
 function FromUndefined(schema: TUndefined, references: TSchema[], value: any): boolean {
   return IsUndefined(value)
 }
-function FromUnion(schema: TUnion, references: TSchema[], value: any): boolean {
-  return schema.anyOf.some((inner) => Visit(inner, references, value))
+function FromUnion(schema: TUnion, references: TSchema[], value: any, cache: WeakSet<object>): boolean {
+  return schema.anyOf.some((inner) => Visit(inner, references, value, cache))
 }
 function FromUint8Array(schema: TUint8Array, references: TSchema[], value: any): boolean {
   if (!IsUint8Array(value)) {
@@ -425,7 +427,7 @@ function FromKind(schema: TSchema, references: TSchema[], value: unknown): boole
   const func = TypeRegistry.Get(schema[Kind])!
   return func(schema, value)
 }
-function Visit<T extends TSchema>(schema: T, references: TSchema[], value: any): boolean {
+function Visit<T extends TSchema>(schema: T, references: TSchema[], value: any, cache: WeakSet<object>): boolean {
   const references_ = IsDefined<string>(schema.$id) ? Pushref(schema, references) : references
   const schema_ = schema as any
   switch (schema_[Kind]) {
@@ -434,7 +436,7 @@ function Visit<T extends TSchema>(schema: T, references: TSchema[], value: any):
     case 'Argument':
       return FromArgument(schema_, references_, value)
     case 'Array':
-      return FromArray(schema_, references_, value)
+      return FromArray(schema_, references_, value, cache)
     case 'AsyncIterator':
       return FromAsyncIterator(schema_, references_, value)
     case 'BigInt':
@@ -442,17 +444,17 @@ function Visit<T extends TSchema>(schema: T, references: TSchema[], value: any):
     case 'Boolean':
       return FromBoolean(schema_, references_, value)
     case 'Constructor':
-      return FromConstructor(schema_, references_, value)
+      return FromConstructor(schema_, references_, value, cache)
     case 'Date':
       return FromDate(schema_, references_, value)
     case 'Function':
       return FromFunction(schema_, references_, value)
     case 'Import':
-      return FromImport(schema_, references_, value)
+      return FromImport(schema_, references_, value, cache)
     case 'Integer':
       return FromInteger(schema_, references_, value)
     case 'Intersect':
-      return FromIntersect(schema_, references_, value)
+      return FromIntersect(schema_, references_, value, cache)
     case 'Iterator':
       return FromIterator(schema_, references_, value)
     case 'Literal':
@@ -460,19 +462,19 @@ function Visit<T extends TSchema>(schema: T, references: TSchema[], value: any):
     case 'Never':
       return FromNever(schema_, references_, value)
     case 'Not':
-      return FromNot(schema_, references_, value)
+      return FromNot(schema_, references_, value, cache)
     case 'Null':
       return FromNull(schema_, references_, value)
     case 'Number':
       return FromNumber(schema_, references_, value)
     case 'Object':
-      return FromObject(schema_, references_, value)
+      return FromObject(schema_, references_, value, cache)
     case 'Promise':
       return FromPromise(schema_, references_, value)
     case 'Record':
-      return FromRecord(schema_, references_, value)
+      return FromRecord(schema_, references_, value, cache)
     case 'Ref':
-      return FromRef(schema_, references_, value)
+      return FromRef(schema_, references_, value, cache)
     case 'RegExp':
       return FromRegExp(schema_, references_, value)
     case 'String':
@@ -482,13 +484,13 @@ function Visit<T extends TSchema>(schema: T, references: TSchema[], value: any):
     case 'TemplateLiteral':
       return FromTemplateLiteral(schema_, references_, value)
     case 'This':
-      return FromThis(schema_, references_, value)
+      return FromThis(schema_, references_, value, cache)
     case 'Tuple':
-      return FromTuple(schema_, references_, value)
+      return FromTuple(schema_, references_, value, cache)
     case 'Undefined':
       return FromUndefined(schema_, references_, value)
     case 'Union':
-      return FromUnion(schema_, references_, value)
+      return FromUnion(schema_, references_, value, cache)
     case 'Uint8Array':
       return FromUint8Array(schema_, references_, value)
     case 'Unknown':
@@ -504,10 +506,13 @@ function Visit<T extends TSchema>(schema: T, references: TSchema[], value: any):
 // Check
 // --------------------------------------------------------------------------
 /** Returns true if the value matches the given type. */
-export function Check<T extends TSchema>(schema: T, references: TSchema[], value: unknown): value is Static<T>
+export function Check<T extends TSchema>(schema: T, references: TSchema[], value: unknown, cache?: WeakSet<object>): value is Static<T>
 /** Returns true if the value matches the given type. */
-export function Check<T extends TSchema>(schema: T, value: unknown): value is Static<T>
+export function Check<T extends TSchema>(schema: T, value: unknown, cache?: WeakSet<object>): value is Static<T>
 /** Returns true if the value matches the given type. */
 export function Check(...args: any[]) {
-  return args.length === 3 ? Visit(args[0], args[1], args[2]) : Visit(args[0], [], args[1])
+  if (args.length === 2 || (args.length === 3 && args[2] instanceof WeakSet)) {
+    return Visit(args[0], [], args[1], args[2] ?? new WeakSet())
+  }
+  return Visit(args[0], args[1], args[2], args[3] ?? new WeakSet())
 }

--- a/test/runtime/value/cast/recursive.ts
+++ b/test/runtime/value/cast/recursive.ts
@@ -1,90 +1,90 @@
-import { Value } from '@sinclair/typebox/value'
-import { Type } from '@sinclair/typebox'
-import { Assert } from '../../assert/index'
+import { Value } from "@sinclair/typebox/value";
+import { Type } from "@sinclair/typebox";
+import { Assert } from "../../assert/index";
 
-describe('value/cast/Recursive', () => {
+describe("value/cast/Recursive", () => {
   const T = Type.Recursive((This) =>
     Type.Object({
       id: Type.String(),
       nodes: Type.Array(This),
-    }),
-  )
-  const E = { id: '', nodes: [] }
-  it('Should upcast from string', () => {
-    const value = 'hello'
-    const result = Value.Cast(T, value)
-    Assert.IsEqual(result, E)
-  })
-  it('Should upcast from number', () => {
-    const value = E
-    const result = Value.Cast(T, value)
-    Assert.IsEqual(result, E)
-  })
-  it('Should upcast from boolean', () => {
-    const value = true
-    const result = Value.Cast(T, value)
-    Assert.IsEqual(result, E)
-  })
-  it('Should upcast from object', () => {
-    const value = {}
-    const result = Value.Cast(T, value)
-    Assert.IsEqual(result, E)
-  })
-  it('Should upcast from array', () => {
-    const value = [1]
-    const result = Value.Cast(T, value)
-    Assert.IsEqual(result, E)
-  })
-  it('Should upcast from undefined', () => {
-    const value = undefined
-    const result = Value.Cast(T, value)
-    Assert.IsEqual(result, E)
-  })
-  it('Should upcast from null', () => {
-    const value = null
-    const result = Value.Cast(T, value)
-    Assert.IsEqual(result, E)
-  })
-  it('Should upcast from date', () => {
-    const value = new Date(100)
-    const result = Value.Cast(T, value)
-    Assert.IsEqual(result, E)
-  })
-  it('Should preserve', () => {
+    })
+  );
+  const E = { id: "", nodes: [] };
+  it("Should upcast from string", () => {
+    const value = "hello";
+    const result = Value.Cast(T, value);
+    Assert.IsEqual(result, E);
+  });
+  it("Should upcast from number", () => {
+    const value = E;
+    const result = Value.Cast(T, value);
+    Assert.IsEqual(result, E);
+  });
+  it("Should upcast from boolean", () => {
+    const value = true;
+    const result = Value.Cast(T, value);
+    Assert.IsEqual(result, E);
+  });
+  it("Should upcast from object", () => {
+    const value = {};
+    const result = Value.Cast(T, value);
+    Assert.IsEqual(result, E);
+  });
+  it("Should upcast from array", () => {
+    const value = [1];
+    const result = Value.Cast(T, value);
+    Assert.IsEqual(result, E);
+  });
+  it("Should upcast from undefined", () => {
+    const value = undefined;
+    const result = Value.Cast(T, value);
+    Assert.IsEqual(result, E);
+  });
+  it("Should upcast from null", () => {
+    const value = null;
+    const result = Value.Cast(T, value);
+    Assert.IsEqual(result, E);
+  });
+  it("Should upcast from date", () => {
+    const value = new Date(100);
+    const result = Value.Cast(T, value);
+    Assert.IsEqual(result, E);
+  });
+  it("Should preserve", () => {
     const value = {
-      id: 'A',
+      id: "A",
       nodes: [
-        { id: 'B', nodes: [] },
-        { id: 'C', nodes: [] },
-        { id: 'D', nodes: [] },
+        { id: "B", nodes: [] },
+        { id: "C", nodes: [] },
+        { id: "D", nodes: [] },
       ],
-    }
-    const result = Value.Cast(T, value)
-    Assert.IsEqual(result, value)
-  })
-  it('Should upcast from varying types', () => {
+    };
+    const result = Value.Cast(T, value);
+    Assert.IsEqual(result, value);
+  });
+  it("Should upcast from varying types", () => {
     const TypeA = Type.Recursive((This) =>
       Type.Object({
         id: Type.String(),
         nodes: Type.Array(This),
-      }),
-    )
+      })
+    );
     const TypeB = Type.Recursive((This) =>
       Type.Object({
         id: Type.String(),
-        name: Type.String({ default: 'test' }),
+        name: Type.String({ default: "test" }),
         nodes: Type.Array(This),
-      }),
-    )
+      })
+    );
     const ValueA = {
-      id: 'A',
+      id: "A",
       nodes: [
-        { id: 'B', nodes: [] },
-        { id: 'C', nodes: [] },
-        { id: 'D', nodes: [] },
+        { id: "B", nodes: [] },
+        { id: "C", nodes: [] },
+        { id: "D", nodes: [] },
       ],
-    }
-    const ValueB = Value.Cast(TypeB, ValueA)
+    };
+    const ValueB = Value.Cast(TypeB, ValueA);
     // Assert.isEqual(ValueB, {
     //   id: 'A',
     //   name: 'test',
@@ -94,5 +94,228 @@ describe('value/cast/Recursive', () => {
     //     { id: 'D', name: 'test', nodes: [] },
     //   ],
     // })
-  })
-})
+  });
+
+  it("should handle simple circular structures", () => {
+    const input = {
+      a: "hello",
+    };
+
+    // @ts-expect-error
+    input.b = input;
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        a: Type.String(),
+        b: This,
+      })
+    );
+
+    const result = Value.Cast(schema, input);
+
+    Assert.IsEqual(result, input);
+  });
+
+  it("should handle type coercion in circular structures #1", () => {
+    const input = {
+      id: 1,
+      nodes: [],
+    };
+
+    // @ts-expect-error
+    input.nodes = [input];
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        id: Type.String(),
+        nodes: Type.Array(This),
+      })
+    );
+
+    const result = Value.Cast(schema, input);
+
+    const output = {
+      id: "",
+      nodes: [],
+    };
+
+    // @ts-expect-error
+    output.nodes = [output];
+
+    Assert.IsEqual(result, output);
+  });
+
+  it("should handle type coercion in circular structures #2", () => {
+    const input = {
+      value: 42, // number should be cast to string
+      next: null,
+    };
+
+    // @ts-expect-error
+    input.next = input;
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        value: Type.String(),
+        next: Type.Union([This, Type.Null()]),
+      })
+    );
+
+    const result = Value.Cast(schema, input);
+
+    Assert.IsEqual(result.value, "");
+    Assert.IsEqual(result.next, result);
+  });
+
+  it("should handle deeply nested circular structures", () => {
+    const input = {
+      id: "root",
+      child: {
+        id: "child",
+        parent: null,
+      },
+    };
+
+    // Create circular reference
+    // @ts-expect-error
+    input.child.parent = input;
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        id: Type.String(),
+        child: Type.Object({
+          id: Type.String(),
+          parent: Type.Union([This, Type.Null()]),
+        }),
+      })
+    );
+
+    const result = Value.Cast(schema, input);
+
+    Assert.IsEqual(result.id, "root");
+    Assert.IsEqual(result.child.id, "child");
+    Assert.IsEqual(result.child.parent, result);
+  });
+
+  it("should handle circular array with multiple references", () => {
+    const node1 = { id: "node1", refs: [] };
+    const node2 = { id: "node2", refs: [] };
+
+    // @ts-expect-error
+    node1.refs = [node2, node1];
+    // @ts-expect-error
+    node2.refs = [node1];
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        id: Type.String(),
+        refs: Type.Array(This),
+      })
+    );
+
+    const result = Value.Cast(schema, node1);
+
+    Assert.IsEqual(result.id, "node1");
+    Assert.IsEqual(result.refs.length, 2);
+    Assert.IsEqual(result.refs[0].id, "node2");
+    Assert.IsEqual(result.refs[1], result);
+    Assert.IsEqual(result.refs[0].refs[0], result);
+  });
+
+  it("should handle optional properties in circular structures", () => {
+    const input = {
+      id: "test",
+      parent: undefined,
+    };
+
+    // @ts-expect-error
+    input.parent = input;
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        id: Type.String(),
+        parent: Type.Optional(This),
+        metadata: Type.Optional(Type.String()),
+      })
+    );
+
+    const result = Value.Cast(schema, input);
+
+    Assert.IsEqual(result.id, "test");
+    Assert.IsEqual(result.parent, result);
+    Assert.IsEqual(result.metadata, undefined);
+  });
+
+  it("should handle mixed circular and non-circular references", () => {
+    const leaf = { id: "leaf", children: [] };
+    const branch = { id: "branch", children: [leaf] };
+    const root = { id: "root", children: [branch] };
+
+    // Add circular reference
+    // @ts-expect-error
+    branch.children.push(root);
+
+    const schema = Type.Recursive((This) =>
+      Type.Object({
+        id: Type.String(),
+        children: Type.Array(This),
+      })
+    );
+
+    const result = Value.Cast(schema, root);
+
+    Assert.IsEqual(result.id, "root");
+    Assert.IsEqual(result.children.length, 1);
+    Assert.IsEqual(result.children[0].id, "branch");
+    Assert.IsEqual(result.children[0].children.length, 2);
+    Assert.IsEqual(result.children[0].children[0].id, "leaf");
+    Assert.IsEqual(result.children[0].children[1], result);
+  });
+
+  it("should handle circular references with union types", () => {
+    const textNode = {
+      type: "text",
+      content: "Hello",
+      parent: null,
+    };
+
+    const containerNode = {
+      type: "container",
+      children: [textNode],
+      parent: null,
+    };
+
+    // @ts-expect-error
+    textNode.parent = containerNode;
+    // @ts-expect-error
+    containerNode.parent = containerNode; // self-reference
+
+    const schema = Type.Recursive((This) =>
+      Type.Union([
+        Type.Object({
+          type: Type.Literal("text"),
+          content: Type.String(),
+          parent: Type.Union([This, Type.Null()]),
+        }),
+        Type.Object({
+          type: Type.Literal("container"),
+          children: Type.Array(This),
+          parent: Type.Union([This, Type.Null()]),
+        }),
+      ])
+    );
+
+    const result = Value.Cast(schema, containerNode);
+
+    Assert.IsEqual(result.type, "container");
+    // @ts-expect-error - TypeScript can't infer the union type here
+    Assert.IsEqual(result.children.length, 1);
+    // @ts-expect-error
+    Assert.IsEqual(result.children[0].type, "text");
+    // @ts-expect-error
+    Assert.IsEqual(result.children[0].content, "Hello");
+    // @ts-expect-error
+    Assert.IsEqual(result.children[0].parent, result);
+    Assert.IsEqual(result.parent, result);
+  });
+});

--- a/test/runtime/value/check/recursive.ts
+++ b/test/runtime/value/check/recursive.ts
@@ -95,4 +95,24 @@ describe('value/check/Recursive', () => {
     const result = Value.Check(T, value)
     Assert.IsEqual(result, false)
   })
+
+  it('should not break when checking a circular structure #3', () => {
+    const value = {
+      a: '',
+    }
+
+    // @ts-expect-error
+    value.b = value
+
+    const T = Type.Recursive((This) =>
+      Type.Object({
+        a: Type.String(),
+        b: This,
+      }),
+    )
+
+    const result = Value.Check(T, value)
+
+    Assert.IsEqual(result, true)
+  })
 })

--- a/test/runtime/value/check/recursive.ts
+++ b/test/runtime/value/check/recursive.ts
@@ -66,4 +66,33 @@ describe('value/check/Recursive', () => {
     const result = Value.Check(T, value)
     Assert.IsEqual(result, false)
   })
+
+  // ------------------------------------------------------------------------
+  // ref: https://github.com/sinclairzx81/typebox/issues/1302
+  // ------------------------------------------------------------------------
+  it('should not break when checking a circular structure #1', () => {
+    const value = {
+      id: '1',
+      nodes: [],
+    }
+
+    // @ts-expect-error
+    value.nodes[0] = value
+
+    const result = Value.Check(T, value)
+    Assert.IsEqual(result, true)
+  })
+
+  it('should not break when checking a circular structure #2', () => {
+    const value = {
+      id: 1,
+      nodes: [],
+    }
+
+    // @ts-expect-error
+    value.nodes[0] = value
+
+    const result = Value.Check(T, value)
+    Assert.IsEqual(result, false)
+  })
 })

--- a/test/runtime/value/clone/clone.ts
+++ b/test/runtime/value/clone/clone.ts
@@ -153,4 +153,101 @@ describe('value/clone/Clone', () => {
     const R = Value.Clone(V)
     Assert.IsEqual(R, V)
   })
+  // ------------------------------------------------------------------------
+  // ref: https://github.com/sinclairzx81/typebox/issues/1300
+  // ------------------------------------------------------------------------
+  it('Should handle circular references #1', () => {
+    const V = { a: 1, b: { c: 2 } } as any
+    V.b.d = V.b
+    const R = Value.Clone(V)
+    Assert.IsEqual(R, V)
+  })
+  it('Should handle circular references #2', () => {
+    const V = { a: {}, b: {} } as any
+    V.a.c = V.b
+    V.b.d = V.a
+    const R = Value.Clone(V)
+    console.log(R)
+    Assert.IsEqual(R, V)
+  })
+  it('Should handle indirect circular references #1', () => {
+    // Create a chain: A -> B -> C -> A
+    const A = { name: 'A' } as any
+    const B = { name: 'B' } as any
+    const C = { name: 'C' } as any
+
+    A.next = B
+    B.next = C
+    C.next = A // Circular reference through chain
+
+    const R = Value.Clone(A)
+    Assert.IsEqual(R.name, 'A')
+    Assert.IsEqual(R.next.name, 'B')
+    Assert.IsEqual(R.next.next.name, 'C')
+    Assert.IsEqual(R.next.next.next, R) // Should reference back to root
+  })
+  it('Should handle indirect circular references #2', () => {
+    // Create a more complex structure with multiple indirect references
+    const root = {
+      data: { value: 1 },
+      children: [],
+      metadata: {},
+    } as any
+
+    const child1 = {
+      id: 1,
+      parent: root,
+      siblings: [],
+    } as any
+
+    const child2 = {
+      id: 2,
+      parent: root,
+      siblings: [],
+    } as any
+
+    // Set up the circular references
+    root.children = [child1, child2]
+    child1.siblings = [child2]
+    child2.siblings = [child1]
+    root.metadata.firstChild = child1
+
+    const R = Value.Clone(root)
+
+    // Verify structure integrity
+    Assert.IsEqual(R.data.value, 1)
+    Assert.IsEqual(R.children.length, 2)
+    Assert.IsEqual(R.children[0].id, 1)
+    Assert.IsEqual(R.children[1].id, 2)
+
+    // Verify circular references are maintained
+    Assert.IsEqual(R.children[0].parent, R)
+    Assert.IsEqual(R.children[1].parent, R)
+    Assert.IsEqual(R.children[0].siblings[0], R.children[1])
+    Assert.IsEqual(R.children[1].siblings[0], R.children[0])
+    Assert.IsEqual(R.metadata.firstChild, R.children[0])
+  })
+  it('Should handle deep indirect circular references', () => {
+    // Create a deeply nested structure with circular reference at the end
+    const V = {
+      level1: {
+        level2: {
+          level3: {
+            level4: {
+              level5: {},
+            },
+          },
+        },
+      },
+    } as any
+
+    // Create circular reference from deep level back to root
+    V.level1.level2.level3.level4.level5.backToRoot = V
+    V.level1.level2.level3.level4.level5.backToLevel2 = V.level1.level2
+
+    const R = Value.Clone(V)
+
+    // Verify the structure and circular references
+    Assert.IsEqual(R, V)
+  })
 })


### PR DESCRIPTION
The current `Cast` function does not handle recursive (circular) structures. When an object references itself, the function runs into infinite recursion and throws a Maximum call stack size exceeded error.

See issue: https://github.com/sinclairzx81/typebox/issues/1304

```ts
const value = {
  id: "1",
  nodes: [],
};

// @ts-expect-error
value.nodes[0] = value;

Value.Cast(T, value); // ❌ Callstack error
```

This PR adds support for checking recursive structures by detecting and handling circular references. Objects that reference themselves (directly or indirectly) can now be casted safely without causing stack overflows.