### PR TITLE
Version 1.0.30

### DIFF
--- a/changelog/1.0.0.md
+++ b/changelog/1.0.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.0.30](https://github.com/sinclairzx81/typebox/pull/1386)
+  - Finalize Base Schema | Translations
 - [Revision 1.0.29](https://github.com/sinclairzx81/typebox/pull/1385)
   - TS 5.0.4: Add Explicit Guard for BaseValidator Callback
 - [Revision 1.0.28](https://github.com/sinclairzx81/typebox/pull/1383)

--- a/design/website/docs/type/base.md
+++ b/design/website/docs/type/base.md
@@ -29,13 +29,13 @@ Once created, the type can be used with TypeBox validators.
 const R = Value.Check(DateType(), new Date())      // const R = true
 
 const E = Value.Errors(DateType(), 'x')            // const E = [{
-                                                   //   keyword: "~base",
+                                                   //   keyword: "~guard",
                                                    //   schemaPath: "#",
                                                    //   instancePath: "",
                                                    //   params: { 
                                                    //     errors: [ { message: "not a Date" } ] 
                                                    //   },
-                                                   //   message: "must match against typebox schema"
+                                                   //   message: "must match check function"
                                                    // }]
 ```
 

--- a/docs/docs/type/base.html
+++ b/docs/docs/type/base.html
@@ -20,13 +20,13 @@ export function DateType(): TDateType {
 <pre><code class="language-typescript">const R = Value.Check(DateType(), new Date())      // const R = true
 
 const E = Value.Errors(DateType(), &#39;x&#39;)            // const E = [{
-                                                   //   keyword: &quot;~base&quot;,
+                                                   //   keyword: &quot;~guard&quot;,
                                                    //   schemaPath: &quot;#&quot;,
                                                    //   instancePath: &quot;&quot;,
                                                    //   params: { 
                                                    //     errors: [ { message: &quot;not a Date&quot; } ] 
                                                    //   },
-                                                   //   message: &quot;must match against typebox schema&quot;
+                                                   //   message: &quot;must match check function&quot;
                                                    // }]
 </code></pre>
 <h2>Guard</h2>

--- a/example/index.ts
+++ b/example/index.ts
@@ -4,50 +4,18 @@ import Schema from 'typebox/schema'
 import Value from 'typebox/value'
 import Type from 'typebox'
 
-// ------------------------------------------------------------------
-// Type
-// ------------------------------------------------------------------
-const T = Type.Object({
-  x: Type.Number(),
-  y: Type.Number(),
-  z: Type.Number()
+import Settings from 'typebox/system'
+
+//Settings.Settings.Set({ enumerableKind: true })
+
+class Fail extends Type.Base {
+  override Check(value: unknown): value is unknown {
+    return false
+  }
+}
+
+const A = Type.Object({
+  x: new Fail()
 })
 
-// ------------------------------------------------------------------
-// Script
-// ------------------------------------------------------------------
-const S = Type.Script({ T }, `{
-  [K in keyof T]: T[K] | null
-}`)
-
-// ------------------------------------------------------------------
-// Infer
-// ------------------------------------------------------------------
-type T = Type.Static<typeof T>
-type S = Type.Static<typeof S>
-
-// ------------------------------------------------------------------
-// Parse
-// ------------------------------------------------------------------
-
-const R = Value.Parse(T, { x: 1, y: 2, z: 3 })
-
-// ------------------------------------------------------------------
-// Compile
-// ------------------------------------------------------------------
-
-const C = Compile(S)
-
-const X = C.Parse({ x: 1, y: 2, z: 3 })
-
-// ------------------------------------------------------------------
-// Format
-// ------------------------------------------------------------------
-
-const E = Format.IsEmail('user@domain.com')
-
-// ------------------------------------------------------------------
-// Schema
-// ------------------------------------------------------------------
-
-const D = Schema.Check({ type: 'string' }, 'hello')
+console.log(Value.Errors(A, { x: 1 }))

--- a/example/index.ts
+++ b/example/index.ts
@@ -4,18 +4,50 @@ import Schema from 'typebox/schema'
 import Value from 'typebox/value'
 import Type from 'typebox'
 
-import Settings from 'typebox/system'
-
-//Settings.Settings.Set({ enumerableKind: true })
-
-class Fail extends Type.Base {
-  override Check(value: unknown): value is unknown {
-    return false
-  }
-}
-
-const A = Type.Object({
-  x: new Fail()
+// ------------------------------------------------------------------
+// Type
+// ------------------------------------------------------------------
+const T = Type.Object({
+  x: Type.Number(),
+  y: Type.Number(),
+  z: Type.Number()
 })
 
-console.log(Value.Errors(A, { x: 1 }))
+// ------------------------------------------------------------------
+// Script
+// ------------------------------------------------------------------
+const S = Type.Script({ T }, `{
+  [K in keyof T]: T[K] | null
+}`)
+
+// ------------------------------------------------------------------
+// Infer
+// ------------------------------------------------------------------
+type T = Type.Static<typeof T>
+type S = Type.Static<typeof S>
+
+// ------------------------------------------------------------------
+// Parse
+// ------------------------------------------------------------------
+
+const R = Value.Parse(T, { x: 1, y: 2, z: 3 })
+
+// ------------------------------------------------------------------
+// Compile
+// ------------------------------------------------------------------
+
+const C = Compile(S)
+
+const X = C.Parse({ x: 1, y: 2, z: 3 })
+
+// ------------------------------------------------------------------
+// Format
+// ------------------------------------------------------------------
+
+const E = Format.IsEmail('user@domain.com')
+
+// ------------------------------------------------------------------
+// Schema
+// ------------------------------------------------------------------
+
+const D = Schema.Check({ type: 'string' }, 'hello')

--- a/src/error/errors.ts
+++ b/src/error/errors.ts
@@ -119,7 +119,7 @@ export interface TAnyOfError extends TValidationErrorBase {
 // Base
 // ------------------------------------------------------------------
 export interface TBaseError extends TValidationErrorBase {
-  keyword: '~base'
+  keyword: '~guard'
   params: { errors: object[] }
 }
 // ------------------------------------------------------------------

--- a/src/schema/engine/_refine.ts
+++ b/src/schema/engine/_refine.ts
@@ -38,20 +38,20 @@ import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 // ------------------------------------------------------------------
 export function BuildRefine(context: BuildContext, schema: S.XRefine, value: string): string {
   const refinements = V.CreateExternalVariable(schema['~refine'].map((refinement) => refinement))
-  return E.Every(refinements, E.Constant(0), ['refinement', '_'], E.Call(E.Member('refinement', 'callback'), [value]))
+  return E.Every(refinements, E.Constant(0), ['refinement', '_'], E.Call(E.Member('refinement', 'refine'), [value]))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
 export function CheckRefine(context: CheckContext, schema: S.XRefine, value: unknown): boolean {
-  return G.Every(schema['~refine'], 0, (refinement, _) => refinement.callback(value))
+  return G.Every(schema['~refine'], 0, (refinement, _) => refinement.refine(value))
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
 export function ErrorRefine(context: ErrorContext, schemaPath: string, instancePath: string, schema: S.XRefine, value: unknown): boolean {
   return G.EveryAll(schema['~refine'], 0, (refinement, index) => {
-    return refinement.callback(value) || context.AddError({
+    return refinement.refine(value) || context.AddError({
       keyword: '~refine',
       schemaPath,
       instancePath,

--- a/src/schema/engine/index.ts
+++ b/src/schema/engine/index.ts
@@ -37,7 +37,7 @@ export * from './_externals.ts'
 // ------------------------------------------------------------------
 // Schematics
 // ------------------------------------------------------------------
-export * from './_base.ts'
+export * from './_guard.ts'
 export * from './_refine.ts'
 
 export * from './additionalProperties.ts'

--- a/src/schema/engine/schema.ts
+++ b/src/schema/engine/schema.ts
@@ -33,7 +33,7 @@ import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { BuildRefine, CheckRefine, ErrorRefine } from './_refine.ts'
-import { BuildBase, CheckBase, ErrorBase } from './_base.ts'
+import { BuildGuard, CheckGuard, ErrorGuard } from './_guard.ts'
 
 import { BuildAdditionalItems, CheckAdditionalItems, ErrorAdditionalItems } from './additionalItems.ts'
 import { BuildAdditionalProperties, CheckAdditionalProperties, ErrorAdditionalProperties } from './additionalProperties.ts'
@@ -214,7 +214,7 @@ export function BuildSchema(context: BuildContext, schema: S.XSchemaLike, value:
     conditions.push(HasNumberType(schema) ? reduced : guarded)
   }
   if (S.IsRef(schema)) conditions.push(BuildRef(context, schema, value))
-  if (S.IsBase(schema)) conditions.push(BuildBase(context, schema, value))
+  if (S.IsGuard(schema)) conditions.push(BuildGuard(context, schema, value))
   if (S.IsConst(schema)) conditions.push(BuildConst(context, schema, value))
   if (S.IsEnum(schema)) conditions.push(BuildEnum(context, schema, value))
   if (S.IsIf(schema)) conditions.push(BuildIf(context, schema, value))
@@ -270,7 +270,7 @@ export function CheckSchema(context: CheckContext, schema: S.XSchemaLike, value:
       (!S.IsMultipleOf(schema) || CheckMultipleOf(context, schema, value))
     )) &&
     (!S.IsRef(schema) || CheckRef(context, schema, value)) &&
-    (!S.IsBase(schema) || CheckBase(context, schema, value)) &&
+    (!S.IsGuard(schema) || CheckGuard(context, schema, value)) &&
     (!S.IsConst(schema) || CheckConst(context, schema, value)) &&
     (!S.IsEnum(schema) || CheckEnum(context, schema, value)) &&
     (!S.IsIf(schema) || CheckIf(context, schema, value)) &&
@@ -327,7 +327,7 @@ export function ErrorSchema(context: ErrorContext, schemaPath: string, instanceP
         +(!S.IsMultipleOf(schema) || ErrorMultipleOf(context, schemaPath, instancePath, schema, value))
       )) &
       +(!S.IsRef(schema) || ErrorRef(context, schemaPath, instancePath, schema, value)) &
-      +(!S.IsBase(schema) || ErrorBase(context, schemaPath, instancePath, schema, value)) &
+      +(!S.IsGuard(schema) || ErrorGuard(context, schemaPath, instancePath, schema, value)) &
       +(!S.IsConst(schema) || ErrorConst(context, schemaPath, instancePath, schema, value)) &
       +(!S.IsEnum(schema) || ErrorEnum(context, schemaPath, instancePath, schema, value)) &
       +(!S.IsIf(schema) || ErrorIf(context, schemaPath, instancePath, schema, value)) &

--- a/src/schema/types/_guard.ts
+++ b/src/schema/types/_guard.ts
@@ -28,31 +28,30 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import * as S from '../types/index.ts'
-import * as V from './_externals.ts'
-import { EmitGuard as E } from '../../guard/index.ts'
-import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
+import { Guard } from '../../guard/index.ts'
+import type { XSchema } from './schema.ts'
 
 // ------------------------------------------------------------------
-// Build
+// Type
 // ------------------------------------------------------------------
-export function BuildBase(context: BuildContext, schema: S.XBase, value: string): string {
-  return E.Call(E.Member(E.Member(V.CreateExternalVariable(schema), '~base'), 'check'), [value])
+export interface XGuardInterface<Value extends unknown = unknown> {
+  check(value: unknown): value is Value
+  errors(value: unknown): object[]
+}
+export interface XGuard<Value extends unknown = unknown> {
+  '~guard': XGuardInterface<Value>
 }
 // ------------------------------------------------------------------
-// Check
+// Guard
 // ------------------------------------------------------------------
-export function CheckBase(context: CheckContext, schema: S.XBase, value: unknown): boolean {
-  return schema['~base'].check(value)
+export function IsGuardInterface(value: unknown): value is XGuardInterface {
+  return Guard.IsObject(value)
+    && Guard.HasPropertyKey(value, 'check')
+    && Guard.HasPropertyKey(value, 'errors')
+    && Guard.IsFunction(value.check)
+    && Guard.IsFunction(value.errors)
 }
-// ------------------------------------------------------------------
-// Error
-// ------------------------------------------------------------------
-export function ErrorBase(context: ErrorContext, schemaPath: string, instancePath: string, schema: S.XBase, value: unknown): boolean {
-  return schema['~base'].check(value) || context.AddError({
-    keyword: '~base',
-    schemaPath,
-    instancePath,
-    params: { errors: schema['~base'].errors(value) },
-  })
+export function IsGuard(value: XSchema): value is XGuard {
+  return Guard.HasPropertyKey(value, '~guard')
+    && IsGuardInterface(value['~guard'])
 }

--- a/src/schema/types/_refine.ts
+++ b/src/schema/types/_refine.ts
@@ -35,7 +35,7 @@ import type { XSchema } from './schema.ts'
 // Type
 // ------------------------------------------------------------------
 export interface XRefinement {
-  callback: (value: unknown) => boolean
+  refine: (value: unknown) => boolean
   message: string
 }
 export interface XRefine<Refinements extends XRefinement[] = XRefinement[]> {
@@ -52,9 +52,9 @@ export function IsRefine(value: XSchema): value is XRefine {
   return Guard.HasPropertyKey(value, '~refine')
     && Guard.IsArray(value["~refine"])
     && Guard.Every(value['~refine'], 0, value => Guard.IsObject(value)
-      && Guard.HasPropertyKey(value, 'callback')
+      && Guard.HasPropertyKey(value, 'refine')
       && Guard.HasPropertyKey(value, 'message')
-      && Guard.IsFunction(value.callback)
+      && Guard.IsFunction(value.refine)
       && Guard.IsString(value.message)
     )
 }

--- a/src/schema/types/index.ts
+++ b/src/schema/types/index.ts
@@ -30,7 +30,7 @@ THE SOFTWARE.
 // Extensions
 // ------------------------------------------------------------------
 export * from './_refine.ts'
-export * from './_base.ts'
+export * from './_guard.ts'
 
 // ------------------------------------------------------------------
 // Standard

--- a/src/schema/types/static.ts
+++ b/src/schema/types/static.ts
@@ -28,7 +28,7 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import type { XBase } from './_base.ts'
+import type { XGuard } from './_guard.ts'
 import type { XSchemaLike } from './schema.ts'
 import type { XAdditionalProperties } from './additionalProperties.ts'
 import type { XAnyOf } from './anyOf.ts'
@@ -208,7 +208,7 @@ type XStaticJsonSchema<Schema extends unknown,
 // ------------------------------------------------------------------
 /** Statically infers a JSON Schema or Validator */
 export type XStaticType<Schema extends XSchemaLike, Result extends unknown = (
-  Schema extends XBase<infer Value> ? Value : XStaticJsonSchema<Schema>
+  Schema extends XGuard<infer Value> ? Value : XStaticJsonSchema<Schema>
 )> = Result
 // ------------------------------------------------------------------
 // XStaticMutable: Preflight
@@ -225,7 +225,7 @@ type XStaticMutableObject<Schema extends object, Result extends Record<PropertyK
   -readonly [K in keyof Schema]: XStaticMutable<Schema[K]>
 }> = Result
 type XStaticMutable<Schema> = (
-  Schema extends XBase ? Schema :
+  Schema extends XGuard ? Schema :
   Schema extends readonly [...infer Schemas extends unknown[]] ? XStaticMutableTuple<Schemas> :
   Schema extends readonly (infer Schema)[] ? XStaticMutableArray<Schema> :
   Schema extends object ? XStaticMutableObject<Schema> :

--- a/src/system/locale/ar_001.ts
+++ b/src/system/locale/ar_001.ts
@@ -64,8 +64,8 @@ export function ar_001(error: TValidationError): string {
     case 'unevaluatedItems': return 'يجب ألا يحتوي على عناصر غير مقيمة'
     case 'unevaluatedProperties': return 'يجب ألا يحتوي على خصائص غير مقيمة'
     case 'uniqueItems': return `يجب ألا يحتوي على عناصر مكررة`
+    case '~guard': return `يجب أن يتطابق مع دالة الفحص`
     case '~refine': return error.params.message
-    case '~guard': return `يجب أن يتطابق مع مخطط ${'Base'}`
     default: return 'حدث خطأ غير معروف في التحقق من الصحة'
   }
 }

--- a/src/system/locale/ar_001.ts
+++ b/src/system/locale/ar_001.ts
@@ -65,7 +65,7 @@ export function ar_001(error: TValidationError): string {
     case 'unevaluatedProperties': return 'يجب ألا يحتوي على خصائص غير مقيمة'
     case 'uniqueItems': return `يجب ألا يحتوي على عناصر مكررة`
     case '~refine': return error.params.message
-    case '~base': return `يجب أن يتطابق مع مخطط ${'Base'}`
+    case '~guard': return `يجب أن يتطابق مع مخطط ${'Base'}`
     default: return 'حدث خطأ غير معروف في التحقق من الصحة'
   }
 }

--- a/src/system/locale/bn_BD.ts
+++ b/src/system/locale/bn_BD.ts
@@ -65,7 +65,7 @@ export function bn_BD(error: TValidationError): string {
     case 'unevaluatedProperties': return 'অবমূল্যায়িত বৈশিষ্ট্য থাকতে পারবে না'
     case 'uniqueItems': return `অনুলিপি আইটেম থাকতে পারবে না`
     case '~refine': return error.params.message
-    case '~base': return `${'Base'} স্কিমার সাথে মিলতে হবে`
+    case '~guard': return `${'Base'} স্কিমার সাথে মিলতে হবে`
     default: return 'একটি অজানা বৈধকরণ ত্রুটি ঘটেছে'
   }
 }

--- a/src/system/locale/bn_BD.ts
+++ b/src/system/locale/bn_BD.ts
@@ -64,8 +64,8 @@ export function bn_BD(error: TValidationError): string {
     case 'unevaluatedItems': return 'অবমূল্যায়িত আইটেম থাকতে পারবে না'
     case 'unevaluatedProperties': return 'অবমূল্যায়িত বৈশিষ্ট্য থাকতে পারবে না'
     case 'uniqueItems': return `অনুলিপি আইটেম থাকতে পারবে না`
+    case '~guard': return `চেক ফাংশনের সাথে মেলাতে হবে`
     case '~refine': return error.params.message
-    case '~guard': return `${'Base'} স্কিমার সাথে মিলতে হবে`
     default: return 'একটি অজানা বৈধকরণ ত্রুটি ঘটেছে'
   }
 }

--- a/src/system/locale/cs_CZ.ts
+++ b/src/system/locale/cs_CZ.ts
@@ -65,7 +65,7 @@ export function cs_CZ(error: TValidationError): string {
     case 'unevaluatedProperties': return 'nesmí mít nevyhodnocené vlastnosti'
     case 'uniqueItems': return `nesmí mít duplicitní položky`
     case '~refine': return error.params.message
-    case '~base': return `musí odpovídat schématu ${'Base'}`
+    case '~guard': return `musí odpovídat schématu ${'Base'}`
     default: return 'došlo k neznámé chybě ověření'
   }
 }

--- a/src/system/locale/cs_CZ.ts
+++ b/src/system/locale/cs_CZ.ts
@@ -64,8 +64,8 @@ export function cs_CZ(error: TValidationError): string {
     case 'unevaluatedItems': return 'nesmí mít nevyhodnocené položky'
     case 'unevaluatedProperties': return 'nesmí mít nevyhodnocené vlastnosti'
     case 'uniqueItems': return `nesmí mít duplicitní položky`
+    case '~guard': return `musí odpovídat kontrolní funkci`
     case '~refine': return error.params.message
-    case '~guard': return `musí odpovídat schématu ${'Base'}`
     default: return 'došlo k neznámé chybě ověření'
   }
 }

--- a/src/system/locale/de_DE.ts
+++ b/src/system/locale/de_DE.ts
@@ -65,7 +65,7 @@ export function de_DE(error: TValidationError): string {
     case 'unevaluatedProperties': return 'darf keine unbewerteten Eigenschaften haben'
     case 'uniqueItems': return `darf keine doppelten Elemente haben`
     case '~refine': return error.params.message
-    case '~base': return `muss mit dem ${'Base'}-Schema übereinstimmen`
+    case '~guard': return `muss mit dem ${'Base'}-Schema übereinstimmen`
     default: return 'ein unbekannter Validierungsfehler ist aufgetreten'
   }
 }

--- a/src/system/locale/de_DE.ts
+++ b/src/system/locale/de_DE.ts
@@ -64,8 +64,8 @@ export function de_DE(error: TValidationError): string {
     case 'unevaluatedItems': return 'darf keine unbewerteten Elemente haben'
     case 'unevaluatedProperties': return 'darf keine unbewerteten Eigenschaften haben'
     case 'uniqueItems': return `darf keine doppelten Elemente haben`
+    case '~guard': return `muss der Prüffunktion entsprechen`
     case '~refine': return error.params.message
-    case '~guard': return `muss mit dem ${'Base'}-Schema übereinstimmen`
     default: return 'ein unbekannter Validierungsfehler ist aufgetreten'
   }
 }

--- a/src/system/locale/el_GR.ts
+++ b/src/system/locale/el_GR.ts
@@ -64,8 +64,8 @@ export function el_GR(error: TValidationError): string {
     case 'unevaluatedItems': return 'δεν πρέπει να έχει μη αξιολογημένα στοιχεία'
     case 'unevaluatedProperties': return 'δεν πρέπει να έχει μη αξιολογημένες ιδιότητες'
     case 'uniqueItems': return `δεν πρέπει να έχει διπλά στοιχεία`
+    case '~guard': return `πρέπει να αντιστοιχεί στη συνάρτηση ελέγχου`
     case '~refine': return error.params.message
-    case '~guard': return `πρέπει να ταιριάζει με το σχήμα ${'Base'}`
     default: return 'προέκυψε ένα άγνωστο σφάλμα επικύρωσης'
   }
 }

--- a/src/system/locale/el_GR.ts
+++ b/src/system/locale/el_GR.ts
@@ -65,7 +65,7 @@ export function el_GR(error: TValidationError): string {
     case 'unevaluatedProperties': return 'δεν πρέπει να έχει μη αξιολογημένες ιδιότητες'
     case 'uniqueItems': return `δεν πρέπει να έχει διπλά στοιχεία`
     case '~refine': return error.params.message
-    case '~base': return `πρέπει να ταιριάζει με το σχήμα ${'Base'}`
+    case '~guard': return `πρέπει να ταιριάζει με το σχήμα ${'Base'}`
     default: return 'προέκυψε ένα άγνωστο σφάλμα επικύρωσης'
   }
 }

--- a/src/system/locale/en_US.ts
+++ b/src/system/locale/en_US.ts
@@ -63,8 +63,8 @@ export function en_US(error: TValidationError): string {
     case 'unevaluatedItems': return 'must not have unevaluated items'
     case 'unevaluatedProperties': return 'must not have unevaluated properties'
     case 'uniqueItems': return `must not have duplicate items`
+    case '~guard': return `must match check function`
     case '~refine': return error.params.message
-    case '~guard': return `must match guard logic`
     // deno-coverage-ignore - unreachable
     default: return 'an unknown validation error occurred'
   }

--- a/src/system/locale/en_US.ts
+++ b/src/system/locale/en_US.ts
@@ -64,7 +64,7 @@ export function en_US(error: TValidationError): string {
     case 'unevaluatedProperties': return 'must not have unevaluated properties'
     case 'uniqueItems': return `must not have duplicate items`
     case '~refine': return error.params.message
-    case '~base': return `must match against ${'Base'} schema`
+    case '~guard': return `must match guard logic`
     // deno-coverage-ignore - unreachable
     default: return 'an unknown validation error occurred'
   }

--- a/src/system/locale/es_419.ts
+++ b/src/system/locale/es_419.ts
@@ -64,8 +64,8 @@ export function es_419(error: TValidationError): string {
     case 'unevaluatedItems': return 'no debe tener elementos no evaluados'
     case 'unevaluatedProperties': return 'no debe tener propiedades no evaluadas'
     case 'uniqueItems': return `no debe tener elementos duplicados`
+    case '~guard': return `debe coincidir con la función de verificación`
     case '~refine': return error.params.message
-    case '~guard': return `debe coincidir con el esquema de ${'Base'}`
     default: return 'ocurrió un error de validación desconocido'
   }
 }

--- a/src/system/locale/es_419.ts
+++ b/src/system/locale/es_419.ts
@@ -65,7 +65,7 @@ export function es_419(error: TValidationError): string {
     case 'unevaluatedProperties': return 'no debe tener propiedades no evaluadas'
     case 'uniqueItems': return `no debe tener elementos duplicados`
     case '~refine': return error.params.message
-    case '~base': return `debe coincidir con el esquema de ${'Base'}`
+    case '~guard': return `debe coincidir con el esquema de ${'Base'}`
     default: return 'ocurrió un error de validación desconocido'
   }
 }

--- a/src/system/locale/es_AR.ts
+++ b/src/system/locale/es_AR.ts
@@ -65,7 +65,7 @@ export function es_AR(error: TValidationError): string {
     case 'unevaluatedProperties': return 'no debe tener propiedades no evaluadas'
     case 'uniqueItems': return `no debe tener elementos duplicados`
     case '~refine': return error.params.message
-    case '~base': return `debe coincidir con el esquema de ${'Base'}`
+    case '~guard': return `debe coincidir con el esquema de ${'Base'}`
     default: return 'ocurrió un error de validación desconocido'
   }
 }

--- a/src/system/locale/es_AR.ts
+++ b/src/system/locale/es_AR.ts
@@ -64,8 +64,8 @@ export function es_AR(error: TValidationError): string {
     case 'unevaluatedItems': return 'no debe tener elementos no evaluados'
     case 'unevaluatedProperties': return 'no debe tener propiedades no evaluadas'
     case 'uniqueItems': return `no debe tener elementos duplicados`
+    case '~guard': return `debe coincidir con la función de verificación`
     case '~refine': return error.params.message
-    case '~guard': return `debe coincidir con el esquema de ${'Base'}`
     default: return 'ocurrió un error de validación desconocido'
   }
 }

--- a/src/system/locale/es_ES.ts
+++ b/src/system/locale/es_ES.ts
@@ -65,7 +65,7 @@ export function es_ES(error: TValidationError): string {
     case 'unevaluatedProperties': return 'no debe tener propiedades no evaluadas'
     case 'uniqueItems': return `no debe tener elementos duplicados`
     case '~refine': return error.params.message
-    case '~base': return `debe coincidir con el esquema de ${'Base'}`
+    case '~guard': return `debe coincidir con el esquema de ${'Base'}`
     default: return 'ha ocurrido un error de validación desconocido'
   }
 }

--- a/src/system/locale/es_ES.ts
+++ b/src/system/locale/es_ES.ts
@@ -64,8 +64,8 @@ export function es_ES(error: TValidationError): string {
     case 'unevaluatedItems': return 'no debe tener elementos no evaluados'
     case 'unevaluatedProperties': return 'no debe tener propiedades no evaluadas'
     case 'uniqueItems': return `no debe tener elementos duplicados`
+    case '~guard': return `debe coincidir con la función de verificación`
     case '~refine': return error.params.message
-    case '~guard': return `debe coincidir con el esquema de ${'Base'}`
     default: return 'ha ocurrido un error de validación desconocido'
   }
 }

--- a/src/system/locale/es_MX.ts
+++ b/src/system/locale/es_MX.ts
@@ -65,7 +65,7 @@ export function es_MX(error: TValidationError): string {
     case 'unevaluatedProperties': return 'no debe tener propiedades no evaluadas'
     case 'uniqueItems': return `no debe tener elementos duplicados`
     case '~refine': return error.params.message
-    case '~base': return `debe coincidir con el esquema de ${'Base'}`
+    case '~guard': return `debe coincidir con el esquema de ${'Base'}`
     default: return 'ocurrió un error de validación desconocido'
   }
 }

--- a/src/system/locale/es_MX.ts
+++ b/src/system/locale/es_MX.ts
@@ -64,8 +64,8 @@ export function es_MX(error: TValidationError): string {
     case 'unevaluatedItems': return 'no debe tener elementos no evaluados'
     case 'unevaluatedProperties': return 'no debe tener propiedades no evaluadas'
     case 'uniqueItems': return `no debe tener elementos duplicados`
+    case '~guard': return `debe coincidir con la función de verificación`
     case '~refine': return error.params.message
-    case '~guard': return `debe coincidir con el esquema de ${'Base'}`
     default: return 'ocurrió un error de validación desconocido'
   }
 }

--- a/src/system/locale/fa_IR.ts
+++ b/src/system/locale/fa_IR.ts
@@ -64,8 +64,8 @@ export function fa_IR(error: TValidationError): string {
     case 'unevaluatedItems': return 'نباید آیتم‌های ارزیابی نشده داشته باشد'
     case 'unevaluatedProperties': return 'نباید ویژگی‌های ارزیابی نشده داشته باشد'
     case 'uniqueItems': return `نباید آیتم‌های تکراری داشته باشد`
+    case '~guard': return `باید با تابع بررسی مطابقت داشته باشد`
     case '~refine': return error.params.message
-    case '~guard': return `باید با طرح‌واره ${'Base'} مطابقت داشته باشد`
     default: return 'یک خطای اعتبارسنجی ناشناخته رخ داده است'
   }
 }

--- a/src/system/locale/fa_IR.ts
+++ b/src/system/locale/fa_IR.ts
@@ -65,7 +65,7 @@ export function fa_IR(error: TValidationError): string {
     case 'unevaluatedProperties': return 'نباید ویژگی‌های ارزیابی نشده داشته باشد'
     case 'uniqueItems': return `نباید آیتم‌های تکراری داشته باشد`
     case '~refine': return error.params.message
-    case '~base': return `باید با طرح‌واره ${'Base'} مطابقت داشته باشد`
+    case '~guard': return `باید با طرح‌واره ${'Base'} مطابقت داشته باشد`
     default: return 'یک خطای اعتبارسنجی ناشناخته رخ داده است'
   }
 }

--- a/src/system/locale/fil_PH.ts
+++ b/src/system/locale/fil_PH.ts
@@ -65,7 +65,7 @@ export function fil_PH(error: TValidationError): string {
     case 'unevaluatedProperties': return 'hindi dapat magkaroon ng mga hindi pa nasusuring katangian'
     case 'uniqueItems': return `hindi dapat magkaroon ng mga duplicate na item`
     case '~refine': return error.params.message
-    case '~base': return `dapat tumugma laban sa ${'Base'} schema`
+    case '~guard': return `dapat tumugma laban sa ${'Base'} schema`
     default: return 'nagkaroon ng hindi kilalang error sa pagpapatunay'
   }
 }

--- a/src/system/locale/fil_PH.ts
+++ b/src/system/locale/fil_PH.ts
@@ -64,8 +64,8 @@ export function fil_PH(error: TValidationError): string {
     case 'unevaluatedItems': return 'hindi dapat magkaroon ng mga hindi pa nasusuring item'
     case 'unevaluatedProperties': return 'hindi dapat magkaroon ng mga hindi pa nasusuring katangian'
     case 'uniqueItems': return `hindi dapat magkaroon ng mga duplicate na item`
+    case '~guard': return `dapat tumugma sa function ng pagsusuri`
     case '~refine': return error.params.message
-    case '~guard': return `dapat tumugma laban sa ${'Base'} schema`
     default: return 'nagkaroon ng hindi kilalang error sa pagpapatunay'
   }
 }

--- a/src/system/locale/fr_CA.ts
+++ b/src/system/locale/fr_CA.ts
@@ -64,8 +64,8 @@ export function fr_CA(error: TValidationError): string {
     case 'unevaluatedItems': return 'ne doit pas avoir d\'éléments non évalués'
     case 'unevaluatedProperties': return 'ne doit pas avoir de propriétés non évaluées'
     case 'uniqueItems': return `ne doit pas avoir d'éléments en double`
+    case '~guard': return `doit correspondre à la fonction de vérification`
     case '~refine': return error.params.message
-    case '~guard': return `doit correspondre au schéma ${'Base'}`
     default: return 'une erreur de validation inconnue est survenue'
   }
 }

--- a/src/system/locale/fr_CA.ts
+++ b/src/system/locale/fr_CA.ts
@@ -65,7 +65,7 @@ export function fr_CA(error: TValidationError): string {
     case 'unevaluatedProperties': return 'ne doit pas avoir de propriétés non évaluées'
     case 'uniqueItems': return `ne doit pas avoir d'éléments en double`
     case '~refine': return error.params.message
-    case '~base': return `doit correspondre au schéma ${'Base'}`
+    case '~guard': return `doit correspondre au schéma ${'Base'}`
     default: return 'une erreur de validation inconnue est survenue'
   }
 }

