### PR TITLE
resolves #1402: implement toJSON for string types to handle Regex patterns

### DIFF
--- a/src/type/types/string.ts
+++ b/src/type/types/string.ts
@@ -29,39 +29,31 @@ THE SOFTWARE.
 // deno-lint-ignore-file
 // deno-fmt-ignore-file
 
-import { Memory } from "../../system/memory/index.ts";
-import {
-  type TSchema,
-  type TSchemaOptions,
-  type TStringOptions,
-  IsKind,
-} from "./schema.ts";
+import { Memory } from '../../system/memory/index.ts'
+import { type TSchema, type TSchemaOptions, type TStringOptions, IsKind } from './schema.ts'
 
 // ------------------------------------------------------------------
 // StringPattern
 // ------------------------------------------------------------------
-export const StringPattern = ".*";
+export const StringPattern = '.*'
 // ------------------------------------------------------------------
 // Static
 // ------------------------------------------------------------------
-export type StaticString = string;
+export type StaticString = string
 // ------------------------------------------------------------------
 // Type
 // ------------------------------------------------------------------
 /** Represents a String type. */
 export interface TString extends TSchema {
-  "~kind": "String";
-  type: "string";
+  '~kind': 'String',
+  type: 'string'
 }
 // ------------------------------------------------------------------
 // Factory
 // ------------------------------------------------------------------
 /** Creates a String type. */
 export function String(options?: TStringOptions): TString {
-  return Memory.Create(
-    {
-      "~kind": "String",
-      toJSON() {
+  return Memory.Create({ '~kind': 'String', toJSON() {
         return {
           ...this,
           pattern:
@@ -69,16 +61,12 @@ export function String(options?: TStringOptions): TString {
               ? this.pattern.toString().replace(/^[/]/, "").replace(/[/]$/, "")
               : this.pattern,
         };
-      },
-    },
-    { type: "string" },
-    options
-  ) as never;
+      } }, { type: 'string' }, options) as never
 }
 // ------------------------------------------------------------------
 // Guard
 // ------------------------------------------------------------------
 /** Returns true if the given value is TString. */
 export function IsString(value: unknown): value is TString {
-  return IsKind(value, "String");
+  return IsKind(value, 'String')
 }


### PR DESCRIPTION
I built locally and ran with the type in the associated PR and got:

```json
{
  "type":"string",
  "pattern":"^@component\\/",
  "description":"The unique identifier for the component, e.g. @component/button. Must start with \"@component/\"."
}
```

which is what I would have expected