### PR TITLE
Version 1.1.23

### DIFF
--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.1.23](https://github.com/sinclairzx81/typebox/pull/1575)
+  - Revert Email and IdnEmail
 - [Revision 1.1.22](https://github.com/sinclairzx81/typebox/pull/1573)
   - Include Support for 0.x Array Convert
 - [Revision 1.1.21](https://github.com/sinclairzx81/typebox/pull/1572)

--- a/design/website/docs/schema/6_specification.md
+++ b/design/website/docs/schema/6_specification.md
@@ -74,7 +74,7 @@ The following optional keywords, formats and proposals are also supported.
 | format/date-time | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | format/duration | - | - | - | - | ✅ | ✅ | ✅ |
 | format/ecmascript-regex | 1/2 | - | - | - | - | 0/1 | 0/1 |
-| format/email | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| format/email | ✅ | ✅ | ✅ | ✅ | ✅ | 22/27 | 22/27 |
 | format/host-name | 2/12 | - | - | - | - | - | - |
 | format/hostname | - | 27/28 | 27/28 | ✅ | ✅ | ✅ | ✅ |
 | format/idn-email | - | - | - | ✅ | ✅ | ✅ | ✅ |

--- a/docs/docs/schema/6_specification.html
+++ b/docs/docs/schema/6_specification.html
@@ -628,8 +628,8 @@
 <td align="left">✅</td>
 <td align="left">✅</td>
 <td align="left">✅</td>
-<td align="left">✅</td>
-<td align="left">✅</td>
+<td align="left">22/27</td>
+<td align="left">22/27</td>
 </tr>
 <tr>
 <td align="left">format/host-name</td>

--- a/src/format/email.ts
+++ b/src/format/email.ts
@@ -26,34 +26,12 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { IsIPv4Internal } from './ipv4.ts'
+const Email = /^(?!.*\.\.)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i
 
 /**
  * Returns true if the value is an Email
- * @specification Json Schema 2020-12
+ * @specification ajv-formats
  */
 export function IsEmail(value: string): boolean {
-  const dot = value.indexOf('.')
-  const at = value.indexOf('@')
-  const quoted = value[0] === '"' && value[at - 1] === '"'
-  const ipLiteral = value[at + 1] === '[' && value[value.length - 1] === ']'
-  const ipv6 = ipLiteral && value.indexOf(':', at) !== -1
-  const ipv4 = ipLiteral && !ipv6 && IsIPv4Internal(value, at + 2, value.length - 1)
-  return (at > 0 && at < value.length - 1) &&
-    !(
-      // .test@example.com
-      (!quoted && dot === 0) ||
-      // te..st@example.com
-      (!quoted && dot !== -1 && value.indexOf('.', dot + 1) === dot + 1) ||
-      // test.@example.com
-      (dot !== -1 && value.indexOf('@', dot) === dot + 1) ||
-      // joe bloggs@example.com
-      (!quoted && value.indexOf(' ') !== -1) ||
-      // user1@oceania.org, user2@oceania.org
-      (value.indexOf(',') !== -1) ||
-      // joe.bloggs@[127.0.0.300]
-      (ipLiteral && !ipv4 && !ipv6) ||
-      // joe.bloggs@invalid=domain.com
-      (value.indexOf('=', at) !== -1)
-    )
+  return Email.test(value)
 }

--- a/src/format/idn-email.ts
+++ b/src/format/idn-email.ts
@@ -26,12 +26,12 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { IsEmail } from './email.ts'
+const IdnEmail = /^(?!.*\.\.)[\p{L}\p{N}!#$%&'*+/=?^_`{|}~-]+(?:\.[\p{L}\p{N}!#$%&'*+/=?^_`{|}~-]+)*@[\p{L}\p{N}](?:[\p{L}\p{N}-]{0,61}[\p{L}\p{N}])?(?:\.[\p{L}\p{N}](?:[\p{L}\p{N}-]{0,61}[\p{L}\p{N}])?)*$/iu
 
 /**
  * Returns true if the value is an IdnEmail
- * @specification Json Schema 2020-12
+ * @specification ajv-formats (unicode-extension)
  */
 export function IsIdnEmail(value: string): boolean {
-  return IsEmail(value)
+  return IdnEmail.test(value)
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.1.22'
+const Version = '1.1.23'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/jsonschema/cases/draft2020-12/optional/format/_email.json
+++ b/test/jsonschema/cases/draft2020-12/optional/format/_email.json
@@ -1,0 +1,36 @@
+[
+  {
+    "description": "validation of e-mail addresses",
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "email"
+    },
+    "tests": [
+      {
+        "description": "a quoted string with a space in the local part is valid",
+        "data": "\"joe bloggs\"@example.com",
+        "valid": true
+      },
+      {
+        "description": "a quoted string with a double dot in the local part is valid",
+        "data": "\"joe..bloggs\"@example.com",
+        "valid": true
+      },
+      {
+        "description": "a quoted string with a @ in the local part is valid",
+        "data": "\"joe@bloggs\"@example.com",
+        "valid": true
+      },
+      {
+        "description": "an IPv4-address-literal after the @ is valid",
+        "data": "joe.bloggs@[127.0.0.1]",
+        "valid": true
+      },
+      {
+        "description": "an IPv6-address-literal after the @ is valid",
+        "data": "joe.bloggs@[IPv6:::1]",
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/jsonschema/cases/draft2020-12/optional/format/email.json
+++ b/test/jsonschema/cases/draft2020-12/optional/format/email.json
@@ -62,31 +62,6 @@
         "valid": true
       },
       {
-        "description": "a quoted string with a space in the local part is valid",
-        "data": "\"joe bloggs\"@example.com",
-        "valid": true
-      },
-      {
-        "description": "a quoted string with a double dot in the local part is valid",
-        "data": "\"joe..bloggs\"@example.com",
-        "valid": true
-      },
-      {
-        "description": "a quoted string with a @ in the local part is valid",
-        "data": "\"joe@bloggs\"@example.com",
-        "valid": true
-      },
-      {
-        "description": "an IPv4-address-literal after the @ is valid",
-        "data": "joe.bloggs@[127.0.0.1]",
-        "valid": true
-      },
-      {
-        "description": "an IPv6-address-literal after the @ is valid",
-        "data": "joe.bloggs@[IPv6:::1]",
-        "valid": true
-      },
-      {
         "description": "dot before local part is not valid",
         "data": ".test@example.com",
         "valid": false

--- a/test/jsonschema/cases/v1/format/_email.json
+++ b/test/jsonschema/cases/v1/format/_email.json
@@ -1,0 +1,36 @@
+[
+  {
+    "description": "validation of e-mail addresses",
+    "schema": {
+      "$schema": "https://json-schema.org/v1",
+      "format": "email"
+    },
+    "tests": [
+      {
+        "description": "a quoted string with a space in the local part is valid",
+        "data": "\"joe bloggs\"@example.com",
+        "valid": true
+      },
+      {
+        "description": "a quoted string with a double dot in the local part is valid",
+        "data": "\"joe..bloggs\"@example.com",
+        "valid": true
+      },
+      {
+        "description": "a quoted string with a @ in the local part is valid",
+        "data": "\"joe@bloggs\"@example.com",
+        "valid": true
+      },
+      {
+        "description": "an IPv4-address-literal after the @ is valid",
+        "data": "joe.bloggs@[127.0.0.1]",
+        "valid": true
+      },
+      {
+        "description": "an IPv6-address-literal after the @ is valid",
+        "data": "joe.bloggs@[IPv6:::1]",
+        "valid": true
+      }
+    ]
+  }
+]

--- a/test/jsonschema/cases/v1/format/email.json
+++ b/test/jsonschema/cases/v1/format/email.json
@@ -62,31 +62,6 @@
         "valid": true
       },
       {
-        "description": "a quoted string with a space in the local part is valid",
-        "data": "\"joe bloggs\"@example.com",
-        "valid": true
-      },
-      {
-        "description": "a quoted string with a double dot in the local part is valid",
-        "data": "\"joe..bloggs\"@example.com",
-        "valid": true
-      },
-      {
-        "description": "a quoted string with a @ in the local part is valid",
-        "data": "\"joe@bloggs\"@example.com",
-        "valid": true
-      },
-      {
-        "description": "an IPv4-address-literal after the @ is valid",
-        "data": "joe.bloggs@[127.0.0.1]",
-        "valid": true
-      },
-      {
-        "description": "an IPv6-address-literal after the @ is valid",
-        "data": "joe.bloggs@[IPv6:::1]",
-        "valid": true
-      },
-      {
         "description": "dot before local part is not valid",
         "data": ".test@example.com",
         "valid": false

--- a/test/typebox/runtime/format/idn-email.ts
+++ b/test/typebox/runtime/format/idn-email.ts
@@ -63,3 +63,76 @@ Test('Should IsIdnEmail 12', () => {
   // Local part with consecutive dots
   Assert.IsFalse(Format.IsIdnEmail('test..user@example.com'))
 })
+// ------------------------------------------------------------------
+// IdnEmail: Valid
+//
+// https://github.com/sinclairzx81/typebox/issues/1574
+// ------------------------------------------------------------------
+Test('Should IsIdnEmail 13', () => {
+  Assert.IsTrue(Format.IsIdnEmail('test@example.com'))
+})
+Test('Should IsIdnEmail 14', () => {
+  Assert.IsTrue(Format.IsIdnEmail('user.name+tag@domain.co.uk'))
+})
+Test('Should IsIdnEmail 15', () => {
+  Assert.IsTrue(Format.IsIdnEmail('a@b.cd'))
+})
+Test('Should IsIdnEmail 16', () => {
+  Assert.IsTrue(Format.IsIdnEmail('user@sub.domain.com'))
+})
+Test('Should IsIdnEmail 17', () => {
+  Assert.IsTrue(Format.IsIdnEmail('first.last@example.org'))
+})
+Test('Should IsIdnEmail 18', () => {
+  Assert.IsTrue(Format.IsIdnEmail('test@例子.测试'))
+})
+Test('Should IsIdnEmail 19', () => {
+  Assert.IsTrue(Format.IsIdnEmail('user@müller.example.com'))
+})
+Test('Should IsIdnEmail 20', () => {
+  Assert.IsTrue(Format.IsIdnEmail('test@스타벅스.코리아'))
+})
+Test('Should IsIdnEmail 21', () => {
+  Assert.IsTrue(Format.IsIdnEmail('user@παράδειγμα.δοκιμή'))
+})
+Test('Should IsIdnEmail 22', () => {
+  Assert.IsTrue(Format.IsIdnEmail('test@россия.рф'))
+})
+Test('Should IsIdnEmail 23', () => {
+  Assert.IsTrue(Format.IsIdnEmail('user@東京.jp'))
+})
+Test('Should IsIdnEmail 24', () => {
+  Assert.IsTrue(Format.IsIdnEmail('test@fußball.example.com'))
+})
+Test('Should IsIdnEmail 25', () => {
+  Assert.IsTrue(Format.IsIdnEmail('user@café.fr'))
+})
+Test('Should IsIdnEmail 26', () => {
+  Assert.IsTrue(Format.IsIdnEmail('test@bücher.example.com'))
+})
+Test('Should IsIdnEmail 27', () => {
+  Assert.IsTrue(Format.IsIdnEmail('user@example.com'))
+})
+Test('Should IsIdnEmail 28', () => {
+  Assert.IsTrue(Format.IsIdnEmail('user@例子.测试'))
+})
+// ------------------------------------------------------------------
+// IdnEmail: Invalid
+//
+// https://github.com/sinclairzx81/typebox/issues/1574
+// ------------------------------------------------------------------
+Test('Should IsIdnEmail 29', () => {
+  Assert.IsFalse(Format.IsIdnEmail('test@'))
+})
+Test('Should IsIdnEmail 30', () => {
+  Assert.IsFalse(Format.IsIdnEmail('@domain.com'))
+})
+Test('Should IsIdnEmail 31', () => {
+  Assert.IsFalse(Format.IsIdnEmail('user@domain..com'))
+})
+Test('Should IsIdnEmail 32', () => {
+  Assert.IsFalse(Format.IsIdnEmail('@例子.测试'))
+})
+Test('Should IsIdnEmail 33', () => {
+  Assert.IsFalse(Format.IsIdnEmail('user@..例子.测试'))
+})


### PR DESCRIPTION
This PR reverts the Email and IdnEmail format validators that were added on 1.1.11. Additional work will be required to ensure ajv-formats compatibility is retained while also supporting email specifications defined in 2020-12 and V1. Spec compliance tables have been updated accordingly.

Fixes: https://github.com/sinclairzx81/typebox/issues/1574