### PR TITLE
Version 1.1.29

### DIFF
--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -6,6 +6,7 @@
 - [Revision 1.1.29](https://github.com/sinclairzx81/typebox/pull/1583)
   - Type.Refine Error Callback
   - Type.Unsafe Retain Schema Kind
+  - Alias Unsafe as Unknown in Extends
   - Value.Mutate Deprecation Notice
 - [Revision 1.1.28](https://github.com/sinclairzx81/typebox/pull/1582)
   - Type Engine Optimization

--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -3,6 +3,10 @@
 ---
 
 ### Version Updates
+- [Revision 1.1.29](https://github.com/sinclairzx81/typebox/pull/1583)
+  - Type.Refine Error Callback
+  - Type.Unsafe Retain Schema Kind
+  - Value.Mutate Deprecation Notice
 - [Revision 1.1.28](https://github.com/sinclairzx81/typebox/pull/1582)
   - Type Engine Optimization
 - [Revision 1.1.27](https://github.com/sinclairzx81/typebox/pull/1580)

--- a/design/website/docs/type/refine.md
+++ b/design/website/docs/type/refine.md
@@ -1,29 +1,44 @@
 # Type.Refine
 
-The Refine function applies explicit validation logic to a type. 
-
-> ⚠️ The Refine function will hinder the portability of your type. This is because Refine functions contain implicit rules and logic that cannot be encoded as Json Schema metadata. Refine should only be used if you do not need to share types with other systems.
+The Refine function applies explicit validation logic to a type. Unlike structural type checks, Refine allows you to express constraints that cannot be captured by JSON Schema alone, such as cross-property checks, mathematical properties, or domain-specific business rules.
 
 ## Example
 
-The following creates a Refine type that performs cross property value checks.
+The following creates a Refine type that validates a number is prime.
 
 ```typescript
-const T = Type.Refine(Type.Object({                 // const T = {
-  x: Type.Number(),                                 //   type: 'object',
-  y: Type.Number()                                  //   required: ['x', 'y'],
-}), value => {                                      //   properties: {
-  return value.x === value.y                        //     x: { type: 'number' },
-}, 'x and y should be equal')                       //     y: { type: 'number' }
-                                                    //   }
-                                                    //   '~refine': [(value) => { ... }, '...']
-                                                    // }
+import Type from 'typebox'
 
-const E = Value.Errors(T, { x: 1, y: 2 })           // const E = [{
-                                                    //   keyword: "~refine",
-                                                    //   schemaPath: "#/~refine",
-                                                    //   instancePath: "",
-                                                    //   params: { index: 0, message: "x and y should be equal" },
-                                                    //   message: "x and y should be equal"
-                                                    // }]
+// ------------------------------------------------------------------
+// IsPrime
+// ------------------------------------------------------------------
+const IsPrime = (value: number): boolean => {
+  if (value <= 1) return false
+  for (let i = 2; i <= Math.sqrt(value); i++)
+    if (value % i === 0) return false
+  return true
+}
+// ------------------------------------------------------------------
+// Prime
+// ------------------------------------------------------------------
+
+type Prime = Type.Static<typeof Prime>      // type Prime = number
+                                            //              |
+                                            //              infer from TNumber
+
+const Prime = Type.Refine(Type.Number(),    // const Prime = {
+  value => IsPrime(value),                  //   type: "number",
+  value => `Value ${value} is not Prime`)   //   "~refine": [{ 
+                                            //     check: (value) => {...}, 
+                                            //     error: (value) => {...}
+                                            //   }]
+                                            // }
+
+const E = Value.Errors(Prime, 42)           // const E = [{
+                                            //   keyword: "~refine",
+                                            //   schemaPath: "#",
+                                            //   instancePath: "",
+                                            //   params: { index: 0, message: "Value 42 is not Prime" },
+                                            //   message: "Value 42 is not Prime"
+                                            // }]
 ```

--- a/docs/docs/type/refine.html
+++ b/docs/docs/type/refine.html
@@ -1,25 +1,39 @@
 <h1>Type.Refine</h1>
-<p>The Refine function applies explicit validation logic to a type. </p>
-<blockquote>
-<p>⚠️ The Refine function will hinder the portability of your type. This is because Refine functions contain implicit rules and logic that cannot be encoded as Json Schema metadata. Refine should only be used if you do not need to share types with other systems.</p>
-</blockquote>
+<p>The Refine function applies explicit validation logic to a type. Unlike structural type checks, Refine allows you to express constraints that cannot be captured by JSON Schema alone, such as cross-property checks, mathematical properties, or domain-specific business rules.</p>
 <h2>Example</h2>
-<p>The following creates a Refine type that performs cross property value checks.</p>
-<pre><code class="language-typescript">const T = Type.Refine(Type.Object({                 // const T = {
-  x: Type.Number(),                                 //   type: &#39;object&#39;,
-  y: Type.Number()                                  //   required: [&#39;x&#39;, &#39;y&#39;],
-}), value =&gt; {                                      //   properties: {
-  return value.x === value.y                        //     x: { type: &#39;number&#39; },
-}, &#39;x and y should be equal&#39;)                       //     y: { type: &#39;number&#39; }
-                                                    //   }
-                                                    //   &#39;~refine&#39;: [(value) =&gt; { ... }, &#39;...&#39;]
-                                                    // }
+<p>The following creates a Refine type that validates a number is prime.</p>
+<pre><code class="language-typescript">import Type from &#39;typebox&#39;
 
-const E = Value.Errors(T, { x: 1, y: 2 })           // const E = [{
-                                                    //   keyword: &quot;~refine&quot;,
-                                                    //   schemaPath: &quot;#/~refine&quot;,
-                                                    //   instancePath: &quot;&quot;,
-                                                    //   params: { index: 0, message: &quot;x and y should be equal&quot; },
-                                                    //   message: &quot;x and y should be equal&quot;
-                                                    // }]
+// ------------------------------------------------------------------
+// IsPrime
+// ------------------------------------------------------------------
+const IsPrime = (value: number): boolean =&gt; {
+  if (value &lt;= 1) return false
+  for (let i = 2; i &lt;= Math.sqrt(value); i++)
+    if (value % i === 0) return false
+  return true
+}
+// ------------------------------------------------------------------
+// Prime
+// ------------------------------------------------------------------
+
+type Prime = Type.Static&lt;typeof Prime&gt;      // type Prime = number
+                                            //              |
+                                            //              infer from TNumber
+
+const Prime = Type.Refine(Type.Number(),    // const Prime = {
+  value =&gt; IsPrime(value),                  //   type: &quot;number&quot;,
+  value =&gt; `Value ${value} is not Prime`)   //   &quot;~refine&quot;: [{ 
+                                            //     check: (value) =&gt; {...}, 
+                                            //     error: (value) =&gt; {...}
+                                            //   }]
+                                            // }
+
+const E = Value.Errors(Prime, 42)           // const E = [{
+                                            //   keyword: &quot;~refine&quot;,
+                                            //   schemaPath: &quot;#&quot;,
+                                            //   instancePath: &quot;&quot;,
+                                            //   params: { index: 0, message: &quot;Value 42 is not Prime&quot; },
+                                            //   message: &quot;Value 42 is not Prime&quot;
+                                            // }]
 </code></pre>

--- a/src/schema/engine/_refine.ts
+++ b/src/schema/engine/_refine.ts
@@ -39,24 +39,24 @@ import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 // ------------------------------------------------------------------
 export function BuildRefine(_stack: Stack, _context: BuildContext, schema: S.XRefine, value: string): string {
   const refinements = V.CreateVariable(schema['~refine'].map((refinement) => refinement))
-  return E.Every(refinements, E.Constant(0), ['refinement', '_'], E.Call(E.Member('refinement', 'refine'), [value]))
+  return E.Every(refinements, E.Constant(0), ['refinement', '_'], E.Call(E.Member('refinement', 'check'), [value]))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
 export function CheckRefine(_stack: Stack, _context: CheckContext, schema: S.XRefine, value: unknown): boolean {
-  return G.Every(schema['~refine'], 0, (refinement, _) => refinement.refine(value))
+  return G.Every(schema['~refine'], 0, (refinement, _) => refinement.check(value))
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
 export function ErrorRefine(_stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: S.XRefine, value: unknown): boolean {
   return G.EveryAll(schema['~refine'], 0, (refinement, index) => {
-    return refinement.refine(value) || context.AddError({
+    return refinement.check(value) || context.AddError({
       keyword: '~refine',
       schemaPath,
       instancePath,
-      params: { index, message: refinement.message },
+      params: { index, message: refinement.error(value) },
     })
   })
 }

--- a/src/schema/types/_refine.ts
+++ b/src/schema/types/_refine.ts
@@ -35,8 +35,8 @@ import type { XSchemaObject } from './schema.ts'
 // Type
 // ------------------------------------------------------------------
 export interface XRefinement {
-  refine: (value: unknown) => boolean
-  message: string
+  check: (value: unknown) => boolean
+  error: (value: unknown) => string
 }
 export interface XRefine<Refinements extends XRefinement[] = XRefinement[]> {
   '~refine': Refinements
@@ -52,9 +52,9 @@ export function IsRefine(value: XSchemaObject): value is XRefine {
   return Guard.HasPropertyKey(value, '~refine')
     && Guard.IsArray(value["~refine"])
     && Guard.Every(value['~refine'], 0, value => Guard.IsObject(value)
-      && Guard.HasPropertyKey(value, 'refine')
-      && Guard.HasPropertyKey(value, 'message')
-      && Guard.IsFunction(value.refine)
-      && Guard.IsString(value.message)
+      && Guard.HasPropertyKey(value, 'check')
+      && Guard.HasPropertyKey(value, 'error')
+      && Guard.IsFunction(value.check)
+      && Guard.IsFunction(value.error)
     )
 }

--- a/src/type/engine/indexed/from-object.ts
+++ b/src/type/engine/indexed/from-object.ts
@@ -30,44 +30,97 @@ THE SOFTWARE.
 
 import { type TProperties } from '../../types/properties.ts'
 import { type TSchema } from '../../types/schema.ts'
+import { type TNumber, IsNumber } from '../../types/number.ts'
+import { type TPropertyKeys, PropertyKeys } from '../../types/properties.ts'
 import { type TEvaluateUnion, EvaluateUnion } from '../evaluate/evaluate.ts'
 import { type TToIndexableKeys, ToIndexableKeys } from '../indexable/to-indexable-keys.ts'
+
+import { IntegerKey } from '../../types/record.ts'
 
 // ------------------------------------------------------------------
 // SelectProperty
 // ------------------------------------------------------------------
 type TSelectProperty<Properties extends TProperties, Key extends string,
-  PropertyKey extends string = keyof Properties extends string | number ? `${keyof Properties}` : never,
-  Result extends TSchema[] = Key extends PropertyKey ? [Properties[Key]] : []
+  // note: we are trying to normalize the key to support numeric lookup via string (revise)
+  CanonicalKey extends string = keyof Properties extends string | number ? `${keyof Properties}` : never,
+  Result extends TSchema[] = Key extends CanonicalKey ? [Properties[Key]] : []
 > = Result
-function SelectProperty<Properties extends TProperties, Indexer extends string>(properties: Properties, indexer: Indexer): TSelectProperty<Properties, Indexer> {
-  const result = indexer in properties ? [properties[indexer]] : []
+function SelectProperty<Properties extends TProperties, Key extends string>
+  (properties: Properties, key: Key): 
+    TSelectProperty<Properties, Key> {
+  const result = key in properties ? [properties[key]] : []
   return result as never
 }
-// ------------------------------------------------------------------
-// SelectProperties
-// ------------------------------------------------------------------
 type TSelectProperties<Properties extends TProperties, Keys extends string[], Result extends TSchema[] = []> = (
   Keys extends [infer Left extends string, ...infer Right extends string[]]
     ? TSelectProperties<Properties, Right, [...Result, ...TSelectProperty<Properties, Left>]>
     : Result
 )
-function SelectProperties<Properties extends TProperties, Keys extends string[]>(properties: Properties, indexer: [...Keys]): TSelectProperties<Properties, Keys> {
-  return indexer.reduce((result, left) => {
+function SelectProperties<Properties extends TProperties, Keys extends string[]>
+  (properties: Properties, keys: [...Keys]): 
+    TSelectProperties<Properties, Keys> {
+  return keys.reduce((result, left) => {
     return [...result, ...SelectProperty(properties, left)]
   }, [] as TSchema[]) as never
+}
+// ------------------------------------------------------------------
+// FromIndexer
+// ------------------------------------------------------------------
+type TFromIndexer<Properties extends TProperties, Indexer extends TSchema,
+  Keys extends string[] = TToIndexableKeys<Indexer>,
+  Variants extends TSchema[] = TSelectProperties<Properties, Keys>,
+  Result extends TSchema = TEvaluateUnion<Variants>
+> = Result
+function FromIndexer<Properties extends TProperties, Indexer extends TSchema>(properties: Properties, indexer: Indexer): TFromIndexer<Properties, Indexer> {
+  const keys = ToIndexableKeys(indexer) as string[]
+  const variants = SelectProperties(properties, keys)
+  const result = EvaluateUnion(variants)
+  return result as never
+}
+// ------------------------------------------------------------------
+// FromIndexerNumber
+//
+// A TTuple will collapse to TObject in the context of a TMapped
+// type expression so we need to support [number] indexing on
+// a TObject type. This satisfies the following case.
+//
+//  type Map<T extends unknown[]> = { 
+//    [K in keyof T]: K 
+//  }[number] <-- here
+//
+// ------------------------------------------------------------------
+type TNumericKeys<Keys extends string[], Result extends string[] = []> = (
+  Keys extends [infer Left extends string, ...infer Right extends string[]]
+    ? Left extends `${infer _ extends number}` 
+      ? TNumericKeys<Right, [...Result, Left]> 
+      : TNumericKeys<Right, Result> 
+    : Result
+)
+const NumericKeyPattern = new RegExp(IntegerKey)
+function NumericKeys<Keys extends string[]>(keys: [...Keys]): TNumericKeys<Keys> {
+  const result = keys.filter(key => NumericKeyPattern.test(key))
+  return result as never
+}
+type TFromIndexerNumber<Properties extends TProperties,
+  Keys extends string[] = TPropertyKeys<Properties>,
+  NumericKeys extends string[] = TNumericKeys<Keys>,
+  Variants extends TSchema[] = TSelectProperties<Properties, NumericKeys>,
+  Result extends TSchema = TEvaluateUnion<Variants>
+> = Result
+function FromIndexerNumber<Properties extends TProperties>(properties: Properties): TFromIndexerNumber<Properties> {
+  const keys = PropertyKeys(properties) as string[]
+  const numericKeys = NumericKeys(keys)
+  const variants = SelectProperties(properties, numericKeys)
+  const result = EvaluateUnion(variants)
+  return result as never
 }
 // ------------------------------------------------------------------
 // FromObject
 // ------------------------------------------------------------------
 export type TFromObject<Properties extends TProperties, Indexer extends TSchema,
-  Keys extends string[] = TToIndexableKeys<Indexer>,
-  Variants extends TSchema[] = TSelectProperties<Properties, Keys>,
-  Result extends TSchema = TEvaluateUnion<Variants>
+  Result extends TSchema = Indexer extends TNumber ? TFromIndexerNumber<Properties> : TFromIndexer<Properties, Indexer>
 > = Result
 export function FromObject<Properties extends TProperties, Indexer extends TSchema>(properties: Properties, indexer: Indexer): TFromObject<Properties, Indexer> {
-  const keys = ToIndexableKeys(indexer) as string[]
-  const variants = SelectProperties(properties, keys)
-  const result = EvaluateUnion(variants)
+  const result = IsNumber(indexer) ? FromIndexerNumber(properties) : FromIndexer(properties, indexer)
   return result as never
 }

--- a/src/type/engine/mapped/mapped-variants.ts
+++ b/src/type/engine/mapped/mapped-variants.ts
@@ -28,8 +28,9 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
+import { Guard } from '../../../guard/index.ts'
 import { type TSchema } from '../../types/index.ts'
-import { type TLiteral, IsLiteralNumber, IsLiteralString } from '../../types/literal.ts'
+import { type TLiteral, type TLiteralValue, Literal, IsLiteral } from '../../types/literal.ts'
 import { type TEnum, type TEnumValue, IsEnum } from '../../types/enum.ts'
 import { type TTemplateLiteral, IsTemplateLiteral } from '../../types/template-literal.ts'
 import { type TUnion, IsUnion } from '../../types/union.ts'
@@ -64,12 +65,22 @@ function FromUnion<Types extends TSchema[]>(types: [...Types]): TFromUnion<Types
   }, [] as TSchema[]) as never
 }
 // ------------------------------------------------------------------
+// FromLiteral
+// ------------------------------------------------------------------
+type TFromLiteral<Value extends TLiteralValue, 
+  Result extends TSchema[] = Value extends number ? [TLiteral<`${Value}`>] : [TLiteral<Value>]
+> = Result
+function FromLiteral<Value extends TLiteralValue>(value: Value): TFromLiteral<Value> {
+  const result = Guard.IsNumber(value) ? [Literal(`${value}`)] : [Literal(value)]
+  return result as never
+}
+// ------------------------------------------------------------------
 // FromType
 // ------------------------------------------------------------------
 type TFromType<Type extends TSchema,
   Result extends TSchema[] = (
     Type extends TEnum<infer Values extends TEnumValue[]> ? TFromUnion<TEnumValuesToVariants<Values>> :
-    Type extends TLiteral<string | number> ? [Type] :
+    Type extends TLiteral<infer Value extends number> ? TFromLiteral<Value> :
     Type extends TTemplateLiteral<infer Pattern extends string> ? TFromTemplateLiteral<Pattern> :
     Type extends TUnion<infer Types extends TSchema[]> ? TFromUnion<Types> :
     [Type]
@@ -78,7 +89,7 @@ type TFromType<Type extends TSchema,
 function FromType<Type extends TSchema>(type: Type): TFromType<Type> {
   const result = (
     IsEnum(type) ? FromUnion(EnumValuesToVariants(type.enum)) :
-    IsLiteralString(type) || IsLiteralNumber(type) ? [type] :
+    IsLiteral(type) ? FromLiteral(type.const) :
     IsTemplateLiteral(type) ? FromTemplateLiteral(type.pattern) :
     IsUnion(type) ? FromUnion(type.anyOf) :
     [type]

--- a/src/type/extends/extends.ts
+++ b/src/type/extends/extends.ts
@@ -31,22 +31,24 @@ THE SOFTWARE.
 import { type TSchema } from '../types/schema.ts'
 import { type TProperties } from '../types/properties.ts'
 import { type TCyclic, IsCyclic } from '../types/cyclic.ts'
+import { type TUnknown, Unknown } from '../types/unknown.ts'
+import { type TUnsafe, IsUnsafe } from '../types/unsafe.ts'
 import { type TExtendsLeft, ExtendsLeft } from './extends-left.ts'
 import { type TCyclicExtends, CyclicExtends } from '../engine/cyclic/index.ts'
 
 // ------------------------------------------------------------------
-// Normal
+// Canonical: Preflight
 // ------------------------------------------------------------------
-type TNormal<Type extends TSchema> = (
-  Type extends TCyclic 
-    ? TCyclicExtends<Type> 
-    : Type
+type TCanonical<Type extends TSchema> = (
+  Type extends TCyclic ? TCyclicExtends<Type> : 
+  Type extends TUnsafe ? TUnknown : 
+  Type
 )
-function Normal<Type extends TSchema>(type: Type): TNormal<Type> {
+function Canonical<Type extends TSchema>(type: Type): TCanonical<Type> {
   return (
-    IsCyclic(type) 
-      ? CyclicExtends(type) 
-      : type
+    IsCyclic(type) ? CyclicExtends(type) : 
+    IsUnsafe(type) ? Unknown() : 
+    type
   ) as never
 }
 // ------------------------------------------------------------------
@@ -54,14 +56,14 @@ function Normal<Type extends TSchema>(type: Type): TNormal<Type> {
 // ------------------------------------------------------------------
 /** Performs a structural extends check on left and right types and yields inferred types on right if specified. */
 export type TExtends<Inferred extends TProperties, Left extends TSchema, Right extends TSchema,
-  NormalLeft extends TSchema = TNormal<Left>,
-  NormalRight extends TSchema = TNormal<Right>
-> = TExtendsLeft<Inferred, NormalLeft, NormalRight>
+  CanonicalLeft extends TSchema = TCanonical<Left>,
+  CanonicalRight extends TSchema = TCanonical<Right>
+> = TExtendsLeft<Inferred, CanonicalLeft, CanonicalRight>
 /** Performs a structural extends check on left and right types and yields inferred types on right if specified. */
 export function Extends<Inferred extends TProperties, Left extends TSchema, Right extends TSchema>
   (inferred: Inferred, left: Left, right: Right): 
     TExtends<Inferred, Left, Right> {
-  const normalLeft = Normal(left)
-  const normalRight = Normal(right)
-  return ExtendsLeft(inferred, normalLeft, normalRight)
+  const canonicalLeft = Canonical(left)
+  const canonicalRight = Canonical(right)
+  return ExtendsLeft(inferred, canonicalLeft, canonicalRight)
 }

--- a/src/type/types/_refine.ts
+++ b/src/type/types/_refine.ts
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
+import { Arguments } from '../../system/arguments/index.ts'
 import { Memory } from '../../system/memory/index.ts'
 import { Guard } from '../../guard/index.ts'
 import { type TSchema, IsSchema } from './schema.ts'
@@ -55,22 +56,45 @@ export type TRefine<Type extends TSchema = TSchema> = (
 // ------------------------------------------------------------------
 // Factory
 // ------------------------------------------------------------------
-export type TRefineCallback<Type extends TSchema> = (value: Static<Type>) => boolean
+export type TRefineCheckCallback<Type extends TSchema = TSchema> = (value: Static<Type>) => boolean
+export type TRefineErrorCallback<Type extends TSchema = TSchema> = (value: Static<Type>) => string
 
 export interface TRefinement<Type extends TSchema = TSchema> {
-  refine: TRefineCallback<Type>
-  message: string
+  check: TRefineCheckCallback<Type>
+  error: TRefineErrorCallback<Type>
 }
-/** Applies a Refine check to the given type. */
-export function Refine<Type extends TSchema>(type: Type, refine: TRefineCallback<Type>, message: string = 'error'): TRefineAdd<Type> {
-  return RefineAdd(type, { refine, message }) as never
+
+/** Refines a type with an explicit check */
+export function Refine<Type extends TSchema>(type: Type, check: TRefineCheckCallback<Type>, error: TRefineErrorCallback<Type>): TRefineAdd<Type>
+/** Refines a type with an explicit check */
+export function Refine<Type extends TSchema>(type: Type, check: TRefineCheckCallback<Type>): TRefineAdd<Type>
+/** @deprecated Use the error callback signature to generate error message. This overload will be removed in the next version  */
+export function Refine<Type extends TSchema>(type: Type, check: TRefineCheckCallback<Type>, message: string): TRefineAdd<Type>
+/** Refines a type with an explicit check */
+export function Refine(...args: unknown[]): unknown {
+  const [type, check, error_or_message] = Arguments.Match<[TSchema, TRefineCheckCallback, TRefineErrorCallback | string]>(args, {
+    3: (type, check, error) => [type, check, error],
+    2: (type, check) => [type, check, () => 'Refine Error'],
+  })
+  const error = Guard.IsString(error_or_message) ? () => error_or_message : error_or_message
+  return RefineAdd(type, { check, error }) as never
 }
 // ------------------------------------------------------------------
 // Guard
 // ------------------------------------------------------------------
-/** Returns true if the given value is a TRefine. */
-export function IsRefine(value: unknown): value is TRefine<TSchema> {
-  return IsSchema(value) && Guard.HasPropertyKey(value, '~refine')
+/** Returns true if the given value is a TRefinement. */
+export function IsRefinement(value: unknown): value is TRefinement {
+  return Guard.IsObjectNotArray(value)
+    && Guard.HasPropertyKey(value, 'check')
+    && Guard.HasPropertyKey(value, 'error')
+    && Guard.IsFunction(value.check)
+    && Guard.IsFunction(value.error)
 }
-
+/** Returns true if the given value is a TRefine. */
+export function IsRefine(value: unknown): value is TRefine {
+  return IsSchema(value) 
+    && Guard.HasPropertyKey(value, '~refine') 
+    && Guard.IsArray(value['~refine'])
+    && Guard.Every(value['~refine'], 0, value => IsRefinement(value))
+}
 

--- a/src/type/types/properties.ts
+++ b/src/type/types/properties.ts
@@ -90,9 +90,12 @@ export function RequiredArray<Properties extends TProperties>(properties: Proper
 // ------------------------------------------------------------------
 // PropertyKeys
 // ------------------------------------------------------------------
+type TKeyToString<Key extends number | string> = `${Key}`
 /** Extracts a tuple of keys from a TProperties value. */
 export type TPropertyKeys<Properties extends TProperties,
-  Result extends string[] = TUnionToTuple<Extract<keyof Properties, string>>
+  ExtractKey extends number | string = Extract<keyof Properties, number | string>,
+  StringKey extends string = TKeyToString<ExtractKey>,
+  Result extends string[] = TUnionToTuple<StringKey>
 > = Result
 /** Extracts a tuple of keys from a TProperties value. */
 export function PropertyKeys<Properties extends TProperties>(properties: Properties): TPropertyKeys<Properties> {

--- a/src/type/types/record.ts
+++ b/src/type/types/record.ts
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 import { Memory } from '../../system/memory/index.ts'
 import { Guard } from '../../guard/index.ts'
-import { type TSchema, type TObjectOptions, IsKind, IsSchema } from './schema.ts'
+import { type TSchema, type TObjectOptions, IsKind } from './schema.ts'
 import { type StaticType, type StaticDirection } from './static.ts'
 import { type TProperties } from './properties.ts'
 import { type TInteger, Integer, IntegerPattern } from './integer.ts'
@@ -88,15 +88,6 @@ export type TRecordDeferred<Key extends TSchema = TSchema, Value extends TSchema
 /** Represents a deferred Record action. */
 export function RecordDeferred<Key extends TSchema, Value extends TSchema>(key: Key, value: Value, options: TObjectOptions = {}): TRecordDeferred<Key, Value> {
   return Deferred('Record', [key, value], options)
-}
-// ------------------------------------------------------------------
-// Guard
-// ------------------------------------------------------------------
-/** Returns true if this value is a deferred Interface action. */
-export function IsRecordDeferred(value: unknown): value is TRecordDeferred {
-  return IsSchema(value)
-    && Guard.HasPropertyKey(value, 'action')
-    && Guard.IsEqual(value.action, 'Record')
 }
 // -------------------------------------------------------------------
 // Factory

--- a/src/type/types/unsafe.ts
+++ b/src/type/types/unsafe.ts
@@ -29,8 +29,9 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 // deno-lint-ignore-file 
 
+import { Guard } from '../../guard/index.ts'
 import { Memory } from '../../system/memory/index.ts'
-import { type TSchema, IsKind } from './schema.ts'
+import { type TSchema } from './schema.ts'
 
 // ------------------------------------------------------------------
 // Static
@@ -41,20 +42,21 @@ export type StaticUnsafe<Type extends unknown> = Type
 // ------------------------------------------------------------------
 /** Represents an Unsafe type. */
 export interface TUnsafe<Type extends unknown = unknown> extends TSchema {
-  '~kind': 'Unsafe'
-  '~hint': Type // cached for inference
+  '~unsafe': Type // cached for inference
 }
 // ------------------------------------------------------------------
 // Factory
 // ------------------------------------------------------------------
 /** Creates a Unsafe type. */
 export function Unsafe<Type extends unknown>(schema: TSchema): TUnsafe<Type> {
-  return Memory.Create({ ['~kind']: 'Unsafe' }, {}, schema) as never
+  return Memory.Update(schema, { ['~unsafe']: null }, {}) as never
 }
 // ------------------------------------------------------------------
 // Guard
 // ------------------------------------------------------------------
 /** Returns true if the given value is TUnsafe. */
 export function IsUnsafe(value: unknown): value is TUnsafe {
-  return IsKind(value, 'Unsafe')
+  return Guard.IsObjectNotArray(value)
+    && Guard.HasPropertyKey(value, '~unsafe')
+    && Guard.IsNull(value['~unsafe'])
 }

--- a/src/typebox.ts
+++ b/src/typebox.ts
@@ -77,7 +77,7 @@ export { Codec, Decode, DecodeBuilder, Encode, EncodeBuilder, IsCodec, type TCod
 export { Immutable, IsImmutable, type TImmutable } from './type/types/_immutable.ts'
 export { IsOptional, Optional, type TOptional } from './type/types/_optional.ts'
 export { IsReadonly, Readonly, type TReadonly } from './type/types/_readonly.ts'
-export { IsRefine, Refine, type TRefine, type TRefineCallback, type TRefinement } from './type/types/_refine.ts'
+export { IsRefine, Refine, type TRefine, type TRefineCheckCallback, type TRefineErrorCallback, type TRefinement } from './type/types/_refine.ts'
 
 // ------------------------------------------------------------------
 // Standard

--- a/src/value/mutate/mutate.ts
+++ b/src/value/mutate/mutate.ts
@@ -63,6 +63,8 @@ function IsMismatchedValue(left: unknown, right: unknown): boolean {
  * Performs a deep structural assignment, applying values from next to current while retaining internal references. This function 
  * is written for use in infrastructure that interprets reference changes as a signal to perform some action (i.e. React redraw), this
  * function can mitigate this by applying mutable updates deep within a value, ensuring parent references are retained.
+ * 
+ * @deprecated This function is being removed in the next version but will be retained as a reference under examples.
  */
 export function Mutate(current: TMutable, next: TMutable): void {
   if (IsNonMutableValue(current) || IsNonMutableValue(next)) throw new MutateError('Only object and array types can be mutated at the root level')

--- a/task/turing/turing.ts
+++ b/task/turing/turing.ts
@@ -237,6 +237,13 @@ type DecrementMap = [
 ]` as never) as never as Type.TProperties
 
 // --------------------------------------------------------------------------
+// MemoryUsage
+// --------------------------------------------------------------------------
+export function MemoryUsage() {
+  const toMB = (bytes: number) => (bytes / 1024 / 1024).toFixed(2) + ' MB'
+  return Object.fromEntries(Object.entries(process.memoryUsage()).map(([k, v]) => [k, toMB(v)]))
+}
+// --------------------------------------------------------------------------
 // Compile
 // --------------------------------------------------------------------------
 function Compile(input: string): Type.TTuple<Type.TLiteral[]> {
@@ -256,6 +263,7 @@ export function Run(): void {
   const output = program.properties.output.properties.items.items.map((item: any) => String.fromCharCode(item.const)).join('')
   console.log({ output })
 }
+
 // --------------------------------------------------------------------------
 // Debug
 // --------------------------------------------------------------------------
@@ -277,7 +285,8 @@ export function Debug(): void {
     const current = program.properties.instruction.properties.next.items[0]
     const next = program.properties.instruction.properties.next.items.map((type: Type.TLiteral) => type.const).join(' ')
     const prev = program.properties.instruction.properties.prev.items.map((type: Type.TLiteral) => type.const).join(' ')
-    console.log('Program', { step, input, output, memory, current, next, prev })
+    const usage = MemoryUsage()
+    console.log('Program', { step, input, output, memory, current, next, prev, usage })
     if(program.properties.instruction.properties.next.items.length === 0) break
     program = Type.Script({ ...Interpretter, State: program }, `ProgramStep<State>`)
     step += 1

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.1.28'
+const Version = '1.1.29'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/schema/types/~refine.ts
+++ b/test/typebox/runtime/schema/types/~refine.ts
@@ -10,7 +10,7 @@ Test('Should Guard 1', () => {
 })
 Test('Should Guard 2', () => {
   Assert.IsTrue(Schema.IsRefine({
-    '~refine': [{ refine: (value: unknown) => true, message: 'fail' }]
+    '~refine': [{ check: (value: unknown) => true, error: () => 'fail' }]
   }))
 })
 Test('Should Guard 3', () => {

--- a/test/typebox/runtime/type/engine/action/indexed.ts
+++ b/test/typebox/runtime/type/engine/action/indexed.ts
@@ -489,3 +489,32 @@ Test('Should Index 37', () => {
   const S: Type.TNumber = Type.Index(T, Type.Literal('length'))
   Assert.IsTrue(Type.IsNumber(S))
 })
+// ------------------------------------------------------------------
+// NumericIndex: TPropertyKeys returns both Number and String keys
+// ------------------------------------------------------------------
+Test('Should Index 38', () => {
+  const T = Type.Object({
+    x: Type.Literal(1),
+    0: Type.Literal(2),
+    y: Type.Literal(3),
+    1: Type.Literal(4)
+  })
+  const S: Type.TUnion<[Type.TLiteral<2>, Type.TLiteral<4>]> = Type.Index(T, Type.Number())
+  Assert.IsTrue(Type.IsUnion(S))
+  Assert.IsEqual(S.anyOf.length, 2)
+  Assert.IsEqual(S.anyOf[0].const, 2)
+  Assert.IsEqual(S.anyOf[1].const, 4)
+})
+Test('Should Index 39', () => {
+  const T = Type.Object({
+    'x': Type.Literal(1),
+    '0': Type.Literal(2),
+    'y': Type.Literal(3),
+    '1': Type.Literal(4)
+  })
+  const S: Type.TUnion<[Type.TLiteral<2>, Type.TLiteral<4>]> = Type.Index(T, Type.Number())
+  Assert.IsTrue(Type.IsUnion(S))
+  Assert.IsEqual(S.anyOf.length, 2)
+  Assert.IsEqual(S.anyOf[0].const, 2)
+  Assert.IsEqual(S.anyOf[1].const, 4)
+})

--- a/test/typebox/runtime/type/extends/unsafe.ts
+++ b/test/typebox/runtime/type/extends/unsafe.ts
@@ -1,37 +1,40 @@
 import Type, { Extends, ExtendsResult } from 'typebox'
 import { Assert } from 'test'
 
-const Test = Assert.Context('Extends.Unknown')
+// Note: TUnsafe is aliased as TUnsafe in TExtends contexts. This is handled
+// via a Preflight TCanonical mapping. We may be able to improve this in
+// later versions with a dedicated TNominal<T>. (Review)
+const Test = Assert.Context('Extends.Unsafe')
 
 // ------------------------------------------------------------------
 // Invariant
 // ------------------------------------------------------------------
 Test('Should Extends 1', () => {
   Assert.IsExtends<unknown, null>(false)
-  const R: ExtendsResult.TExtendsFalse = Extends({}, Type.Unknown(), Type.Null())
+  const R: ExtendsResult.TExtendsFalse = Extends({}, Type.Unsafe({}), Type.Null())
   Assert.IsTrue(ExtendsResult.IsExtendsFalse(R))
 })
 Test('Should Extends 2', () => {
   Assert.IsExtends<null, unknown>(true)
-  const R: ExtendsResult.TExtendsTrue = Extends({}, Type.Null(), Type.Unknown())
+  const R: ExtendsResult.TExtendsTrue = Extends({}, Type.Null(), Type.Unsafe({}))
   Assert.IsTrue(ExtendsResult.IsExtendsTrue(R))
 })
 // ------------------------------------------------------------------
-// Any, Never and Unknown
+// Any, Never and Unsafe
 // ------------------------------------------------------------------
 Test('Should Extends 3', () => {
   Assert.IsExtends<any, unknown>(true)
-  const R: ExtendsResult.TExtendsTrue = Extends({}, Type.Any(), Type.Unknown())
+  const R: ExtendsResult.TExtendsTrue = Extends({}, Type.Any(), Type.Unsafe({}))
   Assert.IsTrue(ExtendsResult.IsExtendsTrue(R))
 })
 Test('Should Extends 4', () => {
   Assert.IsExtendsWhenLeftIsNever<never, unknown>(true)
-  const R: ExtendsResult.TExtendsTrue = Extends({}, Type.Never(), Type.Unknown())
+  const R: ExtendsResult.TExtendsTrue = Extends({}, Type.Never(), Type.Unsafe({}))
   Assert.IsTrue(ExtendsResult.IsExtendsTrue(R))
 })
 Test('Should Extends 5', () => {
   Assert.IsExtends<unknown, unknown>(true)
-  const R: ExtendsResult.TExtendsTrue = Extends({}, Type.Unknown(), Type.Unknown())
+  const R: ExtendsResult.TExtendsTrue = Extends({}, Type.Unsafe({}), Type.Unsafe({}))
   Assert.IsTrue(ExtendsResult.IsExtendsTrue(R))
 })
 // ------------------------------------------------------------------
@@ -39,18 +42,18 @@ Test('Should Extends 5', () => {
 // ------------------------------------------------------------------
 Test('Should Extends 7', () => {
   type _X = unknown extends infer A extends any ? true : false // true
-  const R: Type.ExtendsResult.TExtendsTrue<{ A: Type.TUnknown }> = Extends({}, Type.Unknown(), Type.Infer('A', Type.Any()))
+  const R: Type.ExtendsResult.TExtendsTrue<{ A: Type.TUnknown }> = Extends({}, Type.Unsafe({}), Type.Infer('A', Type.Any()))
   Assert.IsTrue(ExtendsResult.IsExtendsTrue(R))
   Assert.IsTrue(Type.IsUnknown(R.inferred.A))
 })
 Test('Should Extends 8', () => {
   type _X = unknown extends infer A extends never ? true : false // false
-  const R: Type.ExtendsResult.TExtendsFalse = Extends({}, Type.Unknown(), Type.Infer('A', Type.Never()))
+  const R: Type.ExtendsResult.TExtendsFalse = Extends({}, Type.Unsafe({}), Type.Infer('A', Type.Never()))
   Assert.IsTrue(ExtendsResult.IsExtendsFalse(R))
 })
 Test('Should Extends 9', () => {
   type _X = unknown extends infer A extends unknown ? true : false // true
-  const R: Type.ExtendsResult.TExtendsTrue<{ A: Type.TUnknown }> = Extends({}, Type.Unknown(), Type.Infer('A', Type.Unknown()))
+  const R: Type.ExtendsResult.TExtendsTrue<{ A: Type.TUnknown }> = Extends({}, Type.Unsafe({}), Type.Infer('A', Type.Unknown()))
   Assert.IsTrue(ExtendsResult.IsExtendsTrue(R))
   Assert.IsTrue(Type.IsUnknown(R.inferred.A))
 })

--- a/test/typebox/runtime/type/script/~algorithm.ts
+++ b/test/typebox/runtime/type/script/~algorithm.ts
@@ -107,7 +107,7 @@ Test('Should Algorithm 5', () => {
 // ------------------------------------------------------------------
 // Reverse: Destructure Right
 // ------------------------------------------------------------------
-Test('Should Algorithm 2', () => {
+Test('Should Algorithm 6', () => {
   const T = Type.Script(`
     type Reverse<T, A extends unknown[] = []> = (
       T extends [infer L, ...infer R extends unknown[]]
@@ -123,7 +123,7 @@ Test('Should Algorithm 2', () => {
   Assert.IsEqual(T.items[2].const, 2)
   Assert.IsEqual(T.items[3].const, 1)
 })
-Test('Should Algorithm 3', () => {
+Test('Should Algorithm 7', () => {
   const T = Type.Script(`
     type Reverse<T, A = []> = (
       T extends [infer L, ...infer R]
@@ -137,4 +137,32 @@ Test('Should Algorithm 3', () => {
   Assert.IsEqual(T.items[1].const, 3)
   Assert.IsEqual(T.items[2].const, 2)
   Assert.IsEqual(T.items[3].const, 1)
+})
+// ------------------------------------------------------------------
+// Advanced
+// ------------------------------------------------------------------
+Test('Should Algorithm 8', () => {
+  const T = Type.Script(`
+    type Values = [3, 2, 6, 1, 7, 3, 10, 4]
+    type TupleToIndexValueUnion<T extends unknown[]> = {
+      [K in keyof T]: [K, T[K]]
+    }[number]
+
+    type FindIndex<
+      T extends unknown[],
+      V,
+    > = Extract<TupleToIndexValueUnion<T>, [string, V]>[0]
+
+    type X = FindIndex<Values, 7>
+    //   ^? "4"
+    type Y = FindIndex<Values, 3>
+    //   ^? "0" | "5"
+  `)
+  const X: Type.TLiteral<'4'> = T.X
+  const Y: Type.TUnion<[Type.TLiteral<'0'>, Type.TLiteral<'5'>]> = T.Y
+  Assert.IsTrue(Type.IsLiteral(X))
+  Assert.IsEqual(X.const, '4')
+  Assert.IsTrue(Type.IsUnion(Y))
+  Assert.IsEqual(Y.anyOf[0].const, '0')
+  Assert.IsEqual(Y.anyOf[1].const, '5')
 })

--- a/test/typebox/runtime/type/types/base.ts
+++ b/test/typebox/runtime/type/types/base.ts
@@ -28,6 +28,9 @@ class TStringBase extends Type.Base<string> {
   public override Errors(value: unknown): object[] {
     return typeof value === 'string' ? [] : [{ message: 'expected string' }]
   }
+  public override Clone(): Type.Base {
+    return new TStringBase()
+  }
 }
 const StringBase = () => new TStringBase()
 Test('Should Base 3', () => {
@@ -53,6 +56,19 @@ Test('Should Base 7', () => {
 Test('Should Base 8', () => {
   const T: TStringBase = StringBase()
   Assert.IsEqual(T.Errors(1), [{ message: 'expected string' }])
+})
+// ------------------------------------------------------------------
+// Clone - Coverage
+// ------------------------------------------------------------------
+Test('Should Base 9', () => {
+  const T: TStringBase = StringBase()
+  const S = T.Clone()
+  Assert.IsEqual(S.Errors(1), [{ message: 'expected string' }])
+})
+
+Test('Should Base 10', () => {
+  const T = new Type.Base()
+  Assert.Throws(() => T.Clone())
 })
 // ------------------------------------------------------------------
 // Clone - Compositor

--- a/test/typebox/runtime/type/types/unsafe.ts
+++ b/test/typebox/runtime/type/types/unsafe.ts
@@ -20,3 +20,16 @@ Test('Should Create Any with options', () => {
   Assert.IsEqual(T.a, 1)
   Assert.IsEqual(T.b, 2)
 })
+// ------------------------------------------------------------------
+// Unsafe/Refine
+// ------------------------------------------------------------------
+Test('Should Unsafe/Refine', () => {
+  const A = Type.Unsafe<Date>(Type.Refine({}, (value) => value instanceof Date))
+  Assert.IsTrue(Type.IsRefine(A))
+  Assert.IsTrue(Type.IsUnsafe(A))
+})
+Test('Should Unsafe/Refine (Reverse)', () => {
+  const A = Type.Refine(Type.Unsafe<Date>({}), (value) => value instanceof Date)
+  Assert.IsTrue(Type.IsRefine(A))
+  Assert.IsTrue(Type.IsUnsafe(A))
+})

--- a/test/typebox/runtime/type/types/~refine.ts
+++ b/test/typebox/runtime/type/types/~refine.ts
@@ -1,0 +1,25 @@
+import { Assert } from 'test'
+import * as Type from 'typebox'
+
+const Test = Assert.Context('Type.Refine')
+
+Test('Should guard Refine 0', () => {
+  const T: Type.TRefine<Type.TString> = Type.Refine(Type.String(), (_value) => true)
+  Assert.IsFalse(Type.IsNull(T))
+  Assert.IsTrue(Type.IsRefine(T))
+})
+Test('Should guard Refine 1', () => {
+  const T: Type.TRefine<Type.TString> = Type.Refine(Type.String(), (_value) => true)
+  Assert.IsTrue(Type.IsString(T))
+  Assert.IsTrue(Type.IsRefine(T))
+})
+Test('Should guard Refine 2', () => {
+  const T: Type.TRefine<Type.TString> = Type.Refine(Type.String(), (_value) => true, (_value) => '')
+  Assert.IsTrue(Type.IsString(T))
+  Assert.IsTrue(Type.IsRefine(T))
+})
+Test('Should guard Refine 3', () => {
+  const T: Type.TRefine<Type.TString> = Type.Refine(Type.String(), (_value) => true, 'deprecated')
+  Assert.IsTrue(Type.IsString(T))
+  Assert.IsTrue(Type.IsRefine(T))
+})

--- a/test/typebox/runtime/value/check/~refine.ts
+++ b/test/typebox/runtime/value/check/~refine.ts
@@ -117,7 +117,7 @@ Test('Should validate Refine 8', () => {
   Assert.IsTrue(A)
   Assert.IsFalse(B)
 })
-Test('Should validate Refine 8', () => {
+Test('Should validate Refine 9', () => {
   const T = Type.Refine(Type.Unsafe<Date>({}), (value) => value instanceof Date)
   const A = Check(T, new Date())
   const B = Check(T, {})

--- a/test/typebox/runtime/value/check/~refine.ts
+++ b/test/typebox/runtime/value/check/~refine.ts
@@ -107,3 +107,20 @@ Test('Should validate Refine 8', () => {
   Assert.IsFalse(R)
   Assert.IsEqual(buffer, [0])
 })
+// ------------------------------------------------------------------
+// Unsafe/Refine
+// ------------------------------------------------------------------
+Test('Should validate Refine 8', () => {
+  const T = Type.Unsafe<Date>(Type.Refine({}, (value) => value instanceof Date))
+  const A = Check(T, new Date())
+  const B = Check(T, {})
+  Assert.IsTrue(A)
+  Assert.IsFalse(B)
+})
+Test('Should validate Refine 8', () => {
+  const T = Type.Refine(Type.Unsafe<Date>({}), (value) => value instanceof Date)
+  const A = Check(T, new Date())
+  const B = Check(T, {})
+  Assert.IsTrue(A)
+  Assert.IsFalse(B)
+})

--- a/test/typebox/runtime/value/errors/errors.ts
+++ b/test/typebox/runtime/value/errors/errors.ts
@@ -1,10 +1,12 @@
 import { Value } from 'typebox/value'
 import { Type } from 'typebox'
 import { Assert } from 'test'
-import { TypeBoxError } from 'npm:@sinclair/typebox'
 
 const Test = Assert.Context('Value.Errors')
 
+// ------------------------------------------------------------------
+// Basic
+// ------------------------------------------------------------------
 Test('Should Errors 1', () => {
   const R = Value.Errors(Type.String(), 1)
   Assert.IsTrue(R.length > 0)
@@ -13,4 +15,13 @@ Test('Should Errors 2', () => {
   const T = Type.String()
   const R = Value.Errors({ T }, Type.Ref('T'), 1)
   Assert.IsTrue(R.length > 0)
+})
+// ------------------------------------------------------------------
+// Refine
+// ------------------------------------------------------------------
+Test('Should Errors 3', () => {
+  const T = Type.Refine({}, (value) => value instanceof Date, () => 'Not a date')
+  const R = Value.Errors(T, {})
+  Assert.IsTrue(R.length > 0)
+  Assert.IsEqual(R[0].message, 'Not a date')
 })

--- a/test/typebox/static/type/unsafe.ts
+++ b/test/typebox/static/type/unsafe.ts
@@ -4,11 +4,21 @@ import { Assert } from 'test'
 // ------------------------------------------------------------------
 // https://github.com/sinclairzx81/typebox/issues/1314
 // ------------------------------------------------------------------
-const T = Type.Object({
-  x: Type.Optional(Type.Unsafe<12345>(Type.String())),
-  y: Type.Optional(Type.String())
-})
-Assert.IsExtends<Static<typeof T>, {
-  x?: 12345
-  y?: string
-}>(true)
+{
+  const T = Type.Object({
+    x: Type.Optional(Type.Unsafe<12345>(Type.String())),
+    y: Type.Optional(Type.String())
+  })
+  Assert.IsExtends<Static<typeof T>, {
+    x?: 12345
+    y?: string
+  }>(true)
+}
+{
+  const T = Type.Unsafe<Date>(Type.Refine({}, (value) => value instanceof Date))
+  Assert.IsExtendsMutual<Static<typeof T>, Date>(true)
+}
+{
+  const T = Type.Refine(Type.Unsafe<Date>({}), (value) => value instanceof Date)
+  Assert.IsExtendsMutual<Static<typeof T>, Date>(true)
+}

--- a/test/typebox/static/type/~refine.ts
+++ b/test/typebox/static/type/~refine.ts
@@ -1,0 +1,7 @@
+import Type, { type Static } from 'typebox'
+import { Assert } from 'test'
+
+{
+  const T = Type.Refine(Type.String(), (value) => value === 'hello')
+  Assert.IsExtendsMutual<Static<typeof T>, string>(true)
+}


### PR DESCRIPTION
This PR brings forward non-breaking updates on the next branch to reduce the PR surface area for the next version of TypeBox.

### Updates

* Type.Refine Error Callback

* Type.Unsafe Retain Schema Kind

* Alias Unsafe as Unknown in Extends

* Value.Mutate Deprecation Notice

### Refine / Unsafe

This PR applies updates the Refine/Unsafe to ensure these types can compose in reverse order, and to ensure that Unsafe is non-destructive to the schema it wraps.

```typescript
{
  const T = Type.Unsafe<Date>(Type.Refine({}, (value) => value instanceof Date))
  Assert.IsExtends<Static<typeof T>, Date>(true)
}
{
  const T = Type.Refine(Type.Unsafe<Date>({}), (value) => value instanceof Date)
  Assert.IsExtends<Static<typeof T>, Date>(true)
}
```

Other updates include a numeric indexing fix for TS Script alignment. Refer Algorithm 8.

