### PR TITLE
Add Type.Convert to control Value.Convert behavior

### DIFF
--- a/src/type/types/_convert.ts
+++ b/src/type/types/_convert.ts
@@ -1,0 +1,77 @@
+/*--------------------------------------------------------------------------
+
+TypeBox
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2025 Haydn Paterson 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
+// deno-fmt-ignore-file
+
+import { Memory } from '../../system/memory/index.ts'
+import { Guard } from '../../guard/index.ts'
+import { type TSchema, IsSchema } from './schema.ts'
+import { TProperties } from './properties.ts'
+
+// ------------------------------------------------------------------
+// ConvertAdd
+// ------------------------------------------------------------------
+/** Applies a Convert override to the given type. */
+export type TConvertAdd<Type extends TSchema = TSchema> = (
+  '~convert' extends keyof Type ? Type : TConvert<Type>
+)
+/** Applies a Convert override to the given type. */
+export function ConvertAdd<Type extends TSchema>(type: Type, conversion: TConvertCallback<TConvertAdd<Type>>): TConvertAdd<Type> {
+  const conversions = IsConvert(type) ? [conversion, ...type['~convert']] : [conversion]
+  return Memory.Update(type, {  }, { '~convert': conversions }) as never
+}
+// ------------------------------------------------------------------
+// Type
+// ------------------------------------------------------------------
+/** Represents a type with embedded Convert override. */
+export type TConvert<Type extends TSchema = TSchema> = (
+  Type & { '~convert': TConvertCallback<Type>[] }
+)
+// ------------------------------------------------------------------
+// Factory
+// ------------------------------------------------------------------
+export type TConvertCallback<Type extends TSchema> = (value: unknown, type: Type, context: TProperties) => TConvertCallbackResult
+// TODO: Should we use classes here? constructor functions? `(value) => Continue(Number(value) * 100)` or `Final(String(value))`
+export type TConvertCallbackResult = {
+	action: "continue" | "final"
+	value: unknown
+}
+
+/** Applies a Convert override to a type. */
+export function Convert<Type extends TSchema>(type: Type, callback: TConvertCallback<TConvertAdd<Type>>): TConvertAdd<Type> {
+  return ConvertAdd(type, callback) as never
+}
+// ------------------------------------------------------------------
+// Guard
+// ------------------------------------------------------------------
+/** Returns true if the given value is a TConvert. */
+export function IsConvert(value: unknown): value is TConvert<TSchema> {
+  return IsSchema(value) && Guard.HasPropertyKey(value, '~convert') && Guard.IsArray(value["~convert"])
+}
+
+

--- a/src/type/types/index.ts
+++ b/src/type/types/index.ts
@@ -30,6 +30,7 @@ THE SOFTWARE.
 // Extensions
 // ------------------------------------------------------------------
 export * from './_codec.ts'
+export * from './_convert.ts'
 export * from './_optional.ts'
 export * from './_readonly.ts'
 export * from './_refine.ts'

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -73,6 +73,7 @@ export { type TUppercase, type TUppercaseDeferred, Uppercase } from './type/acti
 // Extension
 // ------------------------------------------------------------------
 export { Codec, Decode, DecodeBuilder, Encode, EncodeBuilder, IsCodec, type TCodec } from './type/types/_codec.ts'
+export { Convert, IsConvert, type TConvert, type TConvertCallback, type TConvertCallbackResult } from './type/types/_convert.ts'
 export { IsOptional, Optional, type TOptional } from './type/types/_optional.ts'
 export { IsReadonly, Readonly, type TReadonly } from './type/types/_readonly.ts'
 export { IsRefine, Refine, type TRefine, type TRefineCallback, type TRefinement } from './type/types/_refine.ts'

