### PR TITLE
Version 1.0.14

### DIFF
--- a/changelog/1.0.0.md
+++ b/changelog/1.0.0.md
@@ -4,7 +4,7 @@
 
 ### Version Updates
 - [Revision 1.0.14](https://github.com/sinclairzx81/typebox/pull/1349)
-  - Support Readonly String Array on Enum Constructor.
+  - Support Readonly Value Array on Enum Constructor.
 - [Revision 1.0.13](https://github.com/sinclairzx81/typebox/pull/1348)
   - Support Require(ESM) package resolution for Node 20+.
 - [Revision 1.0.12](https://github.com/sinclairzx81/typebox/pull/1347)

--- a/changelog/1.0.0.md
+++ b/changelog/1.0.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.0.14](https://github.com/sinclairzx81/typebox/pull/1349)
+  - Support Readonly String Array on Enum Constructor.
 - [Revision 1.0.13](https://github.com/sinclairzx81/typebox/pull/1348)
   - Support Require(ESM) package resolution for Node 20+.
 - [Revision 1.0.12](https://github.com/sinclairzx81/typebox/pull/1347)

--- a/src/type/engine/enum/typescript-enum-to-enum-values.ts
+++ b/src/type/engine/enum/typescript-enum-to-enum-values.ts
@@ -32,12 +32,18 @@ import { Guard } from '../../../guard/index.ts'
 import { type TEnumValue } from '../../types/enum.ts'
 import { type TUnionToTuple } from '../helpers/union.ts'
 
-export type TTSEnumLike = Record<PropertyKey, TEnumValue>
+// ------------------------------------------------------------------
+// TypeScriptEnumDeclaration
+// ------------------------------------------------------------------
+export type TTypeScriptEnumLike = Record<PropertyKey, TEnumValue>
 
+export function IsTypeScriptEnumLike(value: unknown): value is TTypeScriptEnumLike {
+  return Guard.IsObjectNotArray(value)
+}
 // ------------------------------------------------------------------
 // ReduceValues
 // ------------------------------------------------------------------
-type TReduceEnumValues<Keys extends string[], Type extends TTSEnumLike, Result extends TEnumValue[] = []> = (
+type TReduceEnumValues<Keys extends string[], Type extends TTypeScriptEnumLike, Result extends TEnumValue[] = []> = (
   Keys extends [infer Left extends string, ...infer Right extends string[]]
     ? TReduceEnumValues<Right, Type, [...Result, Type[Left]]>
     : Result
@@ -45,11 +51,11 @@ type TReduceEnumValues<Keys extends string[], Type extends TTSEnumLike, Result e
 // ------------------------------------------------------------------
 // TypeScriptEnumToEnumValues
 // ------------------------------------------------------------------
-export type TTSEnumToEnumValues<Type extends TTSEnumLike,
+export type TTypeScriptEnumToEnumValues<Type extends TTypeScriptEnumLike,
   EnumKeys extends string[] = TUnionToTuple<Extract<keyof Type, string>>,
   Elements extends TEnumValue[] = TReduceEnumValues<EnumKeys, Type>
 > = Elements
-export function TSEnumToEnumValues<Type extends TTSEnumLike>(type: Type): TTSEnumToEnumValues<Type> {
+export function TypeScriptEnumToEnumValues<Type extends TTypeScriptEnumLike>(type: Type): TTypeScriptEnumToEnumValues<Type> {
   const keys = Guard.Keys(type).filter((key) => isNaN(key as never))
   return keys.reduce((result, key) => [...result, type[key]], [] as TEnumValue[]) as never
 }

--- a/src/type/types/enum.ts
+++ b/src/type/types/enum.ts
@@ -29,9 +29,9 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import { Memory } from '../../system/memory/index.ts'
-import { Guard } from '../../guard/index.ts'
 import { type TSchema, type TSchemaOptions, IsKind } from './schema.ts'
-import { type TTSEnumToEnumValues, type TTSEnumLike, TSEnumToEnumValues } from '../engine/enum/typescript-enum-to-enum-values.ts'
+import { type TTypeScriptEnumLike, IsTypeScriptEnumLike } from '../engine/enum/typescript-enum-to-enum-values.ts'
+import { type TTypeScriptEnumToEnumValues, TypeScriptEnumToEnumValues } from '../engine/enum/typescript-enum-to-enum-values.ts'
 
 // ------------------------------------------------------------------
 // Static
@@ -53,12 +53,12 @@ export interface TEnum<Values extends TEnumValue[] = TEnumValue[]> extends TSche
 // Factory
 // ------------------------------------------------------------------
 /** Creates an Enum type. */
-export function Enum<Enum extends TTSEnumLike>(value: Enum, options?: TSchemaOptions): TEnum<TTSEnumToEnumValues<Enum>> 
+export function Enum<Values extends TEnumValue[]>(values: readonly [...Values], options?: TSchemaOptions): TEnum<Values> 
+/** Creates an Enum type from a TypeScript enum declaration. */
+export function Enum<Enum extends TTypeScriptEnumLike>(value: Enum, options?: TSchemaOptions): TEnum<TTypeScriptEnumToEnumValues<Enum>> 
 /** Creates an Enum type. */
-export function Enum<Values extends TEnumValue[]>(values: [...Values], options?: TSchemaOptions): TEnum<Values> 
-/** Creates an Enum type. */
-export function Enum(value: TEnumValue[] | TTSEnumLike, options?: TSchemaOptions): never {
-  const values = Guard.IsArray(value) ? value : TSEnumToEnumValues(value)
+export function Enum(value: readonly TEnumValue[] | TTypeScriptEnumLike, options?: TSchemaOptions): never {
+  const values = IsTypeScriptEnumLike(value) ? TypeScriptEnumToEnumValues(value) : value
   return Memory.Create({ '~kind': 'Enum' }, { enum: values }, options) as never
 }
 // ------------------------------------------------------------------

--- a/src/type/types/record.ts
+++ b/src/type/types/record.ts
@@ -36,6 +36,7 @@ import { type StaticType, type StaticDirection } from './static.ts'
 import { type TProperties } from './properties.ts'
 import { type TInteger, Integer, IntegerPattern } from './integer.ts'
 
+import { type TTemplateLiteral } from './template-literal.ts'
 import { type TNumber, Number, NumberPattern } from './number.ts'
 import { type TString, String, StringPattern } from './string.ts'
 
@@ -52,7 +53,7 @@ export type StaticRecord<Direction extends StaticDirection, Context extends TPro
     Key extends TStringKey ? Record<string, StaticValue> :
     Key extends TIntegerKey ? Record<number, StaticValue> :
     Key extends TNumberKey ? Record<number, StaticValue> :
-    Record<PropertyKey, StaticValue>
+    Record<string, StaticValue>
   )
 > = Result
 // -------------------------------------------------------------------

--- a/tasks.ts
+++ b/tasks.ts
@@ -8,7 +8,7 @@ import { Range } from './task/range/index.ts'
 import { Metrics } from './task/metrics/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.0.13'
+const Version = '1.0.14'
 
 // ------------------------------------------------------------------
 // BuildPackage

--- a/test/common/assert.ts
+++ b/test/common/assert.ts
@@ -74,7 +74,8 @@ export function IsExtends<Left extends unknown, Right extends unknown>(_expect: 
 // ------------------------------------------------------------------
 // IsExtendsMutual
 // ------------------------------------------------------------------
-type TExtendsMutualExpect<Left extends unknown, Right extends unknown> = Left extends Right ? Right extends Left ? true : false : false
+type TExtendsMutualExpect<Left extends unknown, Right extends unknown> = (<T>() => T extends Left ? 1 : 2) extends (<T>() => T extends Right ? 1 : 2) ? true
+  : false
 
 export function IsExtendsMutual<Left extends unknown, Right extends unknown>(_expect: TExtendsMutualExpect<Left, Right>) {}
 

--- a/test/typebox/static/schema/additionalProperties.ts
+++ b/test/typebox/static/schema/additionalProperties.ts
@@ -7,7 +7,7 @@ Assert.IsExtendsMutual<
     additionalProperties: { type: 'string' }
   }>,
   {
-    [key: PropertyKey]: string
+    [key: string]: string
   }
 >(true)
 

--- a/test/typebox/static/schema/allOf.ts
+++ b/test/typebox/static/schema/allOf.ts
@@ -66,8 +66,7 @@ Assert.IsExtendsMutual<
     ]
   }>,
   {
-    x: number
-  } & {
+    x: number // question: can we retain logical intersect? (review)
     y: number
   }
 >(true)

--- a/test/typebox/static/schema/anyOf.ts
+++ b/test/typebox/static/schema/anyOf.ts
@@ -54,7 +54,6 @@ Assert.IsExtendsMutual<
     }]
   }>
   Assert.IsExtendsMutual<R, { type: 'A' } | { type: 'B' }>(true)
-  Assert.IsExtendsMutual<R, { type: 'A' } | { type: 'B' }>(false)
 }
 // should infer with union of object and number
 {
@@ -74,5 +73,4 @@ Assert.IsExtendsMutual<
     }]
   }>
   Assert.IsExtendsMutual<R, { type: 'A' } | { type: 'B' } | number>(true)
