### PR TITLE
Version 1.0.22

### DIFF
--- a/changelog/1.0.0.md
+++ b/changelog/1.0.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.0.22](https://github.com/sinclairzx81/typebox/pull/1374)
+  - Resolve Socket.Dev False Positive
 - [Revision 1.0.21](https://github.com/sinclairzx81/typebox/pull/1374)
   - Enable Trusted Publishing: No Functional Changes
 - [Revision 1.0.20](https://github.com/sinclairzx81/typebox/pull/1372)

--- a/changelog/1.0.0.md
+++ b/changelog/1.0.0.md
@@ -3,7 +3,7 @@
 ---
 
 ### Version Updates
-- [Revision 1.0.22](https://github.com/sinclairzx81/typebox/pull/1374)
+- [Revision 1.0.22](https://github.com/sinclairzx81/typebox/pull/1375)
   - Resolve Socket.Dev False Positive
 - [Revision 1.0.21](https://github.com/sinclairzx81/typebox/pull/1374)
   - Enable Trusted Publishing: No Functional Changes

--- a/src/type/engine/cyclic/extends.ts
+++ b/src/type/engine/cyclic/extends.ts
@@ -36,7 +36,7 @@ import { type TArray, Array, IsArray, ArrayOptions } from '../../types/array.ts'
 import { type TAsyncIterator, AsyncIterator, IsAsyncIterator } from '../../types/async-iterator.ts'
 import { type TConstructor, Constructor, IsConstructor } from '../../types/constructor.ts'
 import { type TCyclic } from '../../types/cyclic.ts'
-import { type TFunction, Function, IsFunction } from '../../types/function.ts'
+import { type TFunction, Function as _Function, IsFunction } from '../../types/function.ts'
 import { type TIntersect, Intersect, IsIntersect } from '../../types/intersect.ts'
 import { type TIterator, Iterator, IsIterator } from '../../types/iterator.ts'
 import { type TObject, Object, IsObject } from '../../types/object.ts'
@@ -106,7 +106,7 @@ function FromType<Type extends TSchema>(type: Type): TFromType<Type> {
     IsArray(type) ? Array(FromType(type.items), ArrayOptions(type)) :
     IsAsyncIterator(type) ? AsyncIterator(FromType(type.iteratorItems)) :
     IsConstructor(type) ? Constructor(FromTypes(type.parameters), FromType(type.instanceType)) :
-    IsFunction(type) ? Function(FromTypes(type.parameters), FromType(type.returnType)) :
+    IsFunction(type) ? _Function(FromTypes(type.parameters), FromType(type.returnType)) :
     IsIntersect(type) ? Intersect(FromTypes(type.allOf)) :
     IsIterator(type) ? Iterator(FromType(type.iteratorItems)) :
     IsObject(type) ? Object(FromProperties(type.properties)) :

--- a/src/type/engine/instantiate.ts
+++ b/src/type/engine/instantiate.ts
@@ -45,7 +45,7 @@ import { type TArray, Array, IsArray, ArrayOptions } from '../types/array.ts'
 import { type TAsyncIterator, AsyncIterator, IsAsyncIterator, AsyncIteratorOptions } from '../types/async-iterator.ts'
 import { type TConstructor, Constructor, IsConstructor, ConstructorOptions } from '../types/constructor.ts'
 import { type TDeferred, Deferred, IsDeferred } from '../types/deferred.ts'
-import { type TFunction, Function, IsFunction, FunctionOptions } from '../types/function.ts'
+import { type TFunction, Function as _Function, IsFunction, FunctionOptions } from '../types/function.ts'
 import { type TCall, IsCall } from '../types/call.ts'
 import { type TIdentifier } from '../types/identifier.ts'
 import { type TIntersect, Intersect, IsIntersect, IntersectOptions } from '../types/intersect.ts'
@@ -369,7 +369,7 @@ export function InstantiateType<Context extends TProperties, State extends TStat
     IsCall(type) ? CallInstantiate(context, state, type.target, type.arguments) :
     IsConstructor(type) ? Constructor(InstantiateTypes(context, state, type.parameters), InstantiateType(context, state, type.instanceType) as never, ConstructorOptions(type)) :
     IsDeferred(type) ? InstantiateDeferred(context, state, type.action, type.parameters, type.options) :
-    IsFunction(type) ? Function(InstantiateTypes(context, state, type.parameters), InstantiateType(context, state, type.returnType) as never, FunctionOptions(type)) :
+    IsFunction(type) ? _Function(InstantiateTypes(context, state, type.parameters), InstantiateType(context, state, type.returnType) as never, FunctionOptions(type)) :
     IsIntersect(type) ? Intersect(InstantiateTypes(context, state, type.allOf), IntersectOptions(type)) :
     IsIterator(type) ? Iterator(InstantiateType(context, state, type.iteratorItems), IteratorOptions(type)) :
     IsObject(type) ? Object(InstantiateProperties(context, state, type.properties), ObjectOptions(type)) :

--- a/tasks.ts
+++ b/tasks.ts
@@ -8,7 +8,7 @@ import { Range } from './task/range/index.ts'
 import { Metrics } from './task/metrics/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.0.21'
+const Version = '1.0.22'
 
 // ------------------------------------------------------------------
 // Build


### PR DESCRIPTION
This PR applies an update to prefix `TFunction` factory calls with a leading `_` to stop socket.dev confusing TypeBox inference logic with unsafe calls to `globalThis.Function`.

Applies to:

- src/type/engine/cyclic/extends.ts
- src/type/engine/instantiate.ts