### PR TITLE
feat: add support for optional elements in tuples

### DIFF
--- a/src/type/types/tuple.ts
+++ b/src/type/types/tuple.ts
@@ -32,7 +32,7 @@ import { Memory } from '../../system/memory/index.ts'
 import { type StaticType, type StaticDirection } from './static.ts'
 import { type TSchema, type TTupleOptions, IsKind } from './schema.ts'
 import { type TArray } from './array.ts'
-import { type TOptional } from './_optional.ts'
+import { type TOptional, IsOptional } from './_optional.ts'
 import { type TProperties } from './properties.ts'
 import { type TImmutable } from './_immutable.ts'
 import { type TReadonly } from './_readonly.ts'
@@ -104,9 +104,17 @@ export interface TTuple<Types extends TSchema[] = TSchema[]> extends TSchema {
 // ------------------------------------------------------------------
 // Factory
 // ------------------------------------------------------------------
+/** Counts the number of non-optional elements in a tuple array at runtime. */
+function countNonOptional<Types extends TSchema[]>(types: Types): number {
+  const i = types.findIndex(IsOptional)
+  if (i >= 0 && types.slice(i).some(t => !IsOptional(t)))
+    throw new Error('Tuple optional elements must be at the end')
+  return i < 0 ? types.length : i
+}
+
 /** Creates a Tuple type. */
 export function Tuple<Types extends TSchema[]>(types: [...Types], options: TTupleOptions = {}): TTuple<Types> {
-const [items, minItems, additionalItems] = [types, types.length, false]
+  const [items, minItems, additionalItems] = [types, countNonOptional(types), false]
   return Memory.Create({ ['~kind']: 'Tuple' }, { type: 'array', additionalItems, items, minItems }, options) as never
 }
 // ------------------------------------------------------------------

--- a/test/typebox/runtime/type/types/tuple.ts
+++ b/test/typebox/runtime/type/types/tuple.ts
@@ -43,3 +43,55 @@ Test('Should Create Tuple with options then extract', () => {
   Assert.IsEqual(O.a, 1)
   Assert.IsEqual(O.b, 2)
 })
+// ------------------------------------------------------------------
+// Optional Elements
+// ------------------------------------------------------------------
+Test('Should Create Tuple with optional elements at the end', () => {
+  const T = Type.Tuple([
+    Type.String(),
+    Type.Number(),
+    Type.Optional(Type.Boolean()),
+    Type.Optional(Type.Null()),
+  ])
+  Assert.IsTrue(Type.IsTuple(T))
+  Assert.IsEqual(T.items.length, 4)
+  Assert.IsEqual(T.minItems, 2) // Only first two are non-optional
+})
+Test('Should Create Tuple with all required elements', () => {
+  const T = Type.Tuple([
+    Type.String(),
+    Type.Number(),
+    Type.Boolean(),
+  ])
+  Assert.IsTrue(Type.IsTuple(T))
+  Assert.IsEqual(T.items.length, 3)
+  Assert.IsEqual(T.minItems, 3) // All are required
+})
+Test('Should Create Tuple with all optional elements', () => {
+  const T = Type.Tuple([
+    Type.Optional(Type.String()),
+    Type.Optional(Type.Number()),
+  ])
+  Assert.IsTrue(Type.IsTuple(T))
+  Assert.IsEqual(T.items.length, 2)
+  Assert.IsEqual(T.minItems, 0) // All are optional
+})
+Test('Should throw error when optional element is in the middle', () => {
+  Assert.Throws(() => {
+    Type.Tuple([
+      Type.String(),
+      Type.Optional(Type.Number()),
+      Type.Boolean(), // Non-optional after optional - should error
+    ])
+  })
+})
+Test('Should throw error when optional element is followed by non-optional', () => {
+  Assert.Throws(() => {
+    Type.Tuple([
+      Type.String(),
+      Type.Optional(Type.Number()),
+      Type.Optional(Type.Boolean()),
+      Type.String(), // Non-optional after optional - should error
+    ])
+  })
+})

--- a/test/typebox/runtime/value/check/tuple.ts
+++ b/test/typebox/runtime/value/check/tuple.ts
@@ -63,3 +63,44 @@ Test('Should use optimization logic for prefix items', () => {
   Ok(T, [1, 2])
   Fail(T, [1, 2, 3])
 })
+// ------------------------------------------------------------------
+// Optional Elements
+// ------------------------------------------------------------------
+Test('Should validate tuple with optional elements at end - minimum items', () => {
+  const T = Type.Tuple([
+    Type.String(),
+    Type.Number(),
+    Type.Optional(Type.Boolean()),
+    Type.Optional(Type.Null()),
+  ])
+  Ok(T, ['hello', 42]) // Only required items
+  Ok(T, ['hello', 42, true]) // With one optional
+  Ok(T, ['hello', 42, true, null]) // With all optional
+})
+Test('Should not validate tuple with optional elements when below minimum', () => {
+  const T = Type.Tuple([
+    Type.String(),
+    Type.Number(),
+    Type.Optional(Type.Boolean()),
+    Type.Optional(Type.Null()),
+  ])
+  Fail(T, ['hello']) // Missing required item
+  Fail(T, []) // Empty
+})
+Test('Should validate tuple with all optional elements', () => {
+  const T = Type.Tuple([
+    Type.Optional(Type.String()),
+    Type.Optional(Type.Number()),
+  ])
+  Ok(T, []) // Empty is valid
+  Ok(T, ['hello']) // One item
+  Ok(T, ['hello', 42]) // All items
+})
+Test('Should not validate tuple with optional elements when exceeding max items', () => {
+  const T = Type.Tuple([
+    Type.String(),
+    Type.Number(),
+    Type.Optional(Type.Boolean()),
+  ])
+  Fail(T, ['hello', 42, true, 'extra']) // Too many items
+})


### PR DESCRIPTION
- Add countNonOptional function to calculate minItems based on required elements
- Ensure optional elements must be at the end of tuple (enforced at runtime)
- Update tuple factory to use countNonOptional for minItems calculation
- Add comprehensive tests for optional tuple elements