-  Assert.IsExtendsMutual<R, { type: 'A' } | { type: 'B' } | number>(false)
 }

--- a/test/typebox/static/schema/oneOf.ts
+++ b/test/typebox/static/schema/oneOf.ts
@@ -54,7 +54,6 @@ Assert.IsExtendsMutual<
     }]
   }>
   Assert.IsExtendsMutual<R, { type: 'A' } | { type: 'B' }>(true)
-  Assert.IsExtendsMutual<R, { type: 'A' } | { type: 'B' }>(false)
 }
 // should infer with union of object and number
 {
@@ -74,5 +73,4 @@ Assert.IsExtendsMutual<
     }]
   }>
   Assert.IsExtendsMutual<R, { type: 'A' } | { type: 'B' } | number>(true)
-  Assert.IsExtendsMutual<R, { type: 'A' } | { type: 'B' } | number>(false)
 }

--- a/test/typebox/static/schema/patternProperties.ts
+++ b/test/typebox/static/schema/patternProperties.ts
@@ -1,14 +1,14 @@
 import { Assert } from 'test'
 import { type XStatic } from 'typebox/schema'
 
+
+
 // should infer as expando
-Assert.IsExtendsMutual<
-  XStatic<{
-    patternProperties: {
-      'a': { type: 'number' }
-    }
-  }>,
-  {
-    [x: PropertyKey]: number
+
+type T = XStatic<{
+  patternProperties: {
+    'a': { type: 'number' }
   }
->(true)
+}>
+
+Assert.IsExtendsMutual<T, { [x: string]: number; }>(true)

--- a/test/typebox/static/type/enum.ts
+++ b/test/typebox/static/type/enum.ts
@@ -1,8 +1,71 @@
 import { type Static, Type } from 'typebox'
 import { Assert } from 'test'
 
-const T = Type.Enum([1, 'A', null])
-type T = Static<typeof T>
+// deno-fmt-ignore-file
 
-Assert.IsExtendsMutual<T, 1 | 'A' | null>(true)
-Assert.IsExtendsMutual<T, null>(false)
+// ------------------------------------------------------------------
+// Standard
+// ------------------------------------------------------------------
+{
+  const T = Type.Enum([1, 'A', null])
+  type T = Static<typeof T>
+
+  Assert.IsExtendsMutual<T, 1 | 'A' | null>(true)
+  Assert.IsExtendsMutual<T, null>(false)
+}
+// ------------------------------------------------------------------
+// Exterior Readonly
+// ------------------------------------------------------------------
+{
+  const X = [1, 'A', null] as const
+  const T = Type.Enum(X)
+  type T = Static<typeof T>
+
+  Assert.IsExtendsMutual<T, 1 | 'A' | null>(true)
+  Assert.IsExtendsMutual<T, null>(false)
+}
+// ------------------------------------------------------------------
+// Object Pattern
+// ------------------------------------------------------------------
+{
+  const T = Type.Enum(
+    {
+      A: 1,
+      B: 'A',
+      C: null
+    } as const
+  )
+  type T = Static<typeof T>
+
+  Assert.IsExtendsMutual<T, 1 | 'A' | null>(true)
+  Assert.IsExtendsMutual<T, null>(false)
+}
+// ------------------------------------------------------------------
+// TypeScript Enum: Small
+// ------------------------------------------------------------------
+{
+  enum E { A, B, C }
+  const T = Type.Enum(E)
+  type T = Static<typeof T>
+  Assert.IsExtends<T, E>(true)
+  Assert.IsExtendsMutual<T, null>(false)
+}
+// ------------------------------------------------------------------
+// TypeScript Enum: Large
+// ------------------------------------------------------------------
+{
+  enum E {
+    A1,  A2,  A3,  A4,  A5,  A6,  A7,  A8,  A9,  A10, A11, A12, A13, A14, A15, A16,
+    A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31, A32,
+    A33, A34, A35, A36, A37, A38, A39, A40, A41, A42, A43, A44, A45, A46, A47, A48,
+    A49, A50, A51, A52, A53, A54, A55, A56, A57, A58, A59, A60, A61, A62, A63, A64,
+    A65, A66, A67, A68, A69, A70, A71, A72, A73, A74, A75, A76, A77, A78, A79, A80,
+    A81, A82, A83, A84, A85, A86, A87, A88, A89, A90, A91, A92, A93, A94, A95, A96,
+    A97, A98, A99, A100, A101, A102, A103, A104, A105, A106, A107, A108, A109, A110, A111, A112,
+    A113, A114, A115, A116, A117, A118, A119, A120, A121, A122, A123, A124, A125, A126, A127, A128
+  };
+  const T = Type.Enum(E)
+  type T = Static<typeof T>
+  Assert.IsExtends<T, E>(true)
+  Assert.IsExtendsMutual<T, null>(false)
+}

--- a/test/typebox/static/type/intersect.ts
+++ b/test/typebox/static/type/intersect.ts
@@ -34,7 +34,7 @@ import { Assert } from 'test'
   ])
   type T = Static<typeof T>
   Assert.IsExtendsMutual<T, { x: number } & { y: number }>(true)
