### PR TITLE
Version 1.0.16

### DIFF
--- a/changelog/1.0.0.md
+++ b/changelog/1.0.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.0.16](https://github.com/sinclairzx81/typebox/pull/1358)
+  - Inference Ref Stack | Cyclic Inference Termination
 - [Revision 1.0.15](https://github.com/sinclairzx81/typebox/pull/1346)
   - Specify Types for AssertError Cause Properties
 - [Revision 1.0.14](https://github.com/sinclairzx81/typebox/pull/1349)

--- a/src/type/types/_codec.ts
+++ b/src/type/types/_codec.ts
@@ -35,14 +35,14 @@ import { type TProperties } from './properties.ts'
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticCodec<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema, Decoded extends unknown> = Direction extends 'Decode' ? Decoded
-  : StaticType<Direction, Context, This, Type>
+export type StaticCodec<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema, Decoded extends unknown> = Direction extends 'Decode' ? Decoded
+  : StaticType<Stack, Direction, Context, This, Type>
 
 // ------------------------------------------------------------------
 // Type
 // ------------------------------------------------------------------
-export type TDecodeCallback<Type extends TSchema, Decoded = unknown> = (input: StaticType<'Decode', {}, {}, Type>) => Decoded
-export type TEncodeCallback<Type extends TSchema, Decoded = unknown> = (input: Decoded) => StaticType<'Decode', {}, {}, Type>
+export type TDecodeCallback<Type extends TSchema, Decoded = unknown> = (input: StaticType<[], 'Decode', {}, {}, Type>) => Decoded
+export type TEncodeCallback<Type extends TSchema, Decoded = unknown> = (input: Decoded) => StaticType<[], 'Decode', {}, {}, Type>
 export type TCodec<Type extends TSchema = TSchema, Decoded extends unknown = unknown> = Type & {
   '~codec': {
     encode: TDecodeCallback<Type, Decoded>

--- a/src/type/types/array.ts
+++ b/src/type/types/array.ts
@@ -36,8 +36,8 @@ import { type TProperties } from './properties.ts'
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticArray<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema,
-  Result = StaticType<Direction, Context, This, Type>[]
+export type StaticArray<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema,
+  Result extends unknown[] = StaticType<Stack, Direction, Context, This, Type>[]
 > = Result
 // ------------------------------------------------------------------
 // Type

--- a/src/type/types/async-iterator.ts
+++ b/src/type/types/async-iterator.ts
@@ -36,8 +36,8 @@ import { type TProperties } from './properties.ts'
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticAsyncIterator<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema, 
-  Result = AsyncIterableIterator<StaticType<Direction, Context, This, Type>>
+export type StaticAsyncIterator<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema, 
+  Result = AsyncIterableIterator<StaticType<Stack, Direction, Context, This, Type>>
 > = Result
 // ------------------------------------------------------------------
 // Type

--- a/src/type/types/constructor.ts
+++ b/src/type/types/constructor.ts
@@ -37,9 +37,9 @@ import { type TProperties } from './properties.ts'
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticConstructor<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Parameters extends TSchema[], InstanceType extends TSchema,
-  StaticParameters extends unknown[] = StaticInstantiatedParameters<Direction, Context, This, Parameters>,
-  StaticReturnType extends unknown = StaticType<Direction, Context, This, InstanceType>,
+export type StaticConstructor<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Parameters extends TSchema[], InstanceType extends TSchema,
+  StaticParameters extends unknown[] = StaticInstantiatedParameters<Stack, Direction, Context, This, Parameters>,
+  StaticReturnType extends unknown = StaticType<Stack, Direction, Context, This, InstanceType>,
   Result = new (...args: StaticParameters) => StaticReturnType
 > = Result
 // ------------------------------------------------------------------

--- a/src/type/types/cyclic.ts
+++ b/src/type/types/cyclic.ts
@@ -37,10 +37,12 @@ import { type TProperties } from './properties.ts'
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticCyclic<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Defs extends TProperties, Ref extends string, 
-  Result extends unknown = Ref extends keyof Defs
-  ? StaticType<Direction, Defs, This, Defs[Ref]>
-  : never
+export type StaticCyclic<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Defs extends TProperties, Ref extends string, 
+  Result extends unknown = (
+    Ref extends keyof Defs
+      ? StaticType<[...Stack, Ref], Direction, Defs, This, Defs[Ref]>
+      : never
+  )
 > = Result
 // ------------------------------------------------------------------
 // Type

--- a/src/type/types/function.ts
+++ b/src/type/types/function.ts
@@ -44,18 +44,18 @@ import { type TInstantiate } from '../engine/instantiate.ts'
 // performs a deferred Static Instantiate for inference only.
 //
 // ------------------------------------------------------------------
-export type StaticInstantiatedParameters<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Parameters extends TSchema[], 
+export type StaticInstantiatedParameters<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Parameters extends TSchema[], 
   Evaluated extends TSchema = TInstantiate<Context, TTuple<Parameters>>,
-  Static extends unknown = StaticType<Direction, Context, This, Evaluated>,
+  Static extends unknown = StaticType<Stack, Direction, Context, This, Evaluated>,
   Result extends unknown[] = Static extends unknown[] ? Static : []
 > = Result
 
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticFunction<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Parameters extends TSchema[], ReturnType extends TSchema, 
-  StaticParameters extends unknown[] = StaticInstantiatedParameters<Direction, Context, This, Parameters>,
-  StaticReturnType extends unknown = StaticType<Direction, Context, This, ReturnType>,
+export type StaticFunction<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Parameters extends TSchema[], ReturnType extends TSchema, 
+  StaticParameters extends unknown[] = StaticInstantiatedParameters<Stack, Direction, Context, This, Parameters>,
+  StaticReturnType extends unknown = StaticType<Stack, Direction, Context, This, ReturnType>,
   Result = (...args: StaticParameters) => StaticReturnType
 > = Result
 // ------------------------------------------------------------------

--- a/src/type/types/intersect.ts
+++ b/src/type/types/intersect.ts
@@ -36,9 +36,9 @@ import { type TProperties } from './properties.ts'
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticIntersect<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Types extends TSchema[], Result extends unknown = unknown> = (
+export type StaticIntersect<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Types extends TSchema[], Result extends unknown = unknown> = (
   Types extends [infer Left extends TSchema, ...infer Right extends TSchema[]]
-    ? StaticIntersect<Direction, Context, This, Right, Result & StaticType<Direction, Context, This, Left>>
+    ? StaticIntersect<Stack, Direction, Context, This, Right, Result & StaticType<Stack, Direction, Context, This, Left>>
     : Result
 )
 // ------------------------------------------------------------------

--- a/src/type/types/iterator.ts
+++ b/src/type/types/iterator.ts
@@ -36,8 +36,8 @@ import { type TProperties } from './properties.ts'
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticIterator<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema,
-  Result = IterableIterator<StaticType<Direction, Context, This, Type>>
+export type StaticIterator<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema,
+  Result = IterableIterator<StaticType<Stack, Direction, Context, This, Type>>
 > = Result
 // ------------------------------------------------------------------
 // Type

--- a/src/type/types/object.ts
+++ b/src/type/types/object.ts
@@ -36,8 +36,8 @@ import { type TProperties, type TRequiredArray, type StaticProperties, RequiredA
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticObject<Direction extends StaticDirection, Context extends TProperties, _This extends TProperties, Properties extends TProperties,
-  Result = keyof Properties extends never ? object : StaticProperties<Direction, Context, Properties, Properties>
+export type StaticObject<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, _This extends TProperties, Properties extends TProperties,
+  Result = keyof Properties extends never ? object : StaticProperties<Stack, Direction, Context, Properties, Properties>
 > = Result
 // ------------------------------------------------------------------
 // Schema

--- a/src/type/types/promise.ts
+++ b/src/type/types/promise.ts
@@ -36,8 +36,8 @@ import { type TProperties } from './properties.ts'
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticPromise<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema, 
-  Result = Promise<StaticType<Direction, Context, This, Type>>
+export type StaticPromise<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema, 
+  Result = Promise<StaticType<Stack, Direction, Context, This, Type>>
 > = Result
 // ------------------------------------------------------------------
 // Type

--- a/src/type/types/properties.ts
+++ b/src/type/types/properties.ts
@@ -53,15 +53,15 @@ type StaticPropertiesWithModifiers<Properties extends TProperties, PropertiesWit
 // ----------------------------------------------------------------------------
 // StaticPropertiesWithoutModifiers
 // ----------------------------------------------------------------------------
-type StaticPropertiesWithoutModifiers<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Properties extends TProperties, 
+type StaticPropertiesWithoutModifiers<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Properties extends TProperties, 
   Result extends Record<PropertyKey, unknown> = { 
-    [Key in keyof Properties]: StaticType<Direction, Context, This, Properties[Key]> 
+    [Key in keyof Properties]: StaticType<Stack, Direction, Context, This, Properties[Key]> 
   }> = Result
 // ----------------------------------------------------------------------------
 // StaticProperties
 // ----------------------------------------------------------------------------
-export type StaticProperties<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Properties extends TProperties, 
-  PropertiesWithoutModifiers extends Record<PropertyKey, unknown> = StaticPropertiesWithoutModifiers<Direction, Context, This, Properties>,
+export type StaticProperties<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Properties extends TProperties, 
+  PropertiesWithoutModifiers extends Record<PropertyKey, unknown> = StaticPropertiesWithoutModifiers<Stack, Direction, Context, This, Properties>,
   PropertiesWithModifiers extends Record<PropertyKey, unknown> = StaticPropertiesWithModifiers<Properties, PropertiesWithoutModifiers>,
   Result extends Record<PropertyKey, unknown> = { [Key in keyof PropertiesWithModifiers]: PropertiesWithModifiers[Key] }
 > = Result

--- a/src/type/types/record.ts
+++ b/src/type/types/record.ts
@@ -47,8 +47,8 @@ import { CreateRecord } from '../engine/record/record-create.ts'
 // -------------------------------------------------------------------
 // Static
 // -------------------------------------------------------------------
-export type StaticRecord<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Key extends string, Value extends TSchema, 
-  StaticValue extends unknown = StaticType<Direction, Context, This, Value>,
+export type StaticRecord<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Key extends string, Value extends TSchema, 
+  StaticValue extends unknown = StaticType<Stack, Direction, Context, This, Value>,
   Result extends Record<PropertyKey, unknown> = (
     Key extends TStringKey ? Record<string, StaticValue> :
     Key extends TIntegerKey ? Record<number, StaticValue> :

--- a/src/type/types/ref.ts
+++ b/src/type/types/ref.ts
@@ -60,7 +60,7 @@ type CyclicStackLength<Stack extends unknown[], MaxLength extends number, Buffer
     : true
 )
 type CyclicGuard<Stack extends unknown[], Ref extends string> = (
-  Ref extends Stack[number] ? CyclicStackLength<Stack, 4> : true
+  Ref extends Stack[number] ? CyclicStackLength<Stack, 2> : true
 )
 
 // ------------------------------------------------------------------

--- a/src/type/types/static.ts
+++ b/src/type/types/static.ts
@@ -79,35 +79,35 @@ export type StaticDirection = 'Encode' | 'Decode'
 // ------------------------------------------------------------------
 // StaticType
 // ------------------------------------------------------------------
-export type StaticType<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema> = (
-  Type extends TCodec<infer Type extends TSchema, infer Decoded extends unknown> ? StaticCodec<Direction, Context, This, Type, Decoded> :
+export type StaticType<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema> = (
+  Type extends TCodec<infer Type extends TSchema, infer Decoded extends unknown> ? StaticCodec<Stack, Direction, Context, This, Type, Decoded> :
   Type extends TAny ? StaticAny :
-  Type extends TArray<infer Type extends TSchema> ? StaticArray<Direction, Context, This, Type> :
-  Type extends TAsyncIterator<infer Type extends TSchema> ? StaticAsyncIterator<Direction, Context, This, Type> :
+  Type extends TArray<infer Type extends TSchema> ? StaticArray<Stack, Direction, Context, This, Type> :
+  Type extends TAsyncIterator<infer Type extends TSchema> ? StaticAsyncIterator<Stack, Direction, Context, This, Type> :
   Type extends TBigInt ? StaticBigInt :
   Type extends TBoolean ? StaticBoolean :
-  Type extends TConstructor<infer Parameters extends TSchema[], infer ReturnType extends TSchema> ? StaticConstructor<Direction, Context, This, Parameters, ReturnType> :
+  Type extends TConstructor<infer Parameters extends TSchema[], infer ReturnType extends TSchema> ? StaticConstructor<Stack, Direction, Context, This, Parameters, ReturnType> :
   Type extends TEnum<infer Values extends TEnumValue[]> ? StaticEnum<Values> :
-  Type extends TFunction<infer Parameters extends TSchema[], infer ReturnType extends TSchema> ? StaticFunction<Direction, Context, This, Parameters, ReturnType> :
+  Type extends TFunction<infer Parameters extends TSchema[], infer ReturnType extends TSchema> ? StaticFunction<Stack, Direction, Context, This, Parameters, ReturnType> :
   Type extends TInteger ? StaticInteger :
-  Type extends TIntersect<infer Types extends TSchema[]> ? StaticIntersect<Direction, Context, This, Types> :
-  Type extends TIterator<infer Types extends TSchema> ? StaticIterator<Direction, Context, This, Types> :
+  Type extends TIntersect<infer Types extends TSchema[]> ? StaticIntersect<Stack, Direction, Context, This, Types> :
+  Type extends TIterator<infer Types extends TSchema> ? StaticIterator<Stack, Direction, Context, This, Types> :
   Type extends TLiteral<infer Value extends TLiteralValue> ? StaticLiteral<Value> :
   Type extends TNever ? StaticNever :
   Type extends TNull ? StaticNull :
   Type extends TNumber ? StaticNumber :
-  Type extends TObject<infer Properties extends TProperties> ? StaticObject<Direction, Context, This, Properties> :
-  Type extends TPromise<infer Type extends TSchema> ? StaticPromise<Direction, Context, This, Type> :
-  Type extends TRecord<infer Key extends string, infer Value extends TSchema> ? StaticRecord<Direction, Context, This, Key, Value> :
-  Type extends TCyclic<infer Defs extends TProperties, infer Ref extends string> ? StaticCyclic<Direction, Context, This, Defs, Ref> :
-  Type extends TRef<infer Ref extends string> ? StaticRef<Direction, Context, This, Ref> :
+  Type extends TObject<infer Properties extends TProperties> ? StaticObject<Stack, Direction, Context, This, Properties> :
+  Type extends TPromise<infer Type extends TSchema> ? StaticPromise<Stack, Direction, Context, This, Type> :
+  Type extends TRecord<infer Key extends string, infer Value extends TSchema> ? StaticRecord<Stack, Direction, Context, This, Key, Value> :
+  Type extends TCyclic<infer Defs extends TProperties, infer Ref extends string> ? StaticCyclic<Stack, Direction, Context, This, Defs, Ref> :
+  Type extends TRef<infer Ref extends string> ? StaticRef<Stack, Direction, Context, This, Ref> :
   Type extends TString ? StaticString :
   Type extends TSymbol ? StaticSymbol :
   Type extends TTemplateLiteral<infer Pattern extends string> ? StaticTemplateLiteral<Pattern> :
-  Type extends TThis ? StaticThis<Direction, Context, This> :
-  Type extends TTuple<infer Types extends TSchema[]> ? StaticTuple<Direction, Context, This, Types> :
+  Type extends TThis ? StaticThis<Stack, Direction, Context, This> :
+  Type extends TTuple<infer Types extends TSchema[]> ? StaticTuple<Stack, Direction, Context, This, Types> :
   Type extends TUndefined ? StaticUndefined :
-  Type extends TUnion<infer Types extends TSchema[]> ? StaticUnion<Direction, Context, This, Types> :
+  Type extends TUnion<infer Types extends TSchema[]> ? StaticUnion<Stack, Direction, Context, This, Types> :
   Type extends TUnknown ? StaticUnknown :
   Type extends TUnsafe<infer Type extends unknown> ? StaticUnsafe<Type> :
   Type extends TVoid ? StaticVoid :
@@ -117,10 +117,10 @@ export type StaticType<Direction extends StaticDirection, Context extends TPrope
 // Statics
 // ------------------------------------------------------------------
 /** Infers a static type from a TypeBox type using Parse logic. */
-export type StaticParse<Type extends TSchema, Context extends TProperties = {}> = StaticType<'Decode', Context, {}, Type>
+export type StaticParse<Type extends TSchema, Context extends TProperties = {}> = StaticType<[], 'Decode', Context, {}, Type>
 /** Infers a static type from a TypeBox type using Decode logic. */
-export type StaticDecode<Type extends TSchema, Context extends TProperties = {}> = StaticType<'Decode', Context, {}, Type>
+export type StaticDecode<Type extends TSchema, Context extends TProperties = {}> = StaticType<[], 'Decode', Context, {}, Type>
 /** Infers a static type from a TypeBox type using Encode logic. */
-export type StaticEncode<Type extends TSchema, Context extends TProperties = {}> = StaticType<'Encode', Context, {}, Type>
+export type StaticEncode<Type extends TSchema, Context extends TProperties = {}> = StaticType<[], 'Encode', Context, {}, Type>
 /** Infers a static type from a TypeBox type. */
-export type Static<Type extends TSchema, Context extends TProperties = {}> = StaticType<'Encode', Context, {}, Type>
+export type Static<Type extends TSchema, Context extends TProperties = {}> = StaticType<[], 'Encode', Context, {}, Type>

--- a/src/type/types/this.ts
+++ b/src/type/types/this.ts
@@ -37,8 +37,8 @@ import { type TProperties } from './properties.ts'
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticThis<Direction extends StaticDirection, Context extends TProperties, This extends TProperties> = (
-  StaticType<Direction, Context, This, TObject<This>> 
+export type StaticThis<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties> = (
+  StaticType<Stack, Direction, Context, This, TObject<This>> 
 )
 // ------------------------------------------------------------------
 // Type

--- a/src/type/types/tuple.ts
+++ b/src/type/types/tuple.ts
@@ -48,20 +48,20 @@ import { type TRest } from './rest.ts'
 // unsized Parameter inference at the Tuple level.
 //
 // ------------------------------------------------------------------
-type StaticLast<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema, Result extends unknown[]> = (
+type StaticLast<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema, Result extends unknown[]> = (
   Type extends TRest<infer RestType extends TSchema>
    ? RestType extends TArray<infer ArrayType extends TSchema>
-     ? [...Result, ...TStaticElement<Direction, Context, This, ArrayType>[0][]]
+     ? [...Result, ...TStaticElement<Stack, Direction, Context, This, ArrayType>[0][]]
      : [...Result, never]
-   : [...Result, ...TStaticElement<Direction, Context, This, Type>]
+   : [...Result, ...TStaticElement<Stack, Direction, Context, This, Type>]
 )
 // ------------------------------------------------------------------
 // StaticElement
 // ------------------------------------------------------------------
-type TStaticElement<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema,
+type TStaticElement<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema,
   IsReadonly extends boolean = Type extends TReadonly ? true : false,
   IsOptional extends boolean = Type extends TOptional ? true : false,
-  Inferred extends unknown = StaticType<Direction, Context, This, Type>,
+  Inferred extends unknown = StaticType<Stack, Direction, Context, This, Type>,
   Result extends [unknown?] = (
     [IsReadonly, IsOptional] extends [true, true] ? [Readonly<Inferred>?] :
     [IsReadonly, IsOptional] extends [false, true] ? [Inferred?] :
@@ -72,17 +72,17 @@ type TStaticElement<Direction extends StaticDirection, Context extends TProperti
 // ------------------------------------------------------------------
 // StaticElements
 // ------------------------------------------------------------------
-export type TStaticElements<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Types extends TSchema[], Result extends unknown[] = []> = (
-  Types extends [infer Last extends TSchema] ? StaticLast<Direction, Context, This, Last, Result> :
+export type TStaticElements<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Types extends TSchema[], Result extends unknown[] = []> = (
+  Types extends [infer Last extends TSchema] ? StaticLast<Stack, Direction, Context, This, Last, Result> :
   Types extends [infer Left extends TSchema, ...infer Right extends TSchema[]]
-    ? TStaticElements<Direction, Context, This, Right, [...Result, ...TStaticElement<Direction, Context, This, Left>]>
+    ? TStaticElements<Stack, Direction, Context, This, Right, [...Result, ...TStaticElement<Stack, Direction, Context, This, Left>]>
     : Result
 )
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticTuple<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Types extends TSchema[], 
-  Elements extends unknown[] = TStaticElements<Direction, Context, This, Types>,
+export type StaticTuple<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Types extends TSchema[], 
+  Elements extends unknown[] = TStaticElements<Stack, Direction, Context, This, Types>,
   Result extends unknown[] = Elements
 > = Result
 // ------------------------------------------------------------------

--- a/src/type/types/union.ts
+++ b/src/type/types/union.ts
@@ -36,9 +36,9 @@ import { type TProperties } from './properties.ts'
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticUnion<Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Types extends TSchema[], Result extends unknown = never> = (
+export type StaticUnion<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Types extends TSchema[], Result extends unknown = never> = (
   Types extends [infer Left extends TSchema, ...infer Right extends TSchema[]]
-    ? StaticUnion<Direction, Context, This, Right, Result | StaticType<Direction, Context, This, Left>>
+    ? StaticUnion<Stack, Direction, Context, This, Right, Result | StaticType<Stack, Direction, Context, This, Left>>
     : Result
 )
 // ------------------------------------------------------------------

--- a/src/value/clone/clone.ts
+++ b/src/value/clone/clone.ts
@@ -56,6 +56,8 @@ function FromObjectInstance(value: Record<PropertyKey, unknown>): Record<Propert
   }
   return result
 }
+
+Object.create({})
 // ------------------------------------------------------------------
 // Object
 // ------------------------------------------------------------------

--- a/tasks.ts
+++ b/tasks.ts
@@ -8,7 +8,7 @@ import { Range } from './task/range/index.ts'
 import { Metrics } from './task/metrics/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.0.15'
+const Version = '1.0.16'
 
 // ------------------------------------------------------------------
 // BuildPackage

--- a/test/typebox/static/type/cyclic.ts
+++ b/test/typebox/static/type/cyclic.ts
@@ -1,0 +1,75 @@
+
+import { type Static, Type } from 'typebox'
+import { Assert } from 'test'
+
+// ------------------------------------------------------------------
+// NonCyclic
+// ------------------------------------------------------------------
+{
+  const NonCyclic = Type.Cyclic({
+    NonCyclic: Type.Object({
+      x: Type.Number(),
+      y: Type.Number(),
+      z: Type.Number()
+    })
+  }, 'NonCyclic')
+  type NonCyclic = Static<typeof NonCyclic>
+  // Invariant
+  Assert.IsExtendsMutual<{ x: 1, y: 2, z: false }, NonCyclic>(false)
+  // Extends
+  Assert.IsExtendsMutual<{ x: number, y: number, z: number }, NonCyclic>(true)
+}
+
+// ------------------------------------------------------------------
+// Deep
+//
+// https://github.com/sinclairzx81/typebox/issues/1356
+// ------------------------------------------------------------------
+{
+  const Deep = Type.Cyclic({
+    Deep: Type.Object({
+      deep: Type.Ref('Deep')
+    })
+  }, 'Deep')
+  type Deep = Static<typeof Deep>
+  // Invariant
+  Assert.IsExtends<{ deep: 1 }, Deep>(false)
+  Assert.IsExtends<{ deep: { deep: { deep: 1 } } }, Deep>(false)
+  
+  // Extends
+  Assert.IsExtends<{ deep: any }, Deep>(true)
+  Assert.IsExtends<{ deep: { deep: { deep: any } } }, Deep>(true)
+}
+// ------------------------------------------------------------------
+// JsonValue
+//
+// https://github.com/sinclairzx81/typebox/issues/1356
+// ------------------------------------------------------------------
+{
+  const JsonValue = Type.Cyclic({
+    JsonValue: Type.Union([
+      Type.Record(Type.String(), Type.Ref('JsonValue')),
+      Type.Array(Type.Ref('JsonValue')),
+      Type.String(),
+      Type.Number(),
+      Type.Boolean(),
+      Type.Null(),
+    ])
+  }, 'JsonValue')
+
+  type JsonValue = Static<typeof JsonValue>
+  // Invariant
+  Assert.IsExtends<bigint, JsonValue>(false)
+  Assert.IsExtends<bigint[], JsonValue>(false)
+  Assert.IsExtends<[bigint], JsonValue>(false)
+  Assert.IsExtends<{ x: bigint }, JsonValue>(false)
+
+  // Extends
+  Assert.IsExtends<'A', JsonValue>(true)
+  Assert.IsExtends<1, JsonValue>(true)
+  Assert.IsExtends<true, JsonValue>(true)
+  Assert.IsExtends<null, JsonValue>(true)
+  Assert.IsExtends<null[], JsonValue>(true)
+  Assert.IsExtends<[null], JsonValue>(true)
+  Assert.IsExtends<{ x: null }, JsonValue>(true)
+}


### PR DESCRIPTION
This PR introduces a Ref Stack to the TypeBox inference pipeline. The stack is used to detect cyclic references and to enable an inference termination strategy for Ref. It is implemented to support recursive structures of the following form:

```typescript
// ---------------------------------------------------------------------------
// TypeScript
// ---------------------------------------------------------------------------
type JsonValue = ( // Type alias 'JsonValue' circularly references itself.
  | Record<string, JsonValue> 
  | JsonValue[]
  | string
  | number
  | boolean
  | null
)
// ---------------------------------------------------------------------------
// TypeBox
// ---------------------------------------------------------------------------
const JsonValue = Type.Cyclic({
  JsonValue: Type.Union([
    Type.Record(Type.String(), Type.Ref('JsonValue')),
    Type.Array(Type.Ref('JsonValue')),
    Type.String(),
    Type.Number(),
    Type.Boolean(),
    Type.Null(),
  ])
}, 'JsonValue')
```
### Notes

TypeScript does not support these structures due to circular self-referencing. In TypeBox, however, they are representable using a stack-based recursion termination strategy. If the stack exceeds a configured length (currently set to 2), the recursion terminates and the type resolves to any. This approach provides meaningful type feedback for the user while preventing Instantiation Too Deep errors in TypeScript.

### Historical

Previous versions of TypeBox suggested that users adopt either Any or Unknown for these recursive structures. This approach would suffice if TypeBox were limited to strictly JSON-encodable data. However, because TypeBox supports non-JSON-encodable structures and users may want to construct types that filter values representable for the JSON type subset, it is important that inference for these recursive types is supported in some capacity.

Fixes: https://github.com/sinclairzx81/typebox/issues/1356