### PR TITLE
Declare the cause field on AssertError instances

### DIFF
--- a/src/value/assert/assert.ts
+++ b/src/value/assert/assert.ts
@@ -35,6 +35,7 @@ import { Errors } from '../errors/index.ts'
 // AssertError
 // ------------------------------------------------------------------
 export class AssertError extends Error {
+  declare readonly cause: { source: string, errors: object[], value: unknown };
   constructor(source: string, value: unknown, errors: object[]) {
     super(source)
     Object.defineProperty(this, 'cause', {


### PR DESCRIPTION
This makes it cleaner to extract the errors field from the exception.