### PR TITLE
Version 1.0.7

### DIFF
--- a/changelog/1.0.0.md
+++ b/changelog/1.0.0.md
@@ -4,6 +4,8 @@
 
 ### Version Updates
 
+- [Revision 1.0.7](https://github.com/sinclairzx81/typebox/pull/1331)
+  - Optimize Codecs for Compiled Validators
 - [Revision 1.0.6](https://github.com/sinclairzx81/typebox/pull/1330)
   - Encode Pipeline | Clone | Class Instance Detection
 - [Revision 1.0.5](https://github.com/sinclairzx81/typebox/pull/1327)

--- a/src/compile/validator.ts
+++ b/src/compile/validator.ts
@@ -31,7 +31,7 @@ THE SOFTWARE.
 import { Environment } from '../system/environment/index.ts'
 import { type TLocalizedValidationError } from '../error/index.ts'
 import { type StaticDecode, type StaticEncode, type TProperties, type TSchema, Base } from '../type/index.ts'
-import { Errors, Clean, Convert, Create, Default, Parser, Decode, Encode } from '../value/index.ts'
+import { Errors, Clean, Convert, Create, Default, Decode, Encode, HasCodec, Parser } from '../value/index.ts'
 import { Build } from '../schema/index.ts'
 
 // ------------------------------------------------------------------
@@ -39,6 +39,7 @@ import { Build } from '../schema/index.ts'
 // ------------------------------------------------------------------
 export class Validator<Context extends TProperties = TProperties, Type extends TSchema = TSchema> extends Base<StaticEncode<Type, Context>> {
   private readonly isEvaluated: boolean
+  private readonly hasCodec: boolean
   private readonly code: string
   private readonly check: (value: unknown) => boolean
   constructor(
@@ -47,6 +48,7 @@ export class Validator<Context extends TProperties = TProperties, Type extends T
   ) {
     super()
     const result = Build(context, type).Evaluate()
+    this.hasCodec = HasCodec(context, type)
     this.isEvaluated = result.IsEvaluated
     this.code = result.Code
     this.check = result.Check as never
@@ -79,39 +81,47 @@ export class Validator<Context extends TProperties = TProperties, Type extends T
   // ----------------------------------------------------------------
   // Base<...>
   // ----------------------------------------------------------------
+  /** Checks a value matches the Validator type. */
   public override Check(value: unknown): value is StaticEncode<Type, Context> {
     return this.check(value)
   }
+  /** Returns errors for the given value. */
   public override Errors(value: unknown): TLocalizedValidationError[] {
     if (Environment.CanEvaluate() && this.check(value)) return []
     return Errors(this.context, this.type, value)
   }
+  /** Cleans a value using the Validator type. */
   public override Clean(value: unknown): unknown {
     return Clean(this.context, this.type, value)
   }
+  /** Converts a value using the Validator type. */
   public override Convert(value: unknown): unknown {
     return Convert(this.context, this.type, value)
   }
+  /** Creates a value using the Validator type. */
   public override Create(): StaticEncode<Type, Context> {
     return Create(this.context, this.type)
   }
+  /** Creates defaults using the Validator type. */
   public override Default(value: unknown): unknown {
     return Default(this.context, this.type, value)
   }
   // ----------------------------------------------------------------
-  // Parse
+  // Parse | Decode | Encode
   // ----------------------------------------------------------------
-  /** Parses a value of this type */
+  /** Parses a value */
   public Parse(value: unknown): StaticDecode<Type, Context> {
     const result = this.Check(value) ? value : Parser(this.context, this.type, value)
     return result as never
   }
-  /** Decodes a value of this type */
+  /** Decodes a value */
   public Decode(value: unknown): StaticDecode<Type, Context> {
-    return Decode(this.context, this.type, value)
+    const result = this.hasCodec ? Decode(this.context, this.type, value) : this.Parse(value)
+    return result as never
   }
-  /** Encodes a value of this type */
+  /** Encodes a value */
   public Encode(value: unknown): StaticEncode<Type, Context> {
-    return Encode(this.context, this.type, value)
+    const result = this.hasCodec ? Encode(this.context, this.type, value) : this.Parse(value)
+    return result as never
   }
 }

--- a/src/type/engine/conditional/instantiate.ts
+++ b/src/type/engine/conditional/instantiate.ts
@@ -46,7 +46,7 @@ type TConditionalImmediate<Context extends TProperties, State extends TState, Le
 > = (
   ExtendsResult extends ExtendsResult.TExtendsUnion<infer InferredContext extends TProperties> ? TUnion<[TInstantiateType<InferredContext, State, True>, TInstantiateType<Context, State,False>]> :
   ExtendsResult extends ExtendsResult.TExtendsTrue<infer InferredContext extends TProperties> ? TInstantiateType<InferredContext, State, True> :
-  TInstantiateType<Context, State,False>
+  TInstantiateType<Context, State, False>
 )
 function ConditionalImmediate<Context extends TProperties, State extends TState, Left extends TSchema, Right extends TSchema, True extends TSchema, False extends TSchema>
   (context: Context, state: State, left: Left, right: Right, true_: True, false_: False, options: TSchemaOptions): 

--- a/src/value/check/check.ts
+++ b/src/value/check/check.ts
@@ -32,17 +32,17 @@ import { Arguments } from '../../system/arguments/index.ts'
 import type { Static, TProperties, TSchema } from '../../type/index.ts'
 import { Check as SchemaCheck } from '../../schema/index.ts'
 
-/** Checks a value matches the provided type. This function returns a TypeScript type predicate and does not throw. */
+/** Checks a value matches the provided type. */
 export function Check<const Type extends TSchema, 
   Result extends unknown = Static<Type>
 >(type: Type, value: unknown): value is Result
 
-/** Checks a value matches the provided type. This function returns a TypeScript type predicate and does not throw. */
+/** Checks a value matches the provided type. */
 export function Check<Context extends TProperties, const Type extends TSchema, 
   Result extends unknown = Static<Type, Context>
 >(context: Context, type: Type, value: unknown): value is Result
 
-/** Checks a value matches the provided type. This function returns a TypeScript type predicate and does not throw. */
+/** Checks a value matches the provided type. */
 export function Check(...args: unknown[]): unknown {
   const [context, type, value] = Arguments.Match<[TProperties, TSchema, unknown]>(args, {
     3: (context, type, value) => [context, type, value],

--- a/src/value/codec/has.ts
+++ b/src/value/codec/has.ts
@@ -78,6 +78,8 @@ function FromRecord(context: TProperties, type: TRecord): boolean {
 // Ref
 // ------------------------------------------------------------------
 function FromRef(context: TProperties, type: TRef): boolean {
+  if(visited.has(type.$ref)) return false
+  visited.add(type.$ref)
   return IsCodec(type) || (Guard.HasPropertyKey(context, type.$ref) 
     && FromType(context, context[type.$ref]))
 }
@@ -110,6 +112,11 @@ function FromType(context: TProperties, type: TSchema): boolean {
   )
 }
 // ------------------------------------------------------------------
+// Visited
+// ------------------------------------------------------------------
+const visited = new Set<string>()
+
+// ------------------------------------------------------------------
 // HasCodec
 // ------------------------------------------------------------------
 /** Returns true if this type contains a Codec */
@@ -122,5 +129,6 @@ export function HasCodec(...args: unknown[]): boolean {
     2: (context, type) => [context, type],
     1: (type) => [{}, type]
   })
+  visited.clear()
   return FromType(context, type)
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -8,7 +8,7 @@ import { Range } from './task/range/index.ts'
 import { Metrics } from './task/metrics/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.0.6'
+const Version = '1.0.7'
 
 // ------------------------------------------------------------------
 // BuildPackage

--- a/test/typebox/runtime/value/codec/cyclic.ts
+++ b/test/typebox/runtime/value/codec/cyclic.ts
@@ -6,8 +6,6 @@ import { Assert } from 'test'
 
 const Test = Assert.Context('Value.Codec.Cyclic')
 
-
-
 Test('Should Cyclic 1', () => {
   const StringToNumber = Type.Codec(Type.String())
     .Decode(value => parseInt(value))

--- a/test/typebox/runtime/value/codec/~has.ts
+++ b/test/typebox/runtime/value/codec/~has.ts
@@ -65,3 +65,25 @@ Test('Should Has 10', () => {
     .Encode(value => value)
   Assert.IsTrue(Value.HasCodec(T))
 })
+// ------------------------------------------------------------------
+// Cyclics
+// ------------------------------------------------------------------
+Test('Should Has 11', () => {
+  const C = Type.Codec(Type.Null()).Decode(value => value).Encode(value => value)
+  const T = Type.Cyclic({
+    A: Type.Object({
+      value: C,
+      nodes: Type.Array(Type.Ref('A'))
+    })
+  }, 'A')
+  Assert.IsTrue(Value.HasCodec(T))
+})
+Test('Should Has 12', () => {
+  const C = Type.Codec(Type.Array(Type.Ref('A'))).Decode(value => value).Encode(value => value)
+  const T = Type.Cyclic({
+    A: Type.Object({
+      nodes: C
+    })
+  }, 'A')
+  Assert.IsTrue(Value.HasCodec(T))
+})


### PR DESCRIPTION
This PR implements an optimization for Encode | Decode for compiled Validator. The optimization works by checking if a type contains a codec at the time of compilation. The result of this check is cached per Validator instance and inspected on calls to Decode and Encode. If the cache field `hasCodec` is false, calls to Decode and Encode will fall back to Parse. 