### PR TITLE
Version 1.0.8

### DIFF
--- a/changelog/1.0.0.md
+++ b/changelog/1.0.0.md
@@ -4,6 +4,8 @@
 
 ### Version Updates
 
+- [Revision 1.0.8](https://github.com/sinclairzx81/typebox/pull/1334)
+  - Export StaticDecode, StaticEncode and StaticParse as Defaults
 - [Revision 1.0.7](https://github.com/sinclairzx81/typebox/pull/1331)
   - Optimize Codecs for Compiled Validators
 - [Revision 1.0.6](https://github.com/sinclairzx81/typebox/pull/1330)

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -109,7 +109,7 @@ export { IsRecord, Record, RecordKey, RecordPattern as RecordKeyAsPattern, Recor
 export { IsRef, Ref, type TRef } from './type/types/ref.ts'
 export { IsRest, Rest, type TRest } from './type/types/rest.ts'
 export { IsKind, IsSchema, type TArrayOptions, type TFormat, type TIntersectOptions, type TNumberOptions, type TObjectOptions, type TSchema, type TSchemaOptions, type TStringOptions, type TTupleOptions } from './type/types/schema.ts'
-export { type Static } from './type/types/static.ts'
+export { type Static, type StaticDecode, type StaticEncode, type StaticParse } from './type/types/static.ts'
 export { IsString, String, type TString } from './type/types/string.ts'
 export { IsSymbol, Symbol, type TSymbol } from './type/types/symbol.ts'
 export { IsTemplateLiteral, TemplateLiteral, type TTemplateLiteral } from './type/types/template-literal.ts'

--- a/tasks.ts
+++ b/tasks.ts
@@ -8,7 +8,7 @@ import { Range } from './task/range/index.ts'
 import { Metrics } from './task/metrics/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.0.7'
+const Version = '1.0.8'
 
 // ------------------------------------------------------------------
 // BuildPackage


### PR DESCRIPTION
This PR exports the StaticDecode, StaticEncode and StaticParse infer types as Default exports. This in support of the following usage pattern.

```typescript
import Type from 'typebox'

const A = Type.String()

type A = Type.Static<typeof A>
```