--- a/src/system/locale/fr_FR.ts
+++ b/src/system/locale/fr_FR.ts
@@ -65,7 +65,7 @@ export function fr_FR(error: TValidationError): string {
     case 'unevaluatedProperties': return 'ne doit pas avoir de propriétés non évaluées'
     case 'uniqueItems': return `ne doit pas avoir d'éléments en double`
     case '~refine': return error.params.message
-    case '~base': return `doit correspondre au schéma ${'Base'}`
+    case '~guard': return `doit correspondre au schéma ${'Base'}`
     default: return 'une erreur de validation inconnue est survenue'
   }
 }

--- a/src/system/locale/fr_FR.ts
+++ b/src/system/locale/fr_FR.ts
@@ -64,8 +64,8 @@ export function fr_FR(error: TValidationError): string {
     case 'unevaluatedItems': return 'ne doit pas avoir d\'éléments non évalués'
     case 'unevaluatedProperties': return 'ne doit pas avoir de propriétés non évaluées'
     case 'uniqueItems': return `ne doit pas avoir d'éléments en double`
+    case '~guard': return `doit correspondre à la fonction de vérification`
     case '~refine': return error.params.message
-    case '~guard': return `doit correspondre au schéma ${'Base'}`
     default: return 'une erreur de validation inconnue est survenue'
   }
 }

