### PR TITLE
Version 1.1.0

### DIFF
--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -1,0 +1,32 @@
+# 1.1.0
+
+## Overview
+
+Version 1.1.0 introduces a behavioral change to `Value.Parse(...)` and `Validator.Parse(...)` where automatic corrective parsing is now disabled by default. This change addresses performance overhead when handling invalid data and prepares the `Value.*` API for future revisions.
+
+This update introduces a validation semantics change and is published under a minor semver version.
+
+## Corrective Parse
+
+In 1.0, a feature referred to as “Corrective Parse” was trialed. This feature meant that for any invalid value passed to Parse, TypeBox would attempt to Convert, Default, and Clean the value, then re-Check it before throwing an assertion. The feature was introduced in 1.0 in an effort to establish a de facto parsing pipeline for TypeBox, but it has since been observed that it incurs significant performance overhead for large invalid values. Additionally, the correction behavior has generally proven surprising to users, and is therefore better expressed as an opt-in feature.
+
+The following shows the changes from 1.0 to 1.1
+
+```typescript
+// 1.0 
+const A = Value.Parse(Type.Number(), '123') // A = 123
+
+// 1.1
+const A = Value.Parse(Type.Number(), '123') // throw! - Expected Number
+```
+
+Corrective parsing can be re-enabled by using the `{ correctiveParse: true }` configuration.
+
+```typescript
+import { Settings } from 'typebox/system'
+
+// 1.1
+Settings.Set({ correctiveParse: true })
+
+const A = Value.Parse(Type.Number(), '123') // A = 123
+```