--- a/src/value/convert/from-convert.ts
+++ b/src/value/convert/from-convert.ts
@@ -1,0 +1,47 @@
+/*--------------------------------------------------------------------------
+
+TypeBox
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2025 Haydn Paterson 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
+// deno-fmt-ignore-file
+
+import type { TConvert, TConvertCallbackResult, TProperties } from '../../type/index.ts'
+import { FromTypeWithoutConvert } from './from-type.ts'
+
+export function FromConvert(context: TProperties, type: TConvert, value: unknown): unknown {
+  let action: TConvertCallbackResult["action"] = "continue"
+  for(const conversion of type["~convert"]) {
+    ({action, value} = conversion(value, type, context))
+    if(action === "final") {
+      return value;
+    }
+    else if(action !== "continue") {
+      throw new Error(`Unknown Convert-Callback action type ${action}`)
+    }
+  }
+
+  return FromTypeWithoutConvert(context, type, value);
+}

--- a/src/value/convert/from-type.ts
+++ b/src/value/convert/from-type.ts
@@ -30,6 +30,7 @@ THE SOFTWARE.
 
 import * as T from '../../type/index.ts'
 
+import { FromConvert } from './from-convert.ts'
 import { FromArray } from './from-array.ts'
 import { FromBase } from './from-base.ts'
 import { FromBigInt } from './from-bigint.ts'
@@ -52,6 +53,13 @@ import { FromUnion } from './from-union.ts'
 import { FromVoid } from './from-void.ts'
 
 export function FromType(context: T.TProperties, type: T.TSchema, value: unknown): unknown {
+  return (
+    T.IsConvert(type) ? FromConvert(context, type, value) : 
+    FromTypeWithoutConvert(context, type, value)
+  )
+}
+
+export function FromTypeWithoutConvert(context: T.TProperties, type: T.TSchema, value: unknown): unknown {
   return (
     T.IsArray(type) ? FromArray(context, type, value) :
     T.IsBase(type) ? FromBase(context, type, value) :

--- a/test/typebox/runtime/value/convert/convert.ts
+++ b/test/typebox/runtime/value/convert/convert.ts
@@ -1,0 +1,24 @@
+import { Value } from 'typebox/value'
+import { Type } from 'typebox'
+import { Assert } from 'test'
+
+const Test = Assert.Context('Value.Convert.Convert')
+
+Test('Should Convert 1', () => {
+	const T = Type.Convert(Type.String(), (value) => ({ action: "final", value }))
+	const R = Value.Convert(T, 3.14)
+	Assert.IsEqual(R, 3.14);
+})
+
+Test('Should Convert 2', () => {
+	const T = Type.Convert(Type.String(), (value) => ({ action: "continue", value }))
+	const R = Value.Convert(T, 3.14)
+	Assert.IsEqual(R, "3.14");
+})
+
+Test('Should Convert 3', () => {
+	const T = Type.Convert(Type.String(), function addOne(value) { return  ({ action: "continue", value: Number(value) + 1 }) })
+	const U = Type.Convert(T, function multiplyTen(value) { return  ({ action: "continue", value: Number(value) * 10 }) })
+	const R = Value.Convert(U, 10)
+	Assert.IsEqual(R, "101")
+})

--- a/test/typebox/static/type/convert.ts
+++ b/test/typebox/static/type/convert.ts
@@ -1,0 +1,25 @@
+import { type Static, Type } from 'typebox'
+import { Assert } from 'test'
+
+{
+	const T = Type.Convert(Type.String(), (value) => ({ action: 'continue', value: null }))
+	type T = Static<typeof T>
+
+	Assert.IsExtendsMutual<T, string>(true)
+	Assert.IsExtendsMutual<T, null>(false)
+}
+
+{
+	const T = Type.Convert(Type.String(), (value) => ({ action: 'final', value: null }))
+	type T = Static<typeof T>
+
+	Assert.IsExtendsMutual<T, string>(true)
+	Assert.IsExtendsMutual<T, null>(false)
+}
+
+{
+	const T = Type.Convert(Type.String(), (value, type) => {
+		Assert.IsExtendsMutual<typeof type, typeof T>(true)
+		return { action: 'continue', value: value }
+	})
+}


### PR DESCRIPTION
Add a `Type.Convert` extension that allows modifying or overriding `Value.Convert` behavior. Similar to `Decode`, except this transforms values _before_ validation.

## Open questions
1. Is `Type.Convert` an appropriate name for this extension.
2. Is the object literal `ConvertCallbackResult` appropriate, or should constructor functions be provided?
3. Is splitting `FromType` into `FromType` and `FromTypeWithoutConvert` appropriate or should a boolean flag be used instead?
4. Implemented behavior each `Type.Convert(Inner)` wrapper prepends its callbacks to the list to be executed, is this appropriate?

## Use Cases

### Extended coercion rules
I am using TypeBox to parse data loaded from a directory tree. It would be wonderful if I could extend `Value.Convert` to understand how to coerce `Buffer` objects into strings and numbers.
```ts
const Buffer = {
  asString(options: Type.TStringOptions) { 
    return Type.Convert(
      Type.String(options), 
      (value) => ({ action: "continue", value: Buffer.isBuffer(value) ? value.toString() : value })
    ) 
  },
  asNumber(options: Type.TNumberOptions) { 
    return Type.Convert(
      Type.Number(options), 
      (value) => ({ action: "continue", value: Buffer.isBuffer(value) ? value.toString() : value })
    ) 
  }
}

envdir("env", Type.Object({
    cert: Buffer.asString({ pattern: "BEGIN" }),
    port: Buffer.asNumber({ minimum: 0, multipleOf: 1, maximum: (1 << 16) - 1 }),
}))
```

### Suppress undesirable coercion
```ts
const A = Type.Object({ example: Type.String() })
const B = Type.Object({ example: Type.Number({ minimum: 5 }) })
const U = Type.Union([A, B])

// Coercion rules result in
Type.Parse(U, { example: 0 })
// succeeding with `{ example: "0" }`, regardless that it would fail to match `B`

const StrictU = Type.Convert(U, (value) => ({ action: "final", value }));
Type.Parse(StrictU, { example: 0 })
// exception
```