--- a/src/system/locale/ha_NG.ts
+++ b/src/system/locale/ha_NG.ts
@@ -65,7 +65,7 @@ export function ha_NG(error: TValidationError): string {
     case 'unevaluatedProperties': return 'kada ya kasance yana da kaddarorin da ba a kimanta su ba'
     case 'uniqueItems': return `kada ya kasance yana da abubuwan da suka yi kama`
     case '~refine': return error.params.message
-    case '~base': return `dole ne ya dace da tsarin ${'Base'}`
+    case '~guard': return `dole ne ya dace da tsarin ${'Base'}`
     default: return 'an sami kuskuren tabbatarwa da ba a sani ba'
   }
 }

--- a/src/system/locale/ha_NG.ts
+++ b/src/system/locale/ha_NG.ts
@@ -64,8 +64,8 @@ export function ha_NG(error: TValidationError): string {
     case 'unevaluatedItems': return 'kada ya kasance yana da abubuwan da ba a kimanta su ba'
     case 'unevaluatedProperties': return 'kada ya kasance yana da kaddarorin da ba a kimanta su ba'
     case 'uniqueItems': return `kada ya kasance yana da abubuwan da suka yi kama`
+    case '~guard': return `dole ne ya dace da aikin duba`
     case '~refine': return error.params.message
-    case '~guard': return `dole ne ya dace da tsarin ${'Base'}`
     default: return 'an sami kuskuren tabbatarwa da ba a sani ba'
   }
 }