--- a/design/website/docs/system/1_settings.md
+++ b/design/website/docs/system/1_settings.md
@@ -48,11 +48,11 @@ export interface TSettings {
   useEval: boolean
 
   /**
-   * Enables or disables 'exactOptionalPropertyTypes' check semantics. By default, TypeScript 
-   * allows optional properties to be assigned 'undefined'. While this behavior differs from the 
-   * common interpretation of 'optional' as meaning 'key may be absent', TypeBox adopts the default 
-   * TypeScript semantics to remain consistent with the language. This option is provided to align 
-   * runtime check semantics with projects that configure 'exactOptionalPropertyTypes: true' in 
+   * Enables or disables 'exactOptionalPropertyTypes' check semantics. By default, TypeScript
+   * allows optional properties to be assigned 'undefined'. While this behavior differs from the
+   * common interpretation of 'optional' as meaning 'key may be absent', TypeBox adopts the default
+   * TypeScript semantics to remain consistent with the language. This option is provided to align
+   * runtime check semantics with projects that configure 'exactOptionalPropertyTypes: true' in
    * tsconfig.json.
    * @default false
    */
@@ -63,5 +63,15 @@ export interface TSettings {
    * @default false
    */
   enumerableKind: boolean
+  
+  /**
+   * Controls whether TypeBox uses corrective Parse. When enabled, TypeBox will attempt to recover invalid
+   * values during Parse by running a sequence of `Value.*` operations to `Convert`, `Default`, and `Clean`
+   * the value, followed by a subsequent `Assert`. Enabling this option may incur significant performance
+   * overhead for invalid values. It is recommended to keep this disabled in performance-sensitive
+   * applications.
+   * @default false
+   */
+  correctiveParse: boolean
 }
 ```

--- a/design/website/docs/value/parse.md
+++ b/design/website/docs/value/parse.md
@@ -1,8 +1,6 @@
 # Parse
 
-The Parse function attempts to parse a value and throws an error if the value is invalid. This function is similar to Decode, but it does not execute Decode callbacks. Parse is considered a faster version of Decode, as operations that transform values are skipped when the value already matches the expected type.
-
-> The Parse function first checks a value against the provided type and returns immediately if it matches. If the value does not match, it is processed through a sequence of Clone, Clean, Convert, and Default operations, and then re-checked. If the value remains invalid, a ParseError error is thrown.
+The Parse function validates and returns a value that conforms to a given type. If the value does not satisfy the type, a parse error is thrown.
 
 ## Example
 
@@ -11,5 +9,31 @@ Example usage is shown below.
 ```typescript
 const R = Value.Parse(Type.String(), 'hello')      // const R: string = "hello"
 
-const E = Value.Parse(Type.String(), [{ x: 1 }])   // throws ParseError 
+const E = Value.Parse(Type.String(), 12345)        // throws ParseError 
+```
+
+## Corrective Parse
+
+TypeBox provides an optional corrective parsing mode that attempts to repair invalid values before failing. When enabled, the parser runs a pipeline consisting of Convert, Default, and Clean, then re-asserts the value after processing. This feature can be useful when parsing environment variables into target types.
+
+> ⚠️ This feature can impact performance. It is not recommended for use in high throughput applications.
+
+This feature can be enabled as follows:
+
+```typescript
+import { Settings } from 'typebox/system'
+
+// Corrective Parse: Enable
+
+Settings.Set({ correctiveParse: true })
+
+// Corrective Parse: Convert Value into the target type if reasonable conversion is possible.
+
+const R = Value.Parse(Type.String(), 'hello')      // const R: string = "hello"
+
+const S = Value.Parse(Type.String(), 12345)        // const S: string = "12345"
+
+// Corrective Parse: Reset (optional)
+
+Settings.Reset()
 ```

--- a/docs/docs/system/1_settings.html
+++ b/docs/docs/system/1_settings.html
@@ -40,11 +40,11 @@ console.log(Type.String())                          // const T = { &#39;~kind&#3
   useEval: boolean
 
   /**
-   * Enables or disables &#39;exactOptionalPropertyTypes&#39; check semantics. By default, TypeScript 
-   * allows optional properties to be assigned &#39;undefined&#39;. While this behavior differs from the 
-   * common interpretation of &#39;optional&#39; as meaning &#39;key may be absent&#39;, TypeBox adopts the default 
-   * TypeScript semantics to remain consistent with the language. This option is provided to align 
-   * runtime check semantics with projects that configure &#39;exactOptionalPropertyTypes: true&#39; in 
+   * Enables or disables &#39;exactOptionalPropertyTypes&#39; check semantics. By default, TypeScript
+   * allows optional properties to be assigned &#39;undefined&#39;. While this behavior differs from the
+   * common interpretation of &#39;optional&#39; as meaning &#39;key may be absent&#39;, TypeBox adopts the default
+   * TypeScript semantics to remain consistent with the language. This option is provided to align
+   * runtime check semantics with projects that configure &#39;exactOptionalPropertyTypes: true&#39; in
    * tsconfig.json.
    * @default false
    */
@@ -55,5 +55,15 @@ console.log(Type.String())                          // const T = { &#39;~kind&#3
    * @default false
    */
   enumerableKind: boolean
+  
+  /**
+   * Controls whether TypeBox uses corrective Parse. When enabled, TypeBox will attempt to recover invalid
+   * values during Parse by running a sequence of `Value.*` operations to `Convert`, `Default`, and `Clean`
+   * the value, followed by a subsequent `Assert`. Enabling this option may incur significant performance
+   * overhead for invalid values. It is recommended to keep this disabled in performance-sensitive
+   * applications.
+   * @default false
+   */
+  correctiveParse: boolean
 }
 </code></pre>

--- a/docs/docs/value/parse.html
+++ b/docs/docs/value/parse.html
@@ -1,11 +1,30 @@
 <h1>Parse</h1>
-<p>The Parse function attempts to parse a value and throws an error if the value is invalid. This function is similar to Decode, but it does not execute Decode callbacks. Parse is considered a faster version of Decode, as operations that transform values are skipped when the value already matches the expected type.</p>
-<blockquote>
-<p>The Parse function first checks a value against the provided type and returns immediately if it matches. If the value does not match, it is processed through a sequence of Clone, Clean, Convert, and Default operations, and then re-checked. If the value remains invalid, a ParseError error is thrown.</p>
-</blockquote>
+<p>The Parse function validates and returns a value that conforms to a given type. If the value does not satisfy the type, a parse error is thrown.</p>
 <h2>Example</h2>
 <p>Example usage is shown below.</p>
 <pre><code class="language-typescript">const R = Value.Parse(Type.String(), &#39;hello&#39;)      // const R: string = &quot;hello&quot;
 
-const E = Value.Parse(Type.String(), [{ x: 1 }])   // throws ParseError 
+const E = Value.Parse(Type.String(), 12345)        // throws ParseError 
+</code></pre>
+<h2>Corrective Parse</h2>
+<p>TypeBox provides an optional corrective parsing mode that attempts to repair invalid values before failing. When enabled, the parser runs a pipeline consisting of Convert, Default, and Clean, then re-asserts the value after processing. This feature can be useful when parsing environment variables into target types.</p>
+<blockquote>
+<p>⚠️ This feature can impact performance. It is not recommended for use in high throughput applications.</p>
+</blockquote>
+<p>This feature can be enabled as follows:</p>
+<pre><code class="language-typescript">import { Settings } from &#39;typebox/system&#39;
+
+// Corrective Parse: Enable
+
+Settings.Set({ correctiveParse: true })
+
+// Corrective Parse: Convert Value into the target type if reasonable conversion is possible.
+
+const R = Value.Parse(Type.String(), &#39;hello&#39;)      // const R: string = &quot;hello&quot;
+
+const S = Value.Parse(Type.String(), 12345)        // const S: string = &quot;12345&quot;
+
+// Corrective Parse: Reset (optional)
+
+Settings.Reset()
 </code></pre>

--- a/src/compile/validator.ts
+++ b/src/compile/validator.ts
@@ -28,11 +28,12 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
+import { Settings } from '../system/settings/index.ts'
 import { Arguments } from '../system/arguments/index.ts'
 import { Environment } from '../system/environment/index.ts'
 import { type TLocalizedValidationError } from '../error/index.ts'
 import { type StaticDecode, type StaticEncode, type TProperties, type TSchema, Base } from '../type/index.ts'
-import { Errors, Clean, Convert, Create, Default, Decode, Encode, HasCodec, Parser } from '../value/index.ts'
+import { Errors, Clean, Convert, Create, Default, Decode, Encode, HasCodec, Parser, ParseError } from '../value/index.ts'
 import { Build } from '../schema/index.ts'
 
 // ------------------------------------------------------------------
@@ -142,13 +143,12 @@ export class Validator<Context extends TProperties = TProperties, Type extends T
       this.check
     )
   }
-  // ----------------------------------------------------------------
-  // Parse | Decode | Encode
-  // ----------------------------------------------------------------
   /** Parses a value */
   public Parse(value: unknown): Encode {
-    const result = this.Check(value) ? value : Parser(this.context, this.type, value)
-    return result as never
+    const checked = this.Check(value)
+    if(checked) return value as never
+    if(Settings.Get().correctiveParse) return Parser(this.context, this.type, value) as never
+    throw new ParseError(value, this.Errors(value))
   }
   /** Decodes a value */
   public Decode(value: unknown): Decode {

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -76,6 +76,16 @@ export interface TSettings {
    * @default false
    */
   enumerableKind: boolean
+
+  /**
+   * Controls whether TypeBox uses corrective Parse. When enabled, TypeBox will attempt to recover invalid
+   * values during Parse by running a sequence of `Value.*` operations to `Convert`, `Default`, and `Clean`
+   * the value, followed by a subsequent `Assert`. Enabling this option may incur significant performance
+   * overhead for invalid values. It is recommended to keep this disabled in performance-sensitive
+   * applications.
+   * @default false
+   */
+  correctiveParse: boolean
 }
 
 // Internal mutable state
@@ -84,7 +94,8 @@ const settings: TSettings = {
   maxErrors: 8,
   useEval: true,
   exactOptionalPropertyTypes: false,
-  enumerableKind: false
+  enumerableKind: false,
+  correctiveParse: false
 }
 
 /** Resets system settings to defaults */
@@ -94,6 +105,7 @@ export function Reset(): void {
   settings.useEval = true
   settings.exactOptionalPropertyTypes = false
   settings.enumerableKind = false
+  settings.correctiveParse = false
 }
 
 /** Sets system settings */

--- a/tasks.ts
+++ b/tasks.ts
@@ -8,7 +8,7 @@ import { Range } from './task/range/index.ts'
 import { Metrics } from './task/metrics/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.0.81'
+const Version = '1.1.0'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/compile/compile.ts
+++ b/test/typebox/runtime/compile/compile.ts
@@ -1,5 +1,5 @@
-import { Compile } from 'typebox/compile'
-import { Settings } from 'typebox/system'
+import System from 'typebox/system'
+import Compile from 'typebox/compile'
 import { Type } from 'typebox'
 import { Assert } from 'test'
 
@@ -38,14 +38,14 @@ Test('Should Compile 3', () => {
 // Disable Eval
 // ------------------------------------------------------------------
 Test('Should Compile 4', () => {
-  Settings.Set({ useEval: false })
+  System.Settings.Set({ useEval: false })
   const check = Compile({ A: Type.String() }, Type.Ref('A'))
   const checkResult = check.Check(1)
   const errorsResult = check.Errors(1)
   Assert.Throws(() => check.Parse({}))
   Assert.IsFalse(checkResult)
   Assert.IsTrue(errorsResult.length > 0)
-  Settings.Reset()
+  System.Settings.Reset()
 })
 // ------------------------------------------------------------------
 // Context | Schema
@@ -162,4 +162,91 @@ Test('Should Compile 17', () => {
   const A = Compile(Type.String({ default: 'hello' }))
   const C = A.IsEvaluated()
   Assert.IsTrue(typeof C === 'boolean')
+})
+// ------------------------------------------------------------------
+// Default Parse
+// ------------------------------------------------------------------
+Test('Should Parse Default 0', () => {
+  const T = Compile(Type.Number())
+  const output = T.Parse(1)
+  Assert.IsEqual(output, 1)
+})
+Test('Should Parse Default 1', () => {
+  const T = Compile(Type.Number())
+  Assert.Throws(() => T.Parse('1'))
+})
+// ------------------------------------------------------------------
+// Corrective Parse
+// ------------------------------------------------------------------
+Test('Should Parse Corrective 0 (Additional)', () => {
+  System.Settings.Set({ correctiveParse: true })
+  const T = Compile(Type.Object({
+    x: Type.Number(),
+    y: Type.Number()
+  }))
+  const input = { x: 1, y: 2, z: 3 }
+  const output = T.Parse(input)
+  Assert.IsEqual(output.x, 1)
+  Assert.IsEqual(output.y, 2)
+  Assert.HasPropertyKey(output, 'z')
+  System.Settings.Reset()
+})
+Test('Should Parse Corrective 1 (No Additional)', () => {
+  System.Settings.Set({ correctiveParse: true })
+  const T = Compile(Type.Object({
+    x: Type.Number(),
+    y: Type.Number()
+  }, { additionalProperties: false }))
+  const input = { x: 1, y: 2, z: 3 }
+  const output = T.Parse(input)
+  Assert.IsEqual(output.x, 1)
+  Assert.IsEqual(output.y, 2)
+  Assert.NotHasPropertyKey(output, 'z')
+  System.Settings.Reset()
+})
+Test('Should Parse Corrective 2 (Default)', () => {
+  System.Settings.Set({ correctiveParse: true })
+  const T = Compile(Type.Object({
+    x: Type.Number({ default: 1 }),
+    y: Type.Number({ default: 2 })
+  }))
+  const input = {}
+  const output = T.Parse(input)
+  Assert.IsEqual(output.x, 1)
+  Assert.IsEqual(output.y, 2)
+  System.Settings.Reset()
+})
+Test('Should Parse Corrective 3 (Default)', () => {
+  System.Settings.Set({ correctiveParse: true })
+  const T = Compile(Type.Object({
+    x: Type.Number({ default: 1 }),
+    y: Type.Number({ default: 2 })
+  }))
+  const input = { x: 3, y: 4 }
+  const output = T.Parse(input)
+  Assert.IsEqual(output.x, 3)
+  Assert.IsEqual(output.y, 4)
+  System.Settings.Reset()
+})
+Test('Should Parse Corrective 4 (Convert)', () => {
+  System.Settings.Set({ correctiveParse: true })
+  const T = Compile(Type.Object({
+    x: Type.Number({ default: 1 }),
+    y: Type.Number({ default: 2 })
+  }))
+  const input = { x: '3', y: '4' }
+  const output = T.Parse(input)
+  Assert.IsEqual(output.x, 3)
+  Assert.IsEqual(output.y, 4)
+  System.Settings.Reset()
+})
+Test('Should Parse Corrective 5 (Assert)', () => {
+  System.Settings.Set({ correctiveParse: true })
+  const T = Compile(Type.Object({
+    x: Type.Number({ default: 1 }),
+    y: Type.Number({ default: 2 })
+  }))
+  const input = undefined
+  Assert.Throws(() => T.Parse(input))
+  System.Settings.Reset()
 })

--- a/test/typebox/runtime/value/parse/parse.ts
+++ b/test/typebox/runtime/value/parse/parse.ts
@@ -1,10 +1,35 @@
 import { Assert } from 'test'
+import System from 'typebox/system'
 import Value from 'typebox/value'
 import Type from 'typebox'
 
 const Test = Assert.Context('Value.Parse')
 
-Test('Should Parse 0 (Additional)', () => {
+// ------------------------------------------------------------------
+// Default Parse
+// ----------------------------------------------------------------
+Test('Should Parse Context 0', () => {
+  const T = Type.Number()
+  const output = Value.Parse({ T }, Type.Ref('T'), 1)
+  Assert.IsEqual(output, 1)
+})
+// ------------------------------------------------------------------
+// Default Parse
+// ------------------------------------------------------------------
+Test('Should Parse Default 0', () => {
+  const T = Type.Number()
+  const output = Value.Parse(T, 1)
+  Assert.IsEqual(output, 1)
+})
+Test('Should Parse Default 1', () => {
+  const T = Type.Number()
+  Assert.Throws(() => Value.Parse(T, '1'))
+})
+// ------------------------------------------------------------------
+// Corrective Parse
+// ------------------------------------------------------------------
+Test('Should Parse Corrective 0 (Additional)', () => {
+  System.Settings.Set({ correctiveParse: true })
   const T = Type.Object({
     x: Type.Number(),
     y: Type.Number()
@@ -14,9 +39,10 @@ Test('Should Parse 0 (Additional)', () => {
   Assert.IsEqual(output.x, 1)
   Assert.IsEqual(output.y, 2)
   Assert.HasPropertyKey(output, 'z')
+  System.Settings.Reset()
 })
-
-Test('Should Parse 1 (No Additional)', () => {
+Test('Should Parse Corrective 1 (No Additional)', () => {
+  System.Settings.Set({ correctiveParse: true })
   const T = Type.Object({
     x: Type.Number(),
     y: Type.Number()
@@ -26,8 +52,10 @@ Test('Should Parse 1 (No Additional)', () => {
   Assert.IsEqual(output.x, 1)
   Assert.IsEqual(output.y, 2)
   Assert.NotHasPropertyKey(output, 'z')
+  System.Settings.Reset()
 })
-Test('Should Parse 2 (Default)', () => {
+Test('Should Parse Corrective 2 (Default)', () => {
+  System.Settings.Set({ correctiveParse: true })
   const T = Type.Object({
     x: Type.Number({ default: 1 }),
     y: Type.Number({ default: 2 })
@@ -36,8 +64,10 @@ Test('Should Parse 2 (Default)', () => {
   const output = Value.Parse(T, input)
   Assert.IsEqual(output.x, 1)
   Assert.IsEqual(output.y, 2)
+  System.Settings.Reset()
 })
-Test('Should Parse 3 (Default)', () => {
+Test('Should Parse Corrective 3 (Default)', () => {
+  System.Settings.Set({ correctiveParse: true })
   const T = Type.Object({
     x: Type.Number({ default: 1 }),
     y: Type.Number({ default: 2 })
@@ -46,8 +76,10 @@ Test('Should Parse 3 (Default)', () => {
   const output = Value.Parse(T, input)
   Assert.IsEqual(output.x, 3)
   Assert.IsEqual(output.y, 4)
+  System.Settings.Reset()
 })
-Test('Should Parse 4 (Convert)', () => {
+Test('Should Parse Corrective 4 (Convert)', () => {
+  System.Settings.Set({ correctiveParse: true })
   const T = Type.Object({
     x: Type.Number({ default: 1 }),
     y: Type.Number({ default: 2 })
@@ -56,12 +88,15 @@ Test('Should Parse 4 (Convert)', () => {
   const output = Value.Parse(T, input)
   Assert.IsEqual(output.x, 3)
   Assert.IsEqual(output.y, 4)
+  System.Settings.Reset()
 })
-Test('Should Parse 5 (Assert)', () => {
+Test('Should Parse Corrective 5 (Assert)', () => {
+  System.Settings.Set({ correctiveParse: true })
   const T = Type.Object({
     x: Type.Number({ default: 1 }),
     y: Type.Number({ default: 2 })
   })
   const input = undefined
   Assert.Throws(() => Value.Parse(T, input))
+  System.Settings.Reset()
 })


### PR DESCRIPTION
# 1.1.0

## Overview

Version 1.1.0 introduces a behavioral change to `Value.Parse(...)` and `Validator.Parse(...)` where automatic corrective parsing is now disabled by default. This change addresses performance overhead when handling invalid data and prepares the `Value.*` API for future revisions.

This update introduces a validation semantics change and as such is published under a minor semver version.

## Corrective Parse

In 1.0, a feature referred to as “Corrective Parse” was trialed. This feature meant that for any invalid value passed to Parse, TypeBox would attempt to Convert, Default, and Clean the value, then re-Check it before throwing an assertion. 

The feature was introduced in 1.0 in an effort to establish a de facto parsing pipeline for TypeBox, but it has since been observed that it incurs significant performance overhead for large invalid values. Additionally, the correction behavior has generally proven surprising to many users, and is therefore better expressed as an opt-in feature.

The following shows the changes from 1.0 to 1.1

```typescript
// 1.0 
const A = Value.Parse(Type.Number(), '12345') // A = 12345

// 1.1
const A = Value.Parse(Type.Number(), '12345') // throw! - Expected Number
```

Corrective parsing can be re-enabled by using the `{ correctiveParse: true }` configuration.

```typescript
import { Settings } from 'typebox/system'

Settings.Set({ correctiveParse: true })

// 1.1
const A = Value.Parse(Type.Number(), '12345') // A = 12345 - OK
```

---

A new compiler parsing system for Value.* will be explored in subsequent revisions later in the year.

