### PR TITLE
Version 1.1.25

### DIFF
--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.1.25](https://github.com/sinclairzx81/typebox/pull/1577)
+  - Optimize Native Schema Inference via Type Static
 - [Revision 1.1.24](https://github.com/sinclairzx81/typebox/pull/1576)
   - Support DynamicRef and DynamicAnchor
 - [Revision 1.1.23](https://github.com/sinclairzx81/typebox/pull/1575)

--- a/src/schema/check.ts
+++ b/src/schema/check.ts
@@ -30,17 +30,16 @@ THE SOFTWARE.
 // deno-lint-ignore-file
 
 import { Arguments } from '../system/arguments/index.ts'
+import { type Static } from '../type/types/static.ts'
 import * as Engine from './engine/index.ts'
 import * as Schema from './types/index.ts'
-import * as Static from './static/index.ts'
-
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
 /** Checks a value against the provided schema */
-export function Check<const Schema extends Schema.XSchema>(schema: Schema, value: unknown): value is Static.XStatic<Schema>
+export function Check<const Schema extends Schema.XSchema>(schema: Schema, value: unknown): value is Static<Schema>
 /** Checks a value against the provided schema */
-export function Check<const Schema extends Schema.XSchema>(context: Record<PropertyKey, Schema.XSchema>, schema: Schema, value: unknown):  value is Static.XStatic<Schema>
+export function Check<const Schema extends Schema.XSchema>(context: Record<PropertyKey, Schema.XSchema>, schema: Schema, value: unknown):  value is Static<Schema>
 /** Checks a value against the provided schema */
 export function Check(...args: unknown[]): boolean {
   const [context, schema, value] = Arguments.Match<[Record<PropertyKey, Schema.XSchema>, Schema.XSchema, unknown]>(args, {

--- a/src/schema/compile.ts
+++ b/src/schema/compile.ts
@@ -31,17 +31,17 @@ THE SOFTWARE.
 
 import { Arguments } from '../system/arguments/index.ts'
 import { type TLocalizedValidationError } from '../error/index.ts'
+import { type Static } from '../type/types/static.ts'
 import * as Build from './build.ts'
 import * as Schema from './types/index.ts'
-import * as Static from './static/index.ts'
 import { Errors } from './errors.ts'
 import { ParseError } from './parse.ts'
 
 // ------------------------------------------------------------------
 // Validator
 // ------------------------------------------------------------------
-export class Validator<Schema extends Schema.XSchema = Schema.XSchema, 
-  Value extends unknown = Static.XStatic<Schema>
+export class Validator<const Schema extends Schema.XSchema = Schema.XSchema, 
+  Value extends unknown = Static<Schema>
 >  {
   private readonly build: Build.BuildResult
   private readonly result: Build.EvaluateResult

--- a/src/schema/parse.ts
+++ b/src/schema/parse.ts
@@ -31,10 +31,10 @@ THE SOFTWARE.
 
 import { Arguments } from '../system/arguments/index.ts'
 import { type TLocalizedValidationError } from '../error/index.ts'
+import { type Static } from '../type/types/static.ts'
 import { Check } from './check.ts'
 import { Errors } from './errors.ts'
 import * as Schema from './types/index.ts'
-import * as Static from './static/index.ts'
 
 // ------------------------------------------------------------------
 // ParseError
@@ -50,9 +50,9 @@ export class ParseError {
 // Parse
 // ------------------------------------------------------------------
 /** Parses a value against the provided schema */
-export function Parse<const Schema extends Schema.XSchema>(schema: Schema, value: unknown): Static.XStatic<Schema>
+export function Parse<const Schema extends Schema.XSchema>(schema: Schema, value: unknown): Static<Schema>
 /** Parses a value against the provided schema */
-export function Parse<const Schema extends Schema.XSchema>(context: Record<PropertyKey, Schema.XSchema>, schema: Schema, value: unknown): Static.XStatic<Schema>
+export function Parse<const Schema extends Schema.XSchema>(context: Record<PropertyKey, Schema.XSchema>, schema: Schema, value: unknown): Static<Schema>
 /** Parses a value against the provided schema */
 export function Parse(...args: unknown[]): unknown {
   const [context, schema, value] = Arguments.Match<[Record<PropertyKey, Schema.XSchema>, Schema.XSchema, unknown]>(args, {

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.1.24'
+const Version = '1.1.25'
 
 // ------------------------------------------------------------------
 // Build


### PR DESCRIPTION
This PR implements an inference optimization for `typebox/schema` by re-routing XStatic to Type Static for Check, Parse and Compile. It has been observed that large property sets will cause the native JSON Schema inference to break with deeply nested property sets, which is a scalability issue. 

> The scaling issue was related to TRequired traversal, so will need to investigate a more optimal Native inference strategy before swapping back to XStatic

We can side step this by directing inference back to Type.* which implements optimized inference via Static. This is a cross cutting concern, but worth it to allow Type to be compiled without instantiation issues on the Schema compiler.