--- a/src/system/locale/hi_IN.ts
+++ b/src/system/locale/hi_IN.ts
@@ -65,7 +65,7 @@ export function hi_IN(error: TValidationError): string {
     case 'unevaluatedProperties': return 'में अप्रयुक्त गुण नहीं होने चाहिए'
     case 'uniqueItems': return `में डुप्लिकेट आइटम नहीं होने चाहिए`
     case '~refine': return error.params.message
-    case '~base': return `${'Base'} स्कीमा के विरुद्ध मेल खाना चाहिए`
+    case '~guard': return `${'Base'} स्कीमा के विरुद्ध मेल खाना चाहिए`
     default: return 'एक अज्ञात सत्यापन त्रुटि हुई'
   }
 }

--- a/src/system/locale/hi_IN.ts
+++ b/src/system/locale/hi_IN.ts
@@ -64,8 +64,8 @@ export function hi_IN(error: TValidationError): string {
     case 'unevaluatedItems': return 'में अप्रयुक्त आइटम नहीं होने चाहिए'
     case 'unevaluatedProperties': return 'में अप्रयुक्त गुण नहीं होने चाहिए'
     case 'uniqueItems': return `में डुप्लिकेट आइटम नहीं होने चाहिए`
+    case '~guard': return `चेक फ़ंक्शन से मेल खाना चाहिए`
     case '~refine': return error.params.message
-    case '~guard': return `${'Base'} स्कीमा के विरुद्ध मेल खाना चाहिए`
     default: return 'एक अज्ञात सत्यापन त्रुटि हुई'
   }
 }

