### PR TITLE
Version 1.0.10

### DIFF
--- a/changelog/1.0.0.md
+++ b/changelog/1.0.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.0.10](https://github.com/sinclairzx81/typebox/pull/1340)
+  - Exclude Property Conversion for Optional Properties with Undefined Values.
 - [Revision 1.0.9](https://github.com/sinclairzx81/typebox/pull/1337)
   - Support ExactOptionalPropertyTypes Semantics
 - [Revision 1.0.8](https://github.com/sinclairzx81/typebox/pull/1334)

--- a/tasks.ts
+++ b/tasks.ts
@@ -8,7 +8,7 @@ import { Range } from './task/range/index.ts'
 import { Metrics } from './task/metrics/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.0.9'
+const Version = '1.0.10'
 
 // ------------------------------------------------------------------
 // BuildPackage

--- a/test/typebox/runtime/value/codec/object.ts
+++ b/test/typebox/runtime/value/codec/object.ts
@@ -132,7 +132,6 @@ Test('Should Object 8', () => {
   Assert.IsEqual(E, { })
 })
 // ------------------------------------------------------------------
-//
 // IsOptionalUndefined (Convert)
 //
 // https://github.com/sinclairzx81/typebox/issues/1336#issuecomment-3312847006

--- a/test/typebox/runtime/value/codec/object.ts
+++ b/test/typebox/runtime/value/codec/object.ts
@@ -1,5 +1,6 @@
 // deno-fmt-ignore-file
 
+import { Settings } from 'typebox/system'
 import { Value } from 'typebox/value'
 import { Type } from 'typebox'
 import { Assert } from 'test'
@@ -129,4 +130,32 @@ Test('Should Object 8', () => {
   const E = Value.Encode(T, {})
   Assert.IsEqual(D, { })
   Assert.IsEqual(E, { })
+})
+// ------------------------------------------------------------------
+//
+// IsOptionalUndefined (Convert)
+//
+// https://github.com/sinclairzx81/typebox/issues/1336#issuecomment-3312847006
+// ------------------------------------------------------------------
+Test('Should Object 9', () => {
+  const X = Type.Optional(Type.String({ pattern: /^[a-f]+$/ }))
+  const T = Type.Object({ x: X })
+
+  const A = Value.Encode(T, { x: "abcdef" })
+  const B = Value.Encode(T, { x: undefined })
+
+  Assert.IsEqual(A, { x: "abcdef" })
+  Assert.IsEqual(B, { x: undefined })
+})
+Test('Should Object 10', () => {
+  Settings.Set({ exactOptionalPropertyTypes: true })
+  const X = Type.Optional(Type.String({ pattern: /^[a-f]+$/ }))
+  const T = Type.Object({ x: X })
+
+  const A = Value.Encode(T, { x: "abcdef" })
+  Assert.Throws(() => Value.Encode(T, { x: undefined }))
+
+  Assert.IsEqual(A, { x: "abcdef" })
+
+  Settings.Reset()
 })

--- a/test/typebox/runtime/value/convert/object.ts
+++ b/test/typebox/runtime/value/convert/object.ts
@@ -33,3 +33,24 @@ Test('Should Convert 4', () => {
   const R = Value.Convert(T, { x: '1', y: 0 })
   Assert.IsEqual(R, { x: 1, y: null })
 })
+// ------------------------------------------------------------------
+// IsOptionalUndefined
+//
+// https://github.com/sinclairzx81/typebox/issues/1336#issuecomment-3312808962 
+//
+// ------------------------------------------------------------------
+Test('Should Convert 5', () => {
+  const T = Type.Object({ x: Type.Optional(Type.Number()) })
+  const R = Value.Convert(T, { x: 1 })
+  Assert.IsEqual(R, { x: 1 })
+})
+Test('Should Convert 6', () => {
+  const T = Type.Object({ x: Type.Optional(Type.Number()) })
+  const R = Value.Convert(T, { x: '1' })
+  Assert.IsEqual(R, { x: 1 })
+})
+Test('Should Convert 7', () => {
+  const T = Type.Object({ x: Type.Optional(Type.Number()) })
+  const R = Value.Convert(T, { x: undefined })
+  Assert.IsEqual(R, { x: undefined })
+})

--- a/test/typebox/runtime/value/convert/object.ts
+++ b/test/typebox/runtime/value/convert/object.ts
@@ -37,7 +37,6 @@ Test('Should Convert 4', () => {
 // IsOptionalUndefined
 //
 // https://github.com/sinclairzx81/typebox/issues/1336#issuecomment-3312808962 
-//
 // ------------------------------------------------------------------
 Test('Should Convert 5', () => {
   const T = Type.Object({ x: Type.Optional(Type.Number()) })


### PR DESCRIPTION
This PR applies a fix for Optional Property Encoding. The fix is internally applied to the Convert module where properties types that are Optional but receive `undefined` are skipped due to ambiguous conversion. This is because `undefined` values can also be observed as optional (i.e. a missing key). 

As per comment.

```typescript
// ------------------------------------------------------------------
// IsOptionalUndefined
//
// Determines whether a property should be excluded from conversion
// because it is both optional and has an undefined value. This case
// cannot be safely converted, since it introduces ambiguity between
// an omitted optional property and a property explicitly set to the
// value undefined.
// ------------------------------------------------------------------
function IsOptionalUndefined(property: TSchema, key: PropertyKey, value: Record<PropertyKey, unknown>) {
  return IsOptional(property) && Guard.IsUndefined(value[key])
}
```

