### PR TITLE
Version 1.0.17

### DIFF
--- a/changelog/1.0.0.md
+++ b/changelog/1.0.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.0.17](https://github.com/sinclairzx81/typebox/pull/1366)
+  - Use Exact Standard Schema Interface
 - [Revision 1.0.16](https://github.com/sinclairzx81/typebox/pull/1358)
   - Inference Ref Stack | Cyclic Inference Termination
 - [Revision 1.0.15](https://github.com/sinclairzx81/typebox/pull/1346)

--- a/src/type/types/base.ts
+++ b/src/type/types/base.ts
@@ -4,7 +4,7 @@ TypeBox
 
 The MIT License (MIT)
 
-Copyright (c) 2017-2025 Haydn Paterson
+Copyright (c) 2017-2025 Haydn Paterson 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
+
+// deno-fmt-ignore-file
 
 import { IsKind, type TSchema } from './schema.ts'
 

--- a/src/type/types/base.ts
+++ b/src/type/types/base.ts
@@ -4,7 +4,7 @@ TypeBox
 
 The MIT License (MIT)
 
-Copyright (c) 2017-2025 Haydn Paterson 
+Copyright (c) 2017-2025 Haydn Paterson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -26,53 +26,114 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-// deno-fmt-ignore-file
+import { IsKind, type TSchema } from './schema.ts'
 
-import { type TSchema, IsKind } from './schema.ts'
-
-// --------------------------------------------------------
-// TResult
-// --------------------------------------------------------
-type TResult<Value extends unknown = unknown> = TValue<Value> | TIssues
-// --------------------------------------------------------
-// TValue
-// --------------------------------------------------------
-interface TValue<Value extends unknown = unknown> {
-  value: Value
+// ------------------------------------------------------------------
+// The Standard Schema interface, Do not export these interfaces
+// ------------------------------------------------------------------
+interface StandardSchemaV1<Input = unknown, Output = Input> {
+  /** The Standard Schema properties. */
+  readonly '~standard': StandardSchemaV1.Props<Input, Output>
 }
-function Value<Value>(value: Value): TValue<Value> {
+declare namespace StandardSchemaV1 {
+  /** The Standard Schema properties interface. */
+  export interface Props<Input = unknown, Output = Input> {
+    /** The version number of the standard. */
+    readonly version: 1
+    /** The vendor name of the schema library. */
+    readonly vendor: string
+    /** Validates unknown input values. */
+    readonly validate: (
+      value: unknown
+    ) => Result<Output> | Promise<Result<Output>>
+    /** Inferred types associated with the schema. */
+    readonly types?: Types<Input, Output> | undefined
+  }
+  /** The result interface of the validate function. */
+  export type Result<Output> = SuccessResult<Output> | FailureResult
+  /** The result interface if validation succeeds. */
+  export interface SuccessResult<Output> {
+    /** The typed output value. */
+    readonly value: Output
+    /** The non-existent issues. */
+    readonly issues?: undefined
+  }
+  /** The result interface if validation fails. */
+  export interface FailureResult {
+    /** The issues of failed validation. */
+    readonly issues: ReadonlyArray<Issue>
+  }
+  /** The issue interface of the failure output. */
+  export interface Issue {
+    /** The error message of the issue. */
+    readonly message: string
+    /** The path of the issue, if any. */
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined
+  }
+  /** The path segment interface of the issue. */
+  export interface PathSegment {
+    /** The key representing a path segment. */
+    readonly key: PropertyKey
+  }
+  /** The Standard Schema types interface. */
+  export interface Types<Input = unknown, Output = Input> {
+    /** The input type of the schema. */
+    readonly input: Input
+    /** The output type of the schema. */
+    readonly output: Output
+  }
+  /** Infers the input type of a Standard Schema. */
+  export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema['~standard']['types']
+  >['input']
+  /** Infers the output type of a Standard Schema. */
+  export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+    Schema['~standard']['types']
+  >['output']
+
+  export {}
+}
+
+// --------------------------------------------------------
+// Standard Schema Factory
+// --------------------------------------------------------
+function Value<Value>(value: Value): StandardSchemaV1.SuccessResult<Value> {
   return { value }
 }
-// --------------------------------------------------------
-// TIssues
-// --------------------------------------------------------
-interface TIssues {
-  issues: object[]
-}
-function Issues(issues: object[]): TIssues {
-  return { issues }
+function Issues(issues: object[]): StandardSchemaV1.FailureResult {
+  // We cannot guarantee that the caller will pass an object with an
+  // error message, but it is generally implied. Additionally, we do
+  // not want StandardSchema interfaces proliferating throughout the
+  // codebase; they must remain contained within this module only.
+  return { issues } as never
 }
 // ------------------------------------------------------------------------------------
 // StandardValidatorV1
 // ------------------------------------------------------------------------------------
-class StandardValidatorV1<Value extends unknown = unknown> {
+class StandardValidatorV1<Value extends unknown = unknown> implements StandardSchemaV1.Props<Value> {
   public readonly vendor = 'typebox'
   public readonly version = 1
   constructor(
     private readonly check: (value: unknown) => boolean,
-    private readonly errors: (value: unknown) => object[],
-  ) { }
-  public readonly validate = (value: unknown): TResult<Value> => {
-    return (this.check(value)) ? Value(value as Value) : Issues(this.errors(value))
+    private readonly errors: (value: unknown) => object[]
+  ) {}
+  public readonly validate = (value: unknown): StandardSchemaV1.Result<Value> => {
+    return (this.check(value)) ? Value(value as Value) : Issues(this.errors(value)) as never
   }
 }
 // ------------------------------------------------------------------
 // BaseError
 // ------------------------------------------------------------------
 export class BaseNotImplemented extends Error {
-  constructor(type: Base, override: string) {
-    // @ts-ignore - options supported in deno, node, etc.
-    super(`Base type does not implement '${override}' function`, { cause: type })
+  declare readonly cause: { type: Base; method: string }
+  constructor(type: Base, method: string) {
+    super(`Base type does not implement the '${method}' function`)
+    Object.defineProperty(this, 'cause', {
+      value: { type, method },
+      writable: false,
+      configurable: false,
+      enumerable: false
+    })
   }
 }
 // ------------------------------------------------------------------
@@ -81,18 +142,18 @@ export class BaseNotImplemented extends Error {
 /** Base class for creating extension types. */
 export class Base<Value extends unknown = unknown> implements TSchema {
   public readonly '~kind': 'Base'
-  public readonly '~standard': StandardValidatorV1<Value>
+  public readonly '~standard': StandardSchemaV1.Props<Value>
   constructor() {
     const validator = new StandardValidatorV1(
-      value => this.Check(value),
-      value => this.Errors(value)
+      (value) => this.Check(value),
+      (value) => this.Errors(value)
     )
     const configuration = {
       writable: false,
       configurable: false,
       enumerable: false
     }
-    Object.defineProperty(this, '~kind', { ...configuration, value: 'Base', })
+    Object.defineProperty(this, '~kind', { ...configuration, value: 'Base' })
     Object.defineProperty(this, '~standard', { ...configuration, value: validator })
   }
   /** Checks a value or returns false if invalid */

--- a/tasks.ts
+++ b/tasks.ts
@@ -8,7 +8,7 @@ import { Range } from './task/range/index.ts'
 import { Metrics } from './task/metrics/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.0.16'
+const Version = '1.0.17'
 
 // ------------------------------------------------------------------
 // BuildPackage


### PR DESCRIPTION
This PR brings on Standard Schema interfaces to ensure Base and Validator types are compatible on Standard Schema interfaces. This replaces the self contained narrow form interfaces implemented for Base.

Note: XStandardSchemaV1 inference remained unchanged, and we view the specification via structural result only.

Fixes: https://github.com/sinclairzx81/typebox/issues/1365