--- a/src/system/locale/hu_HU.ts
+++ b/src/system/locale/hu_HU.ts
@@ -66,7 +66,7 @@ export function hu_HU(error: TValidationError): string {
     case 'unevaluatedProperties': return 'nem lehetnek nem értékelt tulajdonságai'
     case 'uniqueItems': return `nem lehetnek ismétlődő elemei`
     case '~refine': return error.params.message
-    case '~base': return `meg kell egyeznie a(z) ${'Base'} sémával`
+    case '~guard': return `meg kell egyeznie a(z) ${'Base'} sémával`
     default: return 'ismeretlen validációs hiba történt'
   }
 }

--- a/src/system/locale/hu_HU.ts
+++ b/src/system/locale/hu_HU.ts
@@ -65,8 +65,8 @@ export function hu_HU(error: TValidationError): string {
     case 'unevaluatedItems': return 'nem lehetnek nem értékelt elemei'
     case 'unevaluatedProperties': return 'nem lehetnek nem értékelt tulajdonságai'
     case 'uniqueItems': return `nem lehetnek ismétlődő elemei`
+    case '~guard': return `meg kell felelnie az ellenőrző függvénynek`
     case '~refine': return error.params.message
-    case '~guard': return `meg kell egyeznie a(z) ${'Base'} sémával`
     default: return 'ismeretlen validációs hiba történt'
   }
 }

--- a/src/system/locale/id_ID.ts
+++ b/src/system/locale/id_ID.ts
@@ -64,8 +64,8 @@ export function id_ID(error: TValidationError): string {
     case 'unevaluatedItems': return 'tidak boleh memiliki item yang belum dievaluasi'
     case 'unevaluatedProperties': return 'tidak boleh memiliki properti yang belum dievaluasi'
     case 'uniqueItems': return `tidak boleh memiliki item duplikat`
+    case '~guard': return `harus sesuai dengan fungsi pemeriksaan`
     case '~refine': return error.params.message
-    case '~guard': return `harus cocok dengan skema ${'Base'}`
     default: return 'terjadi kesalahan validasi yang tidak diketahui'
   }
 }

--- a/src/system/locale/id_ID.ts
+++ b/src/system/locale/id_ID.ts
@@ -65,7 +65,7 @@ export function id_ID(error: TValidationError): string {
     case 'unevaluatedProperties': return 'tidak boleh memiliki properti yang belum dievaluasi'
     case 'uniqueItems': return `tidak boleh memiliki item duplikat`
     case '~refine': return error.params.message
-    case '~base': return `harus cocok dengan skema ${'Base'}`
+    case '~guard': return `harus cocok dengan skema ${'Base'}`
     default: return 'terjadi kesalahan validasi yang tidak diketahui'
   }
 }

--- a/src/system/locale/it_IT.ts
+++ b/src/system/locale/it_IT.ts
@@ -65,7 +65,7 @@ export function it_IT(error: TValidationError): string {
     case 'unevaluatedProperties': return 'non deve avere proprietà non valutate'
     case 'uniqueItems': return `non deve avere elementi duplicati`
     case '~refine': return error.params.message
-    case '~base': return `deve corrispondere allo schema ${'Base'}`
+    case '~guard': return `deve corrispondere allo schema ${'Base'}`
     default: return 'si è verificato un errore di validazione sconosciuto'
   }
 }

--- a/src/system/locale/it_IT.ts
+++ b/src/system/locale/it_IT.ts
@@ -64,8 +64,8 @@ export function it_IT(error: TValidationError): string {
     case 'unevaluatedItems': return 'non deve avere elementi non valutati'
     case 'unevaluatedProperties': return 'non deve avere proprietà non valutate'
     case 'uniqueItems': return `non deve avere elementi duplicati`
+    case '~guard': return `deve corrispondere alla funzione di controllo`
     case '~refine': return error.params.message
-    case '~guard': return `deve corrispondere allo schema ${'Base'}`
     default: return 'si è verificato un errore di validazione sconosciuto'
   }
 }

--- a/src/system/locale/ja_JP.ts
+++ b/src/system/locale/ja_JP.ts
@@ -64,8 +64,8 @@ export function ja_JP(error: TValidationError): string {
     case 'unevaluatedItems': return '未評価のアイテムを持つことはできません'
     case 'unevaluatedProperties': return '未評価のプロパティを持つことはできません'
     case 'uniqueItems': return `重複するアイテムを持つことはできません`
+    case '~guard': return `チェック関数と一致する必要があります`
     case '~refine': return error.params.message
-    case '~guard': return `${'Base'} スキーマと一致する必要があります`
     default: return '不明なバリデーションエラーが発生しました'
   }
 }

--- a/src/system/locale/ja_JP.ts
+++ b/src/system/locale/ja_JP.ts
@@ -65,7 +65,7 @@ export function ja_JP(error: TValidationError): string {
     case 'unevaluatedProperties': return '未評価のプロパティを持つことはできません'
     case 'uniqueItems': return `重複するアイテムを持つことはできません`
     case '~refine': return error.params.message
-    case '~base': return `${'Base'} スキーマと一致する必要があります`
+    case '~guard': return `${'Base'} スキーマと一致する必要があります`
     default: return '不明なバリデーションエラーが発生しました'
   }
 }

--- a/src/system/locale/ko_KR.ts
+++ b/src/system/locale/ko_KR.ts
@@ -65,7 +65,7 @@ export function ko_KR(error: TValidationError): string {
     case 'unevaluatedProperties': return '평가되지 않은 속성을 가질 수 없습니다'
     case 'uniqueItems': return `중복 항목을 가질 수 없습니다`
     case '~refine': return error.params.message
-    case '~base': return `${'Base'} 스키마와 일치해야 합니다`
+    case '~guard': return `${'Base'} 스키마와 일치해야 합니다`
     default: return '알 수 없는 유효성 검사 오류가 발생했습니다'
   }
 }

--- a/src/system/locale/ko_KR.ts
+++ b/src/system/locale/ko_KR.ts
@@ -64,8 +64,8 @@ export function ko_KR(error: TValidationError): string {
     case 'unevaluatedItems': return '평가되지 않은 항목을 가질 수 없습니다'
     case 'unevaluatedProperties': return '평가되지 않은 속성을 가질 수 없습니다'
     case 'uniqueItems': return `중복 항목을 가질 수 없습니다`
+    case '~guard': return `체크 함수와 일치해야 합니다`
     case '~refine': return error.params.message
-    case '~guard': return `${'Base'} 스키마와 일치해야 합니다`
     default: return '알 수 없는 유효성 검사 오류가 발생했습니다'
   }
 }

--- a/src/system/locale/ms_MY.ts
+++ b/src/system/locale/ms_MY.ts
@@ -64,8 +64,8 @@ export function ms_MY(error: TValidationError): string {
     case 'unevaluatedItems': return 'tidak boleh mempunyai item yang tidak dinilai'
     case 'unevaluatedProperties': return 'tidak boleh mempunyai sifat yang tidak dinilai'
     case 'uniqueItems': return `tidak boleh mempunyai item pendua`
+    case '~guard': return `mestilah sepadan dengan fungsi semak`
     case '~refine': return error.params.message
-    case '~guard': return `mesti sepadan dengan skema ${'Base'}`
     default: return 'ralat pengesahan yang tidak diketahui berlaku'
   }
 }

--- a/src/system/locale/ms_MY.ts
+++ b/src/system/locale/ms_MY.ts
@@ -65,7 +65,7 @@ export function ms_MY(error: TValidationError): string {
     case 'unevaluatedProperties': return 'tidak boleh mempunyai sifat yang tidak dinilai'
     case 'uniqueItems': return `tidak boleh mempunyai item pendua`
     case '~refine': return error.params.message
-    case '~base': return `mesti sepadan dengan skema ${'Base'}`
+    case '~guard': return `mesti sepadan dengan skema ${'Base'}`
     default: return 'ralat pengesahan yang tidak diketahui berlaku'
   }
 }

--- a/src/system/locale/nl_NL.ts
+++ b/src/system/locale/nl_NL.ts
@@ -65,7 +65,7 @@ export function nl_NL(error: TValidationError): string {
     case 'unevaluatedProperties': return 'mag geen onbeoordeelde eigenschappen hebben'
     case 'uniqueItems': return `mag geen dubbele items hebben`
     case '~refine': return error.params.message
-    case '~base': return `moet overeenkomen met ${'Base'} schema`
+    case '~guard': return `moet overeenkomen met ${'Base'} schema`
     default: return 'er is een onbekende validatiefout opgetreden'
   }
 }

--- a/src/system/locale/nl_NL.ts
+++ b/src/system/locale/nl_NL.ts
@@ -64,8 +64,8 @@ export function nl_NL(error: TValidationError): string {
     case 'unevaluatedItems': return 'mag geen onbeoordeelde items hebben'
     case 'unevaluatedProperties': return 'mag geen onbeoordeelde eigenschappen hebben'
     case 'uniqueItems': return `mag geen dubbele items hebben`
+    case '~guard': return `moet overeenkomen met de controlefunctie`
     case '~refine': return error.params.message
-    case '~guard': return `moet overeenkomen met ${'Base'} schema`
     default: return 'er is een onbekende validatiefout opgetreden'
   }
 }

