### PR TITLE
Revision 0.34.41

### DIFF
--- a/changelog/0.34.0.md
+++ b/changelog/0.34.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Revision Updates
+- [Revision 0.34.41](https://github.com/sinclairzx81/typebox/pull/1310)
+  - Disable Node10 Module Resolution | TS7 Deprecation Warning.
 - [Revision 0.34.40](https://github.com/sinclairzx81/typebox/pull/1293)
   - Use Uniform over Reciprocal weighting on Cast Union Select
 - [Revision 0.34.39](https://github.com/sinclairzx81/typebox/pull/1296)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.40",
+  "version": "0.34.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/typebox",
-      "version": "0.34.40",
+      "version": "0.34.41",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/typebox",
-  "version": "0.34.40",
+  "version": "0.34.41",
   "description": "Json Schema Type Builder with Static Type Resolution for TypeScript",
   "keywords": [
     "typescript",

--- a/task/build/cjs/compile.ts
+++ b/task/build/cjs/compile.ts
@@ -33,7 +33,8 @@ export async function compile(target: string) {
   const options = [
     `--outDir ${target}`,
     '--target ES2020',
-    '--module CommonJS',
+    '--module Node16',
+    '--moduleResolution Node16',
     '--declaration',
   ].join(' ')
   await shell(`tsc -p ./src/tsconfig.json ${options}`)

--- a/task/build/esm/compile.ts
+++ b/task/build/esm/compile.ts
@@ -34,6 +34,7 @@ export async function compile(target: string) {
     `--outDir ${target}`,
     '--target ES2020',
     '--module ESNext',
+    '--moduleResolution Bundler',
     '--declaration',
   ].join(' ')
   await shell(`tsc -p ./src/tsconfig.json ${options}`)

--- a/task/build/package/create-package-json-redirect.ts
+++ b/task/build/package/create-package-json-redirect.ts
@@ -38,7 +38,7 @@ function writeRedirect(target: string, submodule: string) {
 }
 // --------------------------------------------------------------------------------------------------------------------------
 // Builds redirect directories for earlier versions of Node. Note that TypeScript will use these directories to
-// resolve types when tsconfig.json is configured for `moduleResolution: 'node'`. This approach is referred to as
+// resolve types when tsconfig.json is configured for `moduleResolution: 'Node16'`. This approach is referred to as
 // `package-json-redirect` and enables correct type resolution in lieu of a correct end user configuration.
 //
 // https://github.com/andrewbranch/example-subpath-exports-ts-compat/tree/main/examples/node_modules/package-json-redirects

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "strict": true,
     "target": "ES2020",
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "baseUrl": ".",
     "paths": {
       "@sinclair/typebox/compiler": ["src/compiler/index.ts"],


### PR DESCRIPTION
This PR fixes a deprecation error / warning on TS nightly relating to Node10 resolution. Node10 resolution will be deprecated in TS7 so we need to drop configuration settings for it. This PR updates CJS and ESM configurations for the following build profiles.

ESM
```
--target ES2020
--module ESNext
--moduleResolution Bundler
```

CJS

```
--target ES2020
--module Node16
--moduleResolution Node16
```

---

Bundler ESM seems to be fine for TS type resolution. Node also seems fine running against `.js` and `.mjs` entry points. Node10 is still technically supported according to ATTW using the package-redirection strategy, but will need to keep an eye out for any problems should they arise.