### PR TITLE
Version 1.1.22

### DIFF
--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.1.22](https://github.com/sinclairzx81/typebox/pull/1573)
+  - Include Support for 0.x Array Convert
 - [Revision 1.1.21](https://github.com/sinclairzx81/typebox/pull/1572)
   - Localize JIT Calls to System.Environment
 - [Revision 1.1.20](https://github.com/sinclairzx81/typebox/pull/1568)

--- a/src/system/environment/evaluate.ts
+++ b/src/system/environment/evaluate.ts
@@ -62,5 +62,5 @@ export function CanEvaluate(): boolean {
  * before calling this function.
  */
 export function Evaluate(...args: string[]): globalThis.Function {
-  return new globalThis.Function(...args)
+  return new (globalThis.Function)(...args)
 }

--- a/src/value/codec/has.ts
+++ b/src/value/codec/has.ts
@@ -1,10 +1,10 @@
 /*--------------------------------------------------------------------------
 
-@sinclair/typebox/value
+TypeBox
 
 The MIT License (MIT)
 
-Copyright (c) 2017-2026 Haydn Paterson (sinclair) <haydn.developer@gmail.com>
+Copyright (c) 2017-2026 Haydn Paterson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/value/convert/from-array.ts
+++ b/src/value/convert/from-array.ts
@@ -30,10 +30,9 @@ THE SOFTWARE.
 
 import type { TArray, TProperties } from '../../type/index.ts'
 import { FromType } from './from-type.ts'
-import { Guard } from '../../guard/index.ts'
+import { Try } from './try/index.ts'
 
 export function FromArray(context: TProperties, type: TArray, value: unknown): unknown {
-  return Guard.IsArray(value)
-    ? value.map(value => FromType(context, type.items, value))
-    : value
+  const result = Try.TryArray(value)
+  return result.value.map(value => FromType(context, type.items, value))
 }

--- a/src/value/convert/from-bigint.ts
+++ b/src/value/convert/from-bigint.ts
@@ -28,12 +28,10 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { Guard } from '../../guard/index.ts'
 import type { TBigInt, TProperties } from '../../type/index.ts'
 import { Try } from './try/index.ts'
 
 export function FromBigInt(_context: TProperties, _type: TBigInt, value: unknown): unknown {
-  if(Guard.IsBigInt(value)) return value
   const result = Try.TryBigInt(value)
   return Try.IsOk(result) ? result.value : value
 }

--- a/src/value/convert/from-boolean.ts
+++ b/src/value/convert/from-boolean.ts
@@ -28,12 +28,10 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { Guard } from '../../guard/index.ts'
 import type { TBoolean, TProperties } from '../../type/index.ts'
 import { Try } from './try/index.ts'
 
 export function FromBoolean(_context: TProperties, _type: TBoolean, value: unknown): unknown {
-  if(Guard.IsBoolean(value)) return value
   const result = Try.TryBoolean(value)
   return Try.IsOk(result) ? result.value : value
 }

--- a/src/value/convert/from-enum.ts
+++ b/src/value/convert/from-enum.ts
@@ -30,7 +30,6 @@ THE SOFTWARE.
 
 import { type TEnum, type TProperties } from '../../type/index.ts'
 import { EnumToUnion } from '../../type/engine/enum/index.ts'
-
 import { FromUnion } from './from-union.ts'
 
 export function FromEnum(context: TProperties, type: TEnum, value: unknown): unknown {

--- a/src/value/convert/from-integer.ts
+++ b/src/value/convert/from-integer.ts
@@ -29,11 +29,9 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import type { TInteger, TProperties } from '../../type/index.ts'
-import { Guard } from '../../guard/index.ts'
 import { Try } from './try/index.ts'
 
 export function FromInteger(_context: TProperties, _type: TInteger, value: unknown): unknown {
-  if(Guard.IsInteger(value)) return value
   const result = Try.TryNumber(value)
   return Try.IsOk(result) ? Math.trunc(result.value as number) : value
 }

--- a/src/value/convert/from-null.ts
+++ b/src/value/convert/from-null.ts
@@ -28,12 +28,10 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { Guard } from '../../guard/index.ts'
 import type { TNull, TProperties } from '../../type/index.ts'
 import { Try } from './try/index.ts'
 
 export function FromNull(_context: TProperties, _type: TNull, value: unknown): unknown {
-  if(Guard.IsNull(value)) return value
   const result = Try.TryNull(value)
   return Try.IsOk(result) ? result.value : value
 }

--- a/src/value/convert/from-number.ts
+++ b/src/value/convert/from-number.ts
@@ -29,11 +29,9 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import type { TNumber, TProperties } from '../../type/index.ts'
-import { Guard } from '../../guard/index.ts'
 import { Try } from './try/index.ts'
 
 export function FromNumber(_context: TProperties, _type: TNumber, value: unknown): unknown {
-  if(Guard.IsNumber(value)) return value
   const result = Try.TryNumber(value)
   return Try.IsOk(result) ? result.value : value
 }

--- a/src/value/convert/from-string.ts
+++ b/src/value/convert/from-string.ts
@@ -29,11 +29,9 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import type { TString, TProperties } from '../../type/index.ts'
-import { Guard } from '../../guard/index.ts'
 import { Try } from './try/index.ts'
 
 export function FromString(_context: TProperties, _type: TString, value: unknown): unknown {
-  if(Guard.IsString(value)) return value
   const result = Try.TryString(value)
   return Try.IsOk(result) ? result.value : value
 }

--- a/src/value/convert/from-type.ts
+++ b/src/value/convert/from-type.ts
@@ -28,7 +28,7 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import * as T from '../../type/index.ts'
+import * as Type from '../../type/index.ts'
 
 import { FromArray } from './from-array.ts'
 import { FromBase } from './from-base.ts'
@@ -51,28 +51,28 @@ import { FromUndefined } from './from-undefined.ts'
 import { FromUnion } from './from-union.ts'
 import { FromVoid } from './from-void.ts'
 
-export function FromType(context: T.TProperties, type: T.TSchema, value: unknown): unknown {
+export function FromType(context: Type.TProperties, type: Type.TSchema, value: unknown): unknown {
   return (
-    T.IsArray(type) ? FromArray(context, type, value) :
-    T.IsBase(type) ? FromBase(context, type, value) :
-    T.IsBigInt(type) ? FromBigInt(context, type, value) :
-    T.IsBoolean(type) ? FromBoolean(context, type, value) :
-    T.IsCyclic(type) ? FromCyclic(context, type, value) :
-    T.IsEnum(type) ? FromEnum(context, type, value) :
-    T.IsInteger(type) ? FromInteger(context, type, value) :
-    T.IsIntersect(type) ? FromIntersect(context, type, value) :
-    T.IsLiteral(type) ? FromLiteral(context, type, value) :
-    T.IsNull(type) ? FromNull(context, type, value) :
-    T.IsNumber(type) ? FromNumber(context, type, value) :
-    T.IsObject(type) ? FromObject(context, type, value) :
-    T.IsRecord(type) ? FromRecord(context, type, value) :
-    T.IsRef(type) ? FromRef(context, type, value) :
-    T.IsString(type) ? FromString(context, type, value) :
-    T.IsTemplateLiteral(type) ? FromTemplateLiteral(context, type, value) :
-    T.IsTuple(type) ? FromTuple(context, type, value) :
-    T.IsUndefined(type) ? FromUndefined(context, type, value) :
-    T.IsUnion(type) ? FromUnion(context, type, value) : 
-    T.IsVoid(type) ? FromVoid(context, type, value) :
+    Type.IsArray(type) ? FromArray(context, type, value) :
+    Type.IsBase(type) ? FromBase(context, type, value) :
+    Type.IsBigInt(type) ? FromBigInt(context, type, value) :
+    Type.IsBoolean(type) ? FromBoolean(context, type, value) :
+    Type.IsCyclic(type) ? FromCyclic(context, type, value) :
+    Type.IsEnum(type) ? FromEnum(context, type, value) :
+    Type.IsInteger(type) ? FromInteger(context, type, value) :
+    Type.IsIntersect(type) ? FromIntersect(context, type, value) :
+    Type.IsLiteral(type) ? FromLiteral(context, type, value) :
+    Type.IsNull(type) ? FromNull(context, type, value) :
+    Type.IsNumber(type) ? FromNumber(context, type, value) :
+    Type.IsObject(type) ? FromObject(context, type, value) :
+    Type.IsRecord(type) ? FromRecord(context, type, value) :
+    Type.IsRef(type) ? FromRef(context, type, value) :
+    Type.IsString(type) ? FromString(context, type, value) :
+    Type.IsTemplateLiteral(type) ? FromTemplateLiteral(context, type, value) :
+    Type.IsTuple(type) ? FromTuple(context, type, value) :
+    Type.IsUndefined(type) ? FromUndefined(context, type, value) :
+    Type.IsUnion(type) ? FromUnion(context, type, value) : 
+    Type.IsVoid(type) ? FromVoid(context, type, value) :
     value
   )
 }

--- a/src/value/convert/from-undefined.ts
+++ b/src/value/convert/from-undefined.ts
@@ -29,11 +29,9 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import type { TUndefined, TProperties } from '../../type/index.ts'
-import { Guard } from '../../guard/index.ts'
 import { Try } from './try/index.ts'
 
 export function FromUndefined(_context: TProperties, _type: TUndefined, value: unknown): unknown {
-  if(Guard.IsUndefined(value)) return value
   const result = Try.TryUndefined(value)
   return Try.IsOk(result) ? result.value : value
 }

--- a/src/value/convert/from-void.ts
+++ b/src/value/convert/from-void.ts
@@ -29,11 +29,9 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import type { TVoid, TProperties } from '../../type/index.ts'
-import { Guard } from '../../guard/index.ts'
 import { Try } from './try/index.ts'
 
 export function FromVoid(_context: TProperties, _type: TVoid, value: unknown): unknown {
-  if(Guard.IsUndefined(value)) return value
   const result = Try.TryUndefined(value)
   return Try.IsOk(result) ? (void 0) : value
 }

--- a/src/value/convert/try/try-array.ts
+++ b/src/value/convert/try/try-array.ts
@@ -28,16 +28,9 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import type { TUnion, TProperties } from '../../type/index.ts'
-import { Guard } from '../../guard/index.ts'
-import { Check } from '../check/index.ts'
-import { Clone } from '../clone/index.ts'
-import { FromType } from './from-type.ts'
+import { Guard } from '../../../guard/index.ts'
+import { Ok, type TOk } from './try-result.ts'
 
-export function FromUnion(context: TProperties, type: TUnion, value: unknown): unknown {
-  const matched = type.anyOf.some(type => Check(context, type, value))
-  if(matched) return value
-  const candidates = type.anyOf.map(type => FromType(context, type, Clone(value)))
-  const selected = candidates.find(value => Check(context, type, value))
-  return Guard.IsUndefined(selected) ? value : selected
+export function TryArray(value: unknown): TOk<unknown[]> {
+  return Guard.IsArray(value) ? Ok(value) : Ok([value])
 }

--- a/src/value/convert/try/try-bigint.ts
+++ b/src/value/convert/try/try-bigint.ts
@@ -27,36 +27,15 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 // deno-fmt-ignore-file
-// deno-lint-ignore-file
 
 import { Guard } from '../../../guard/index.ts'
 import { TResult, Ok, Fail } from './try-result.ts'
 
 // ------------------------------------------------------------------
-// BigInt
-// ------------------------------------------------------------------
-// deno-coverage-ignore-start - unreachable | guarded
-function FromBigInt(value: bigint): TResult<bigint> {
-   return Ok(value)
-}
-// deno-coverage-ignore-stop
-// ------------------------------------------------------------------
 // Boolean
 // ------------------------------------------------------------------
 function FromBoolean(value: boolean): TResult<bigint> {
   return Guard.IsEqual(value, true) ? Ok(BigInt(1)) : Ok(BigInt(0))
-}
-// ------------------------------------------------------------------
-// Number
-// ------------------------------------------------------------------
-function FromNumber(value: number): TResult<bigint> { 
-  return Ok(BigInt(Math.trunc(value)))
-}
-// ------------------------------------------------------------------
-// Null
-// ------------------------------------------------------------------
-function FromNull(value: null): TResult<bigint> { 
-  return Ok(BigInt(0))
 }
 // ------------------------------------------------------------------
 // String
@@ -85,24 +64,16 @@ function FromString(value: string): TResult<bigint> {
   )
 }
 // ------------------------------------------------------------------
-// Undefined
-// ------------------------------------------------------------------
-function FromUndefined(value: undefined): TResult<bigint> { 
-  return Ok(BigInt(0))
-}
-// ------------------------------------------------------------------
 // Try
 // ------------------------------------------------------------------
-// deno-coverage-ignore-start - unreachable | guarded
 export function TryBigInt(value: unknown): TResult<bigint> {
   return (
-    Guard.IsBigInt(value) ? FromBigInt(value) :
+    Guard.IsBigInt(value) ? Ok(value) :
     Guard.IsBoolean(value) ? FromBoolean(value) :
-    Guard.IsNumber(value) ? FromNumber(value) :
-    Guard.IsNull(value) ? FromNull(value) :
+    Guard.IsNumber(value) ? Ok(BigInt(Math.trunc(value))) :
+    Guard.IsNull(value) ? Ok(BigInt(0)) :
     Guard.IsString(value) ? FromString(value) :
-    Guard.IsUndefined(value) ? FromUndefined(value) :
+    Guard.IsUndefined(value) ? Ok(BigInt(0)) :
     Fail()
   )
 }
-// deno-coverage-ignore-stop

--- a/src/value/convert/try/try-boolean.ts
+++ b/src/value/convert/try/try-boolean.ts
@@ -27,7 +27,6 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 // deno-fmt-ignore-file
-// deno-lint-ignore-file
 
 import { Guard } from '../../../guard/index.ts'
 import { TResult, Ok, Fail } from './try-result.ts'
@@ -37,66 +36,44 @@ import { TResult, Ok, Fail } from './try-result.ts'
 // ------------------------------------------------------------------
 function FromBigInt(value: bigint): TResult<boolean> {
   return (
-    Guard.IsEqual(value, BigInt(0)) ? Ok(false) : 
+    Guard.IsEqual(value, BigInt(0)) ? Ok(false) :
     Guard.IsEqual(value, BigInt(1)) ? Ok(true) :
     Fail()
   )
 }
 // ------------------------------------------------------------------
-// Boolean
-// ------------------------------------------------------------------
-// deno-coverage-ignore-start - unreachable | guarded
-function FromBoolean(value: boolean): TResult<boolean> {
-  return Ok(value)
-}
-// deno-coverage-ignore-stop
-// ------------------------------------------------------------------
 // Number
 // ------------------------------------------------------------------
-function FromNumber(value: number): TResult<boolean> { 
+function FromNumber(value: number): TResult<boolean> {
   return (
-    Guard.IsEqual(value, 0) ? Ok(false) : 
-    Guard.IsEqual(value, 1) ? Ok(true) : 
+    Guard.IsEqual(value, 0) ? Ok(false) :
+    Guard.IsEqual(value, 1) ? Ok(true) :
     Fail()
   )
-}
-// ------------------------------------------------------------------
-// Null
-// ------------------------------------------------------------------
-function FromNull(value: null): TResult<boolean> { 
-  return Ok(false) 
 }
 // ------------------------------------------------------------------
 // String
 // ------------------------------------------------------------------
 function FromString(value: string): TResult<boolean> {
   return (
-    Guard.IsEqual(value.toLowerCase(), 'false') ? Ok(false) : 
-    Guard.IsEqual(value.toLowerCase(), 'true') ? Ok(true) : 
-    Guard.IsEqual(value, '0') ? Ok(false) : 
-    Guard.IsEqual(value, '1') ? Ok(true) : 
+    Guard.IsEqual(value.toLowerCase(), 'false') ? Ok(false) :
+    Guard.IsEqual(value.toLowerCase(), 'true') ? Ok(true) :
+    Guard.IsEqual(value, '0') ? Ok(false) :
+    Guard.IsEqual(value, '1') ? Ok(true) :
     Fail()
   )
-}
-// ------------------------------------------------------------------
-// Undefined
-// ------------------------------------------------------------------
-function FromUndefined(value: undefined): TResult<boolean> { 
-  return Ok(false) 
 }
 // ------------------------------------------------------------------
 // Try
 // ------------------------------------------------------------------
-// deno-coverage-ignore-start - unreachable | guarded
 export function TryBoolean(value: unknown): TResult<boolean> {
   return (
     Guard.IsBigInt(value) ? FromBigInt(value) :
-    Guard.IsBoolean(value) ? FromBoolean(value) :
+    Guard.IsBoolean(value) ? Ok(value) :
     Guard.IsNumber(value) ? FromNumber(value) :
-    Guard.IsNull(value) ? FromNull(value) :
+    Guard.IsNull(value) ? Ok(false) :
     Guard.IsString(value) ? FromString(value) :
-    Guard.IsUndefined(value) ? FromUndefined(value) :
+    Guard.IsUndefined(value) ? Ok(false) :
     Fail()
   )
 }
-// deno-coverage-ignore-stop

--- a/src/value/convert/try/try-null.ts
+++ b/src/value/convert/try/try-null.ts
@@ -27,7 +27,6 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 // deno-fmt-ignore-file
-// deno-lint-ignore-file
 
 import { Guard } from '../../../guard/index.ts'
 import { TResult, Ok, Fail } from './try-result.ts'
@@ -36,7 +35,7 @@ import { TResult, Ok, Fail } from './try-result.ts'
 // BigInt
 // ------------------------------------------------------------------
 function FromBigInt(value: bigint): TResult<null> {
-   return Guard.IsEqual(value, BigInt(0)) ? Ok(null) : Fail()
+  return Guard.IsEqual(value, BigInt(0)) ? Ok(null) : Fail()
 }
 // ------------------------------------------------------------------
 // Boolean
@@ -47,17 +46,9 @@ function FromBoolean(value: boolean): TResult<null> {
 // ------------------------------------------------------------------
 // Number
 // ------------------------------------------------------------------
-function FromNumber(value: number): TResult<null> { 
+function FromNumber(value: number): TResult<null> {
   return Guard.IsEqual(value, 0) ? Ok(null) : Fail()
 }
-// ------------------------------------------------------------------
-// Null
-// ------------------------------------------------------------------
-// deno-coverage-ignore-start - unreachable | guarded
-function FromNull(value: null): TResult<null> { 
-  return Ok(null)
-}
-// deno-coverage-ignore-stop
 // ------------------------------------------------------------------
 // String
 // ------------------------------------------------------------------
@@ -70,24 +61,16 @@ function FromString(value: string): TResult<null> {
   return predicate ? Ok(null) : Fail()
 }
 // ------------------------------------------------------------------
-// Undefined
-// ------------------------------------------------------------------
-function FromUndefined(value: undefined): TResult<null> { 
-  return Ok(null)
-}
-// ------------------------------------------------------------------
 // Try
 // ------------------------------------------------------------------
-// deno-coverage-ignore-start - unreachable | guarded
 export function TryNull(value: unknown): TResult<null> {
   return (
     Guard.IsBigInt(value) ? FromBigInt(value) :
     Guard.IsBoolean(value) ? FromBoolean(value) :
     Guard.IsNumber(value) ? FromNumber(value) :
-    Guard.IsNull(value) ? FromNull(value) :
+    Guard.IsNull(value) ? Ok(null) :
     Guard.IsString(value) ? FromString(value) :
-    Guard.IsUndefined(value) ? FromUndefined(value) :
+    Guard.IsUndefined(value) ? Ok(null) :
     Fail()
   )
 }
-// deno-coverage-ignore-stop

--- a/src/value/convert/try/try-number.ts
+++ b/src/value/convert/try/try-number.ts
@@ -27,14 +27,9 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 // deno-fmt-ignore-file
-// deno-lint-ignore-file
 
 import { Guard } from '../../../guard/index.ts'
 import { TResult, Ok, Fail, IsOk } from './try-result.ts'
-
-// ------------------------------------------------------------------
-// Two-Phase
-// ------------------------------------------------------------------
 import { TryBigInt } from './try-bigint.ts'
 
 // ------------------------------------------------------------------
@@ -42,31 +37,11 @@ import { TryBigInt } from './try-bigint.ts'
 // ------------------------------------------------------------------
 const maxBigInt = BigInt(Number.MAX_SAFE_INTEGER)
 const minBigInt = BigInt(Number.MIN_SAFE_INTEGER)
-function CanBigIntDowncast(value: bigint): boolean {
-  return (value <= maxBigInt && value >= minBigInt)
-}
 function FromBigInt(value: bigint): TResult<number> {
-  return CanBigIntDowncast(value) ? Ok(Number(value)) : Fail()
+  return (value <= maxBigInt && value >= minBigInt) ? Ok(Number(value)) : Fail()
 }
-// ------------------------------------------------------------------
-// Boolean
-// ------------------------------------------------------------------
 function FromBoolean(value: boolean): TResult<number> {
-  return value ? Ok(1) : Ok(0)
-}
-// ------------------------------------------------------------------
-// Number
-// ------------------------------------------------------------------
-// deno-coverage-ignore-start - unreachable | guarded
-function FromNumber(value: number): TResult<number> {
-  return Ok(value)
-}
-// deno-coverage-ignore-stop
-// ------------------------------------------------------------------
-// Null
-// ------------------------------------------------------------------
-function FromNull(value: null): TResult<number> {
-  return Ok(0)
+  return Ok(value ? 1 : 0)
 }
 // ------------------------------------------------------------------
 // String
@@ -74,34 +49,24 @@ function FromNull(value: null): TResult<number> {
 function FromString(value: string): TResult<number> {
   const coerced = +value
   if (Guard.IsNumber(coerced)) return Ok(coerced)
-  
   const lowercase = value.toLowerCase()
-  if(Guard.IsEqual(lowercase, 'false')) return Ok(0)
-  if(Guard.IsEqual(lowercase, 'true')) return Ok(1)
-
+  if (Guard.IsEqual(lowercase, 'false')) return Ok(0)
+  if (Guard.IsEqual(lowercase, 'true')) return Ok(1)
   const result = TryBigInt(value)
-  if (IsOk(result)) return FromBigInt(result.value)
+  if (IsOk(result)) return (result.value <= maxBigInt && result.value >= minBigInt) ? Ok(Number(result.value)) : Fail()
   return Fail()
-}
-// ------------------------------------------------------------------
-// Undefined
-// ------------------------------------------------------------------
-function FromUndefined(value: undefined): TResult<number> {
-  return Ok(0)
 }
 // ------------------------------------------------------------------
 // Try
 // ------------------------------------------------------------------
-// deno-coverage-ignore-start - unreachable | guarded
 export function TryNumber(value: unknown): TResult<number> {
   return (
     Guard.IsBigInt(value) ? FromBigInt(value) :
     Guard.IsBoolean(value) ? FromBoolean(value) :
-    Guard.IsNumber(value) ? FromNumber(value) :
-    Guard.IsNull(value) ? FromNull(value) :
+    Guard.IsNumber(value) ? Ok(value) :
+    Guard.IsNull(value) ? Ok(0) :
     Guard.IsString(value) ? FromString(value) :
-    Guard.IsUndefined(value) ? FromUndefined(value) :
+    Guard.IsUndefined(value) ? Ok(0) :
     Fail()
   )
 }
-// deno-coverage-ignore-stop

--- a/src/value/convert/try/try-result.ts
+++ b/src/value/convert/try/try-result.ts
@@ -27,7 +27,6 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 // deno-fmt-ignore-file
-// deno-lint-ignore-file
 
 import { Guard } from '../../../guard/index.ts'
 
@@ -42,21 +41,18 @@ export type TResult<Value extends unknown = unknown> =
 // Fail
 // ------------------------------------------------------------------
 export type TFail = undefined
-
 // ------------------------------------------------------------------
 // Ok
 // ------------------------------------------------------------------
 export type TOk<Value extends unknown = unknown> = {
   value: Value
 }
-
 // ------------------------------------------------------------------
 // Guard
 // ------------------------------------------------------------------
 export function IsOk<Result extends TResult>(value: Result): value is Exclude<Result, TFail> {
   return Guard.IsObject(value) && Guard.HasPropertyKey(value, 'value')
 }
-
 // ------------------------------------------------------------------
 // Factory
 // ------------------------------------------------------------------

--- a/src/value/convert/try/try-string.ts
+++ b/src/value/convert/try/try-string.ts
@@ -27,62 +27,18 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 // deno-fmt-ignore-file
-// deno-lint-ignore-file
 
 import { Guard } from '../../../guard/index.ts'
 import { TResult, Ok, Fail } from './try-result.ts'
 
-// ------------------------------------------------------------------
-// BigInt
-// ------------------------------------------------------------------
-function FromBigInt(value: bigint): TResult {
-   return Ok(value.toString())
-}
-// ------------------------------------------------------------------
-// Boolean
-// ------------------------------------------------------------------
-function FromBoolean(value: boolean): TResult {
-  return Ok(value.toString())
-}
-// ------------------------------------------------------------------
-// Number
-// ------------------------------------------------------------------
-function FromNumber(value: number): TResult { 
-  return Ok(value.toString())
-}
-// ------------------------------------------------------------------
-// Null
-// ------------------------------------------------------------------
-function FromNull(value: null): TResult { 
-  return Ok('null')
-}
-// ------------------------------------------------------------------
-// String
-// ------------------------------------------------------------------
-// deno-coverage-ignore-start - unreachable | guarded
-function FromString(value: string): TResult {
-  return Ok(value)
-}
-// deno-coverage-ignore-stop
-// ------------------------------------------------------------------
-// Undefined
-// ------------------------------------------------------------------
-function FromUndefined(value: undefined): TResult { 
-  return Ok('')
-}
-// ------------------------------------------------------------------
-// Try
-// ------------------------------------------------------------------
-// deno-coverage-ignore-start - unreachable | guarded
 export function TryString(value: unknown): TResult {
   return (
-    Guard.IsBigInt(value) ? FromBigInt(value) :
-    Guard.IsBoolean(value) ? FromBoolean(value) :
-    Guard.IsNumber(value) ? FromNumber(value) :
-    Guard.IsNull(value) ? FromNull(value) :
-    Guard.IsString(value) ? FromString(value) :
-    Guard.IsUndefined(value) ? FromUndefined(value) :
+    Guard.IsBigInt(value) ? Ok(value.toString()) :
+    Guard.IsBoolean(value) ? Ok(value.toString()) :
+    Guard.IsNumber(value) ? Ok(value.toString()) :
+    Guard.IsNull(value) ? Ok('null') :
+    Guard.IsString(value) ? Ok(value) :
+    Guard.IsUndefined(value) ? Ok('') :
     Fail()
   )
 }
-// deno-coverage-ignore-stop

--- a/src/value/convert/try/try-undefined.ts
+++ b/src/value/convert/try/try-undefined.ts
@@ -27,7 +27,6 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 // deno-fmt-ignore-file
-// deno-lint-ignore-file
 
 import { Guard } from '../../../guard/index.ts'
 import { TResult, Ok, Fail } from './try-result.ts'
@@ -51,12 +50,6 @@ function FromNumber(value: number): TResult<undefined> {
   return Guard.IsEqual(value, 0) ? Ok(undefined) : Fail()
 }
 // ------------------------------------------------------------------
-// Null
-// ------------------------------------------------------------------
-function FromNull(value: null): TResult<undefined> { 
-  return Ok(undefined)
-}
-// ------------------------------------------------------------------
 // String
 // ------------------------------------------------------------------
 function FromString(value: string): TResult<undefined> {
@@ -68,27 +61,16 @@ function FromString(value: string): TResult<undefined> {
   return predicate ? Ok(undefined) : Fail()
 }
 // ------------------------------------------------------------------
-// Undefined
-// ------------------------------------------------------------------
-// deno-coverage-ignore-start - unreachable | guarded
-function FromUndefined(value: undefined): TResult<undefined> { 
-  return Ok(undefined)
-}
-// deno-coverage-ignore-stop
-
-// ------------------------------------------------------------------
 // Try
 // ------------------------------------------------------------------
-// deno-coverage-ignore-start - unreachable | guarded
 export function TryUndefined(value: unknown): TResult<undefined> {
   return (
     Guard.IsBigInt(value) ? FromBigInt(value) :
     Guard.IsBoolean(value) ? FromBoolean(value) :
     Guard.IsNumber(value) ? FromNumber(value) :
-    Guard.IsNull(value) ? FromNull(value) :
+    Guard.IsNull(value) ? Ok(undefined) :
     Guard.IsString(value) ? FromString(value) :
-    Guard.IsUndefined(value) ? FromUndefined(value) :
+    Guard.IsUndefined(value) ? Ok(value) :
     Fail()
   )
 }
-// deno-coverage-ignore-stop

--- a/src/value/convert/try/try.ts
+++ b/src/value/convert/try/try.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+export * from './try-array.ts'
 export * from './try-bigint.ts'
 export * from './try-boolean.ts'
 export * from './try-null.ts'

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.1.21'
+const Version = '1.1.22'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/value/convert/array.ts
+++ b/test/typebox/runtime/value/convert/array.ts
@@ -20,10 +20,143 @@ Test('Should Convert 3', () => {
   Assert.IsEqual(R, ['1', '3.14', '1', '3.14', 'true', 'false', 'true', 'false', 'hello'])
 })
 // ------------------------------------------------------------------
-// Deprecated support for Array coercion
+// Added support for Array coercion
+//
+// https://github.com/sinclairzx81/typebox/issues/1469
 // ------------------------------------------------------------------
 Test('Should Convert 4', () => {
   const T = Type.Array(Type.Number())
   const R = Value.Convert(T, '1')
-  Assert.IsEqual(R, '1')
+  Assert.IsEqual(R, [1])
+})
+Test('Should Convert 5', () => {
+  const T = Type.Array(Type.Number())
+  const R = Value.Convert(T, [])
+  Assert.IsEqual(R, [])
+})
+Test('Should Convert 6', () => {
+  const T = Type.Array(Type.Number())
+  const R = Value.Convert(T, 42)
+  Assert.IsEqual(R, [42])
+})
+Test('Should Convert 7', () => {
+  const T = Type.Array(Type.Boolean())
+  const R = Value.Convert(T, true)
+  Assert.IsEqual(R, [true])
+})
+Test('Should Convert 8', () => {
+  const T = Type.Array(Type.Null())
+  const R = Value.Convert(T, null)
+  Assert.IsEqual(R, [null])
+})
+Test('Should Convert 9', () => {
+  const T = Type.Array(Type.Unknown())
+  const R = Value.Convert(T, undefined)
+  Assert.IsEqual(R, [undefined])
+})
+Test('Should Convert 10', () => {
+  const T = Type.Array(Type.BigInt())
+  const R = Value.Convert(T, 1n)
+  Assert.IsEqual(R, [1n])
+})
+Test('Should Convert 11', () => {
+  const T = Type.Array(Type.Object({}))
+  const R = Value.Convert(T, {})
+  Assert.IsEqual(R, [{}])
+})
+Test('Should Convert 12', () => {
+  const T = Type.Array(Type.Object({ x: Type.Number() }))
+  const R = Value.Convert(T, { x: 1 })
+  Assert.IsEqual(R, [{ x: 1 }])
+})
+Test('Should Convert 13', () => {
+  const T = Type.Array(Type.Number())
+  const R = Value.Convert(T, '42')
+  Assert.IsEqual(R, [42])
+})
+Test('Should Convert 14', () => {
+  const T = Type.Array(Type.Boolean())
+  const R = Value.Convert(T, 'true')
+  Assert.IsEqual(R, [true])
+})
+Test('Should Convert 15', () => {
+  const T = Type.Array(Type.Boolean())
+  const R = Value.Convert(T, 0)
+  Assert.IsEqual(R, [false])
+})
+Test('Should Convert 16', () => {
+  const T = Type.Array(Type.Number())
+  const R = Value.Convert(T, 'hello')
+  Assert.IsEqual(R, ['hello'])
+})
+Test('Should Convert 17', () => {
+  const T = Type.Array(Type.Number())
+  const R = Value.Convert(T, [1])
+  Assert.IsEqual(R, [1])
+})
+Test('Should Convert 18', () => {
+  const T = Type.Array(Type.Array(Type.Number()))
+  const R = Value.Convert(T, [1, 2, 3])
+  Assert.IsTrue(Value.Check(T, R))
+})
+Test('Should Convert 19', () => {
+  const T = Type.Array(Type.Number())
+  const R = Value.Convert(T, { 0: 1, length: 1 })
+  Assert.IsEqual(R, [{ 0: 1, length: 1 }])
+})
+Test('Should Convert 20', () => {
+  const T = Type.Array(Type.Array(Type.Number()))
+  const R = Value.Convert(T, 42)
+  Assert.IsTrue(Value.Check(T, R))
+})
+// ------------------------------------------------------------------
+// Union
+// ------------------------------------------------------------------
+Test('Should Convert 21', () => {
+  const T = Type.Array(Type.Union([Type.Number(), Type.String()]))
+  const R = Value.Convert(T, 1)
+  Assert.IsTrue(Value.Check(T, R))
+})
+Test('Should Convert 22', () => {
+  const T = Type.Array(Type.Union([Type.Number(), Type.String()]))
+  const R = Value.Convert(T, 'hello')
+  Assert.IsTrue(Value.Check(T, R))
+})
+Test('Should Convert 23', () => {
+  const T = Type.Array(Type.Union([Type.Number(), Type.String()]))
+  const R = Value.Convert(T, [1, 'hello', true, '3.14'])
+  Assert.IsTrue(Value.Check(T, R))
+})
+Test('Should Convert 24', () => {
+  const T = Type.Union([Type.Array(Type.Number()), Type.String()])
+  const R = Value.Convert(T, '1')
+  Assert.IsTrue(Value.Check(T, R))
+})
+Test('Should Convert 25', () => {
+  const T = Type.Array(Type.Union([Type.Array(Type.Number()), Type.String()]))
+  const R = Value.Convert(T, 42)
+  Assert.IsTrue(Value.Check(T, R))
+})
+// ------------------------------------------------------------------
+// Embedded Intersect
+// ------------------------------------------------------------------
+Test('Should Convert 26', () => {
+  const T = Type.Array(Type.Intersect([Type.Object({ x: Type.Number() }), Type.Object({ y: Type.Number() })]))
+  const R = Value.Convert(T, { x: 1, y: 2 })
+  Assert.IsTrue(Value.Check(T, R))
+})
+Test('Should Convert 27', () => {
+  const T = Type.Array(Type.Intersect([Type.Object({ x: Type.Number() }), Type.Object({ y: Type.Number() })]))
+  const R = Value.Convert(T, [{ x: '1', y: '2' }, { x: '3', y: '4' }])
+  Assert.IsTrue(Value.Check(T, R))
+})
+Test('Should Convert 28', () => {
+  const T = Type.Intersect([Type.Array(Type.Number()), Type.Array(Type.Number())])
+  const R = Value.Convert(T, 42)
+  Assert.IsTrue(Value.Check(T, R))
+})
+Test('Should Convert 29', () => {
+  const T = Type.Intersect([Type.Array(Type.Number()), Type.Object({ x: Type.Number() })])
+  const R = Value.Convert(T, 42)
+  Assert.IsFalse(Value.Check(T, R))
 })

--- a/test/typebox/runtime/value/convert/number.ts
+++ b/test/typebox/runtime/value/convert/number.ts
@@ -130,3 +130,8 @@ Test('Should Convert 19', () => {
   const R = Value.Convert(T, undefined)
   Assert.IsEqual(R, 0)
 })
+Test('Should Convert 20', () => {
+  const T = Type.Number()
+  const R = Value.Convert(T, `90071992547409910n`) // trailing 0 too large
+  Assert.IsEqual(R, '90071992547409910n')
+})

--- a/test/typebox/runtime/value/convert/tuple.ts
+++ b/test/typebox/runtime/value/convert/tuple.ts
@@ -19,3 +19,23 @@ Test('Should Convert 3', () => {
   const R = Value.Convert(T, ['1', '2', '3'])
   Assert.IsEqual(R, [1, 2, '3'])
 })
+Test('Should Convert 4', () => {
+  const T = Type.Tuple([Type.Number(), Type.Number()])
+  const R = Value.Convert(T, 'not an array')
+  Assert.IsEqual(R, 'not an array')
+})
+Test('Should Convert 5', () => {
+  const T = Type.Tuple([Type.Number(), Type.Number()])
+  const R = Value.Convert(T, 42)
+  Assert.IsEqual(R, 42)
+})
+Test('Should Convert 6', () => {
+  const T = Type.Tuple([Type.Number(), Type.Number()])
+  const R = Value.Convert(T, null)
+  Assert.IsEqual(R, null)
+})
+Test('Should Convert 7', () => {
+  const T = Type.Tuple([Type.Number(), Type.Number()])
+  const R = Value.Convert(T, { 0: '1', 1: '2' })
+  Assert.IsEqual(R, { 0: '1', 1: '2' })
+})


### PR DESCRIPTION
This PR re-adds Array Convert logic as per 0.x. The update also applies various reductions to the `Try` conversion suite, and defaults to using the Try/Result infrastructure pass-through to allow coverage tests to run for ternary logic (as Try is effectively private to Convert)

Fixes: https://github.com/sinclairzx81/typebox/issues/1469