--- a/src/system/locale/pl_PL.ts
+++ b/src/system/locale/pl_PL.ts
@@ -65,7 +65,7 @@ export function pl_PL(error: TValidationError): string {
     case 'unevaluatedProperties': return 'nie może mieć nieewaluowanych właściwości'
     case 'uniqueItems': return `nie może zawierać zduplikowanych elementów`
     case '~refine': return error.params.message
-    case '~base': return `musi pasować do schematu ${'Base'}`
+    case '~guard': return `musi pasować do schematu ${'Base'}`
     default: return 'wystąpił nieznany błąd walidacji'
   }
 }

--- a/src/system/locale/pl_PL.ts
+++ b/src/system/locale/pl_PL.ts
@@ -64,8 +64,8 @@ export function pl_PL(error: TValidationError): string {
     case 'unevaluatedItems': return 'nie może mieć nieewaluowanych elementów'
     case 'unevaluatedProperties': return 'nie może mieć nieewaluowanych właściwości'
     case 'uniqueItems': return `nie może zawierać zduplikowanych elementów`
+    case '~guard': return `musi pasować do funkcji sprawdzającej`
     case '~refine': return error.params.message
-    case '~guard': return `musi pasować do schematu ${'Base'}`
     default: return 'wystąpił nieznany błąd walidacji'
   }
 }

--- a/src/system/locale/pt_BR.ts
+++ b/src/system/locale/pt_BR.ts
@@ -65,7 +65,7 @@ export function pt_BR(error: TValidationError): string {
     case 'unevaluatedProperties': return 'não deve ter propriedades não avaliadas'
     case 'uniqueItems': return `não deve ter itens duplicados`
     case '~refine': return error.params.message
-    case '~base': return `deve corresponder ao esquema ${'Base'}`
+    case '~guard': return `deve corresponder ao esquema ${'Base'}`
     default: return 'ocorreu um erro de validação desconhecido'
   }
 }

--- a/src/system/locale/pt_BR.ts
+++ b/src/system/locale/pt_BR.ts
@@ -64,8 +64,8 @@ export function pt_BR(error: TValidationError): string {
     case 'unevaluatedItems': return 'não deve ter itens não avaliados'
     case 'unevaluatedProperties': return 'não deve ter propriedades não avaliadas'
     case 'uniqueItems': return `não deve ter itens duplicados`
+    case '~guard': return `deve corresponder à função de verificação`
     case '~refine': return error.params.message
-    case '~guard': return `deve corresponder ao esquema ${'Base'}`
     default: return 'ocorreu um erro de validação desconhecido'
   }
 }

--- a/src/system/locale/pt_PT.ts
+++ b/src/system/locale/pt_PT.ts
@@ -64,8 +64,8 @@ export function pt_PT(error: TValidationError): string {
     case 'unevaluatedItems': return 'não deve ter itens não avaliados'
     case 'unevaluatedProperties': return 'não deve ter propriedades não avaliadas'
     case 'uniqueItems': return `não deve ter itens duplicados`
+    case '~guard': return `deve corresponder à função de verificação`
     case '~refine': return error.params.message
-    case '~guard': return `deve corresponder ao esquema ${'Base'}`
     default: return 'ocorreu um erro de validação desconhecido'
   }
 }

--- a/src/system/locale/pt_PT.ts
+++ b/src/system/locale/pt_PT.ts
@@ -65,7 +65,7 @@ export function pt_PT(error: TValidationError): string {
     case 'unevaluatedProperties': return 'não deve ter propriedades não avaliadas'
     case 'uniqueItems': return `não deve ter itens duplicados`
     case '~refine': return error.params.message
-    case '~base': return `deve corresponder ao esquema ${'Base'}`
+    case '~guard': return `deve corresponder ao esquema ${'Base'}`
     default: return 'ocorreu um erro de validação desconhecido'
   }
 }

--- a/src/system/locale/ro_RO.ts
+++ b/src/system/locale/ro_RO.ts
@@ -64,8 +64,8 @@ export function ro_RO(error: TValidationError): string {
     case 'unevaluatedItems': return 'nu trebuie să aibă elemente neevaluate'
     case 'unevaluatedProperties': return 'nu trebuie să aibă proprietăți neevaluate'
     case 'uniqueItems': return `nu trebuie să aibă elemente duplicate`
+    case '~guard': return `trebuie să corespundă funcției de verificare`
     case '~refine': return error.params.message
-    case '~guard': return `trebuie să se potrivească cu schema ${'Base'}`
     default: return 'a apărut o eroare de validare necunoscută'
   }
 }

--- a/src/system/locale/ro_RO.ts
+++ b/src/system/locale/ro_RO.ts
@@ -65,7 +65,7 @@ export function ro_RO(error: TValidationError): string {
     case 'unevaluatedProperties': return 'nu trebuie să aibă proprietăți neevaluate'
     case 'uniqueItems': return `nu trebuie să aibă elemente duplicate`
     case '~refine': return error.params.message
-    case '~base': return `trebuie să se potrivească cu schema ${'Base'}`
+    case '~guard': return `trebuie să se potrivească cu schema ${'Base'}`
     default: return 'a apărut o eroare de validare necunoscută'
   }
 }

--- a/src/system/locale/ru_RU.ts
+++ b/src/system/locale/ru_RU.ts
@@ -64,8 +64,8 @@ export function ru_RU(error: TValidationError): string {
     case 'unevaluatedItems': return 'не должно быть нерассмотренных элементов'
     case 'unevaluatedProperties': return 'не должно быть нерассмотренных свойств'
     case 'uniqueItems': return `не должно быть повторяющихся элементов`
+    case '~guard': return `должно соответствовать проверочной функции`
     case '~refine': return error.params.message
-    case '~guard': return `должен соответствовать схеме ${'Base'}`
     default: return 'произошла неизвестная ошибка валидации'
   }
 }

--- a/src/system/locale/ru_RU.ts
+++ b/src/system/locale/ru_RU.ts
@@ -65,7 +65,7 @@ export function ru_RU(error: TValidationError): string {
     case 'unevaluatedProperties': return 'не должно быть нерассмотренных свойств'
     case 'uniqueItems': return `не должно быть повторяющихся элементов`
     case '~refine': return error.params.message
-    case '~base': return `должен соответствовать схеме ${'Base'}`
+    case '~guard': return `должен соответствовать схеме ${'Base'}`
     default: return 'произошла неизвестная ошибка валидации'
   }
 }

--- a/src/system/locale/sv_SE.ts
+++ b/src/system/locale/sv_SE.ts
@@ -65,7 +65,7 @@ export function sv_SE(error: TValidationError): string {
     case 'unevaluatedProperties': return 'får inte ha oidentifierade egenskaper'
     case 'uniqueItems': return `får inte ha dubbletter`
     case '~refine': return error.params.message
-    case '~base': return `måste matcha mot ${'Base'} schema`
+    case '~guard': return `måste matcha mot ${'Base'} schema`
     default: return 'ett okänt valideringsfel uppstod'
   }
 }

--- a/src/system/locale/sv_SE.ts
+++ b/src/system/locale/sv_SE.ts
@@ -64,8 +64,8 @@ export function sv_SE(error: TValidationError): string {
     case 'unevaluatedItems': return 'får inte ha oidentifierade objekt'
     case 'unevaluatedProperties': return 'får inte ha oidentifierade egenskaper'
     case 'uniqueItems': return `får inte ha dubbletter`
+    case '~guard': return `måste matcha kontrollfunktionen`
     case '~refine': return error.params.message
-    case '~guard': return `måste matcha mot ${'Base'} schema`
     default: return 'ett okänt valideringsfel uppstod'
   }
 }

--- a/src/system/locale/sw_TZ.ts
+++ b/src/system/locale/sw_TZ.ts
@@ -64,8 +64,8 @@ export function sw_TZ(error: TValidationError): string {
     case 'unevaluatedItems': return 'haipaswi kuwa na vitu visivyotathminiwa'
     case 'unevaluatedProperties': return 'haipaswi kuwa na sifa zisizotathminiwa'
     case 'uniqueItems': return `haipaswi kuwa na vitu vilivyofanana`
+    case '~guard': return `inapaswa kulingana na kipengele cha ukaguzi`
     case '~refine': return error.params.message
-    case '~guard': return `lazima ilingane na schema ya ${'Base'}`
     default: return 'hitilafu isiyojulikana ya uthibitishaji imetokea'
   }
 }

--- a/src/system/locale/sw_TZ.ts
+++ b/src/system/locale/sw_TZ.ts
@@ -65,7 +65,7 @@ export function sw_TZ(error: TValidationError): string {
     case 'unevaluatedProperties': return 'haipaswi kuwa na sifa zisizotathminiwa'
     case 'uniqueItems': return `haipaswi kuwa na vitu vilivyofanana`
     case '~refine': return error.params.message
-    case '~base': return `lazima ilingane na schema ya ${'Base'}`
+    case '~guard': return `lazima ilingane na schema ya ${'Base'}`
     default: return 'hitilafu isiyojulikana ya uthibitishaji imetokea'
   }
 }

