### PR TITLE
Remove invalid closing link HTML element

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
     <meta property="og:type" content="https://sinclairzx81.github.io/typebox">
     <title>TypeBox</title>
     <link rel="icon" href="resources/image/favicon.ico" type="image/x-icon">
-    <link href="index.css" rel="stylesheet"></link>
+    <link href="index.css" rel="stylesheet">
     <script type="module" src="index.js"></script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-EYTCZ4PD6T"></script>
     <script>


### PR DESCRIPTION
A link element in the header does not need to be closed like that. This PR will fix that issue, making the site more complaint.