-  Assert.IsExtendsMutual<T, { x: number; y: number }>(true)
+  Assert.IsExtendsMutual<T, { x: number } & { y: number }>(true)
   Assert.IsExtendsMutual<T, null>(false)
 }
 // overlap
@@ -44,7 +44,7 @@ import { Assert } from 'test'
     Type.Object({ x: Type.Number() })
   ])
   type T = Static<typeof T>
-  Assert.IsExtendsMutual<T, { x: number }>(true)
+  Assert.IsExtendsMutual<T, { x: number } & { x: number }>(true)
   Assert.IsExtendsMutual<T, null>(false)
 }
 // narrow sub property 1
@@ -55,7 +55,7 @@ import { Assert } from 'test'
   ])
   type T = Static<typeof T>
 
-  Assert.IsExtendsMutual<T, { x: 1 }>(true)
+  Assert.IsExtendsMutual<T, { x: number; } & { x: 1; }>(true)
   Assert.IsExtendsMutual<T, null>(false)
 }
 // narrow sub property 2 (order)
@@ -66,6 +66,6 @@ import { Assert } from 'test'
   ])
   type T = Static<typeof T>
 
-  Assert.IsExtendsMutual<T, { x: 1 }>(true)
+  Assert.IsExtendsMutual<T, { x: 1; } & { x: number; }>(true)
   Assert.IsExtendsMutual<T, null>(false)
 }