--- a/src/system/locale/th_TH.ts
+++ b/src/system/locale/th_TH.ts
@@ -65,7 +65,7 @@ export function th_TH(error: TValidationError): string {
     case 'unevaluatedProperties': return 'ต้องไม่มีคุณสมบัติที่ยังไม่ได้ประเมิน'
     case 'uniqueItems': return `ต้องไม่มีรายการที่ซ้ำกัน`
     case '~refine': return error.params.message
-    case '~base': return `ต้องตรงกับ Schema ของ ${'Base'}`
+    case '~guard': return `ต้องตรงกับ Schema ของ ${'Base'}`
     default: return 'เกิดข้อผิดพลาดในการตรวจสอบที่ไม่รู้จัก'
   }
 }

--- a/src/system/locale/th_TH.ts
+++ b/src/system/locale/th_TH.ts
@@ -64,8 +64,8 @@ export function th_TH(error: TValidationError): string {
     case 'unevaluatedItems': return 'ต้องไม่มีรายการที่ยังไม่ได้ประเมิน'
     case 'unevaluatedProperties': return 'ต้องไม่มีคุณสมบัติที่ยังไม่ได้ประเมิน'
     case 'uniqueItems': return `ต้องไม่มีรายการที่ซ้ำกัน`
+    case '~guard': return `ต้องตรงกับฟังก์ชันตรวจสอบ`
     case '~refine': return error.params.message
-    case '~guard': return `ต้องตรงกับ Schema ของ ${'Base'}`
     default: return 'เกิดข้อผิดพลาดในการตรวจสอบที่ไม่รู้จัก'
   }
 }

--- a/src/system/locale/tr_TR.ts
+++ b/src/system/locale/tr_TR.ts
@@ -65,7 +65,7 @@ export function tr_TR(error: TValidationError): string {
     case 'unevaluatedProperties': return 'değerlendirilmemiş özelliklere sahip olmamalıdır'
     case 'uniqueItems': return `yinelenen öğelere sahip olmamalıdır`
     case '~refine': return error.params.message
-    case '~base': return `${'Base'} şemasına göre eşleşmelidir`
+    case '~guard': return `${'Base'} şemasına göre eşleşmelidir`
     default: return 'bilinmeyen bir doğrulama hatası oluştu'
   }
 }

--- a/src/system/locale/tr_TR.ts
+++ b/src/system/locale/tr_TR.ts
@@ -64,8 +64,8 @@ export function tr_TR(error: TValidationError): string {
     case 'unevaluatedItems': return 'değerlendirilmemiş öğelere sahip olmamalıdır'
     case 'unevaluatedProperties': return 'değerlendirilmemiş özelliklere sahip olmamalıdır'
     case 'uniqueItems': return `yinelenen öğelere sahip olmamalıdır`
+    case '~guard': return `kontrol fonksiyonuyla eşleşmelidir`
     case '~refine': return error.params.message
-    case '~guard': return `${'Base'} şemasına göre eşleşmelidir`
     default: return 'bilinmeyen bir doğrulama hatası oluştu'
   }
 }

--- a/src/system/locale/uk_UA.ts
+++ b/src/system/locale/uk_UA.ts
@@ -65,7 +65,7 @@ export function uk_UA(error: TValidationError): string {
     case 'unevaluatedProperties': return 'не повинно мати неперевірених властивостей'
     case 'uniqueItems': return `не повинно мати повторюваних елементів`
     case '~refine': return error.params.message
-    case '~base': return `має відповідати схемі ${'Base'}`
+    case '~guard': return `має відповідати схемі ${'Base'}`
     default: return 'виникла невідома помилка валідації'
   }
 }

--- a/src/system/locale/uk_UA.ts
+++ b/src/system/locale/uk_UA.ts
@@ -64,8 +64,8 @@ export function uk_UA(error: TValidationError): string {
     case 'unevaluatedItems': return 'не повинно мати неперевірених елементів'
     case 'unevaluatedProperties': return 'не повинно мати неперевірених властивостей'
     case 'uniqueItems': return `не повинно мати повторюваних елементів`
+    case '~guard': return `повинно відповідати функції перевірки`
     case '~refine': return error.params.message
-    case '~guard': return `має відповідати схемі ${'Base'}`
     default: return 'виникла невідома помилка валідації'
   }
 }

--- a/src/system/locale/ur_PK.ts
+++ b/src/system/locale/ur_PK.ts
@@ -66,7 +66,7 @@ export function ur_PK(error: TValidationError): string {
     case 'unevaluatedProperties': return 'غیر تشخیص شدہ خصوصیات نہیں ہونی چاہئیں'
     case 'uniqueItems': return `ڈپلیکیٹ آئٹمز نہیں ہونے چاہئیں`
     case '~refine': return error.params.message
-    case '~base': return `${'Base'} اسکیما سے مماثل ہونا چاہیے`
+    case '~guard': return `${'Base'} اسکیما سے مماثل ہونا چاہیے`
     default: return 'تصدیق میں ایک نامعلوم خرابی پیش آئی'
   }
 }

--- a/src/system/locale/ur_PK.ts
+++ b/src/system/locale/ur_PK.ts
@@ -65,8 +65,8 @@ export function ur_PK(error: TValidationError): string {
     case 'unevaluatedItems': return 'غیر تشخیص شدہ آئٹمز نہیں ہونے چاہئیں'
     case 'unevaluatedProperties': return 'غیر تشخیص شدہ خصوصیات نہیں ہونی چاہئیں'
     case 'uniqueItems': return `ڈپلیکیٹ آئٹمز نہیں ہونے چاہئیں`
+    case '~guard': return `چیک فنکشن سے مطابقت ہونی چاہیے`
     case '~refine': return error.params.message
-    case '~guard': return `${'Base'} اسکیما سے مماثل ہونا چاہیے`
     default: return 'تصدیق میں ایک نامعلوم خرابی پیش آئی'
   }
 }

--- a/src/system/locale/vi_VN.ts
+++ b/src/system/locale/vi_VN.ts
@@ -65,7 +65,7 @@ export function vi_VN(error: TValidationError): string {
     case 'unevaluatedProperties': return 'không được có các thuộc tính chưa được đánh giá'
     case 'uniqueItems': return `không được có các mục trùng lặp`
     case '~refine': return error.params.message
-    case '~base': return `phải khớp với schema ${'Base'}`
+    case '~guard': return `phải khớp với schema ${'Base'}`
     default: return 'đã xảy ra lỗi xác thực không xác định'
   }
 }

--- a/src/system/locale/vi_VN.ts
+++ b/src/system/locale/vi_VN.ts
@@ -64,8 +64,8 @@ export function vi_VN(error: TValidationError): string {
     case 'unevaluatedItems': return 'không được có các mục chưa được đánh giá'
     case 'unevaluatedProperties': return 'không được có các thuộc tính chưa được đánh giá'
     case 'uniqueItems': return `không được có các mục trùng lặp`
+    case '~guard': return `phải khớp với hàm kiểm tra`
     case '~refine': return error.params.message
-    case '~guard': return `phải khớp với schema ${'Base'}`
     default: return 'đã xảy ra lỗi xác thực không xác định'
   }
 }

--- a/src/system/locale/yo_NG.ts
+++ b/src/system/locale/yo_NG.ts
@@ -64,8 +64,8 @@ export function yo_NG(error: TValidationError): string {
     case 'unevaluatedItems': return 'ko gbọdọ ni awọn ohun ti ko ṣe iṣiro'
     case 'unevaluatedProperties': return 'ko gbọdọ ni awọn ohun-ini ti ko ṣe iṣiro'
     case 'uniqueItems': return `ko gbọdọ ni awọn ohun elo ẹda`
+    case '~guard': return `gbogbo yẹ ki o ba iṣẹ́ ṣàyẹ̀wò mu`
     case '~refine': return error.params.message
-    case '~guard': return `gbọdọ baramu àlàyé ${'Base'}`
     default: return 'aṣiṣe ijẹrisi aimọ waye'
   }
 }

--- a/src/system/locale/yo_NG.ts
+++ b/src/system/locale/yo_NG.ts
@@ -65,7 +65,7 @@ export function yo_NG(error: TValidationError): string {
     case 'unevaluatedProperties': return 'ko gbọdọ ni awọn ohun-ini ti ko ṣe iṣiro'
     case 'uniqueItems': return `ko gbọdọ ni awọn ohun elo ẹda`
     case '~refine': return error.params.message
-    case '~base': return `gbọdọ baramu àlàyé ${'Base'}`
+    case '~guard': return `gbọdọ baramu àlàyé ${'Base'}`
     default: return 'aṣiṣe ijẹrisi aimọ waye'
   }
 }

--- a/src/system/locale/zh_Hans.ts
+++ b/src/system/locale/zh_Hans.ts
@@ -64,8 +64,8 @@ export function zh_Hans(error: TValidationError): string {
     case 'unevaluatedItems': return '不得有未评估的项'
     case 'unevaluatedProperties': return '不得有未评估的属性'
     case 'uniqueItems': return `不得有重复项`
+    case '~guard': return `必须与检查函数匹配`
     case '~refine': return error.params.message
-    case '~guard': return `必须匹配 ${'Base'} 模式`
     default: return '发生未知验证错误'
   }
 }