--- a/test/typebox/static/type/template-literal.ts
+++ b/test/typebox/static/type/template-literal.ts
@@ -22,7 +22,7 @@ import { Assert } from 'test'
   const T = Type.TemplateLiteral('hello ${1 | 2}')
   type T = Static<typeof T>
 
-  Assert.IsExtendsMutual<T, 'hello 1' | 'hello 1'>(true)
+  Assert.IsExtendsMutual<T, 'hello 1' | 'hello 2'>(true)
   Assert.IsExtendsMutual<T, null>(false)
 }
 // ... including bigint
@@ -30,7 +30,7 @@ import { Assert } from 'test'
   const T = Type.TemplateLiteral('hello ${1n | 2n}')
   type T = Static<typeof T>
 
-  Assert.IsExtendsMutual<T, 'hello 1' | 'hello 1'>(true)
+  Assert.IsExtendsMutual<T, 'hello 1' | 'hello 2'>(true)
   Assert.IsExtendsMutual<T, null>(false)
 }
 // ... they also accept exterior unions but require a more verbose API
@@ -99,7 +99,5 @@ import { Assert } from 'test'
   type T = Static<typeof T>
 
   Assert.IsExtendsMutual<T, `hello ${boolean}`>(true)
-  Assert.IsExtendsMutual<T, `hello ${true}`>(true)
-  Assert.IsExtendsMutual<T, `hello ${false}`>(true)
   Assert.IsExtendsMutual<T, null>(false)
 }


### PR DESCRIPTION
This PR re-adds support for `readonly TEnumValue[]` arguments when constructing types of `TEnum`. It also makes some updates to the type assertion infrastructure to use more strict structural assertion (rel: `Assert.IsMutualExtends`). 

This PR also updates the inference for `TRecord`, inferring `{ [x: string]: T }` instead of the broader `{ [x: PropertyKey]: T }` in cases where the key type cannot be derived from the `patternProperties`.

Fixes: https://github.com/sinclairzx81/typebox/issues/1316