--- a/src/system/locale/zh_Hans.ts
+++ b/src/system/locale/zh_Hans.ts
@@ -65,7 +65,7 @@ export function zh_Hans(error: TValidationError): string {
     case 'unevaluatedProperties': return '不得有未评估的属性'
     case 'uniqueItems': return `不得有重复项`
     case '~refine': return error.params.message
-    case '~base': return `必须匹配 ${'Base'} 模式`
+    case '~guard': return `必须匹配 ${'Base'} 模式`
     default: return '发生未知验证错误'
   }
 }

--- a/src/system/locale/zh_Hant.ts
+++ b/src/system/locale/zh_Hant.ts
@@ -65,7 +65,7 @@ export function zh_Hant(error: TValidationError): string {
     case 'unevaluatedProperties': return '不得有未評估的屬性'
     case 'uniqueItems': return `不得有重複項目`
     case '~refine': return error.params.message
-    case '~base': return `必須匹配 ${'Base'} 模式`
+    case '~guard': return `必須匹配 ${'Base'} 模式`
     default: return '發生未知驗證錯誤'
   }
 }

--- a/src/system/locale/zh_Hant.ts
+++ b/src/system/locale/zh_Hant.ts
@@ -64,8 +64,8 @@ export function zh_Hant(error: TValidationError): string {
     case 'unevaluatedItems': return '不得有未評估的項目'
     case 'unevaluatedProperties': return '不得有未評估的屬性'
     case 'uniqueItems': return `不得有重複項目`
+    case '~guard': return `必須與檢查函數匹配`
     case '~refine': return error.params.message
-    case '~guard': return `必須匹配 ${'Base'} 模式`
     default: return '發生未知驗證錯誤'
   }
 }

--- a/src/system/memory/clone.ts
+++ b/src/system/memory/clone.ts
@@ -34,10 +34,10 @@ import { Metrics } from './metrics.ts'
 // ------------------------------------------------------------------
 // Base
 // ------------------------------------------------------------------
-function IsBase(value: unknown): value is { '~base': unknown } {
-  return Guard.IsObject(value) && Guard.HasPropertyKey(value, '~base')
+function IsBase(value: unknown): value is { '~guard': unknown } {
+  return Guard.IsObject(value) && Guard.HasPropertyKey(value, '~guard')
 }
-function FromBase(value: { '~base': unknown }): unknown {
+function FromBase(value: { '~guard': unknown }): unknown {
   return value // non-clonable
 }
 // ------------------------------------------------------------------

--- a/src/system/memory/clone.ts
+++ b/src/system/memory/clone.ts
@@ -32,12 +32,12 @@ import { Guard } from '../../guard/index.ts'
 import { Metrics } from './metrics.ts'
 
 // ------------------------------------------------------------------
-// Base
+// Guard
 // ------------------------------------------------------------------
-function IsBase(value: unknown): value is { '~guard': unknown } {
+function IsGuard(value: unknown): value is { '~guard': unknown } {
   return Guard.IsObject(value) && Guard.HasPropertyKey(value, '~guard')
 }
-function FromBase(value: { '~guard': unknown }): unknown {
+function FromGuard(value: { '~guard': unknown }): unknown {
   return value // non-clonable
 }
 // ------------------------------------------------------------------
@@ -78,7 +78,7 @@ function FromUnknown(value: unknown): unknown {
 function FromValue(value: unknown): unknown {
   return (
     value instanceof RegExp ? FromRegExp(value) :
-    IsBase(value) ? FromBase(value) :
+    IsGuard(value) ? FromGuard(value) :
     Guard.IsArray(value) ? FromArray(value) : 
     Guard.IsObject(value) ? FromObject(value) : 
     FromUnknown(value)

--- a/src/type/types/_refine.ts
+++ b/src/type/types/_refine.ts
@@ -58,12 +58,12 @@ export type TRefine<Type extends TSchema = TSchema> = (
 export type TRefineCallback<Type extends TSchema> = (value: Static<Type>) => boolean
 
 export interface TRefinement<Type extends TSchema = TSchema> {
-  callback: TRefineCallback<Type>
+  refine: TRefineCallback<Type>
   message: string
 }
 /** Applies a Refine check to the given type. */
-export function Refine<Type extends TSchema>(type: Type, callback: TRefineCallback<Type>, message: string = 'error'): TRefineAdd<Type> {
-  return RefineAdd(type, { callback, message }) as never
+export function Refine<Type extends TSchema>(type: Type, refine: TRefineCallback<Type>, message: string = 'error'): TRefineAdd<Type> {
+  return RefineAdd(type, { refine, message }) as never
 }
 // ------------------------------------------------------------------
 // Guard

--- a/src/type/types/schema.ts
+++ b/src/type/types/schema.ts
@@ -217,7 +217,6 @@ export interface TNumberOptions extends TSchemaOptions {
 // StringOptions
 // ------------------------------------------------------------------
 export type TFormat = 
-  | 'base64'
   | 'date-time'
   | 'date'
   | 'duration'

--- a/tasks.ts
+++ b/tasks.ts
@@ -8,7 +8,7 @@ import { Range } from './task/range/index.ts'
 import { Metrics } from './task/metrics/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.0.29'
+const Version = '1.0.30'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/schema/types/~guard.ts
+++ b/test/typebox/runtime/schema/types/~guard.ts
@@ -1,41 +1,41 @@
 import Schema from 'typebox/schema'
 import { Assert } from 'test'
 
-const Test = Assert.Context('Schema.IsBase')
+const Test = Assert.Context('Schema.IsGuard')
 
 Test('Should Guard 1', () => {
-  Assert.IsTrue(Schema.IsBase({
-    '~base': {
+  Assert.IsTrue(Schema.IsGuard({
+    '~guard': {
       check: (value: unknown) => true,
       errors: (value: unknown) => []
     }
   }))
 })
 Test('Should Guard 2', () => {
-  Assert.IsFalse(Schema.IsBase({
-    '~base': {
+  Assert.IsFalse(Schema.IsGuard({
+    '~guard': {
       check: (value: unknown) => true
     }
   }))
 })
 Test('Should Guard 3', () => {
-  Assert.IsFalse(Schema.IsBase({
-    '~base': {
+  Assert.IsFalse(Schema.IsGuard({
+    '~guard': {
       errors: (value: unknown) => []
     }
   }))
 })
 Test('Should Guard 4', () => {
-  Assert.IsFalse(Schema.IsBase({
-    '~base': {
+  Assert.IsFalse(Schema.IsGuard({
+    '~guard': {
       check: 1,
       errors: (value: unknown) => []
     }
   }))
 })
 Test('Should Guard 5', () => {
-  Assert.IsFalse(Schema.IsBase({
-    '~base': {
+  Assert.IsFalse(Schema.IsGuard({
+    '~guard': {
       check: (value: unknown) => true,
       errors: 1
     }

--- a/test/typebox/runtime/schema/types/~refine.ts
+++ b/test/typebox/runtime/schema/types/~refine.ts
@@ -10,7 +10,7 @@ Test('Should Guard 1', () => {
 })
 Test('Should Guard 2', () => {
   Assert.IsTrue(Schema.IsRefine({
-    '~refine': [{ callback: (value: unknown) => true, message: 'fail' }]
+    '~refine': [{ refine: (value: unknown) => true, message: 'fail' }]
   }))
 })
 Test('Should Guard 3', () => {

--- a/test/typebox/runtime/system/memory.ts
+++ b/test/typebox/runtime/system/memory.ts
@@ -31,7 +31,7 @@ Test('Should Clone 4', () => {
   Assert.IsTrue(A === B)
 })
 Test('Should Clone 4', () => {
-  const A = { '~base': null }
+  const A = { '~guard': null }
   const B = Memory.Clone(A)
   Assert.IsEqual(B, A)
   Assert.IsTrue(A === B)

--- a/test/typebox/runtime/value/check/base.ts
+++ b/test/typebox/runtime/value/check/base.ts
@@ -51,7 +51,7 @@ Test('Should validate Base 6', () => {
     }
     override Errors(): object[] {
       return [{
-        keyword: '~base',
+        keyword: '~guard',
         schemaPath: '',
         instancePath: '',
         params: { issues: [{ message: '' }] },
@@ -68,7 +68,7 @@ Test('Should validate Base 7', () => {
     }
     override Errors(): object[] {
       return [{
-        keyword: '~base',
+        keyword: '~guard',
         schemaPath: '',
         instancePath: '',
         params: { issues: [{ message: 1 }] },
@@ -85,7 +85,7 @@ Test('Should validate Base 8', () => {
     }
     override Errors(): object[] {
       return [{
-        keyword: '~base',
+        keyword: '~guard',
         schemaPath: '',
         instancePath: '',
         params: { issues: null },
@@ -102,7 +102,7 @@ Test('Should validate Base 9', () => {
     }
     override Errors(): object[] {
       return [{
-        keyword: '~base',
+        keyword: '~guard',
         schemaPath: '',
         instancePath: '',
         params: { issues: [{ message: '', path: [] }] }
@@ -189,7 +189,7 @@ Test('Should validate Base 15', () => {
     }
   }
   const F = new Foo()
-  const R = F['~base'].errors(null)
+  const R = F['~guard'].errors(null)
   Assert.IsTrue(Guard.IsArray(R))
   const E = R[0]
   Assert.HasPropertyKey(E, 'foo')


### PR DESCRIPTION
This PR finalizes updates to Base and replaces the internal `~base` extension keyword with the more formal `~guard` keyword. This PR updates error translations inline with `~guard` and updates Base to support `enumerableKind` visibility while keeping `~guard` functions public.



