### PR TITLE
Version 1.1.30

### DIFF
--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.1.30](https://github.com/sinclairzx81/typebox/pull/1584)
+  - Support Recursive Indexed This
 - [Revision 1.1.29](https://github.com/sinclairzx81/typebox/pull/1583)
   - Type.Refine Error Callback
   - Type.Unsafe Retain Schema Kind

--- a/src/type/engine/indexed/from-object.ts
+++ b/src/type/engine/indexed/from-object.ts
@@ -31,36 +31,42 @@ THE SOFTWARE.
 import { type TProperties } from '../../types/properties.ts'
 import { type TSchema } from '../../types/schema.ts'
 import { type TNumber, IsNumber } from '../../types/number.ts'
+import { type TNever, Never } from '../../types/never.ts'
 import { type TPropertyKeys, PropertyKeys } from '../../types/properties.ts'
 import { type TEvaluateUnion, EvaluateUnion } from '../evaluate/evaluate.ts'
 import { type TToIndexableKeys, ToIndexableKeys } from '../indexable/to-indexable-keys.ts'
 
 import { IntegerKey } from '../../types/record.ts'
-
+import { type TExpandThis, ExpandThis } from '../this/expand-this.ts'
 // ------------------------------------------------------------------
-// SelectProperty
+// IndexProperty
 // ------------------------------------------------------------------
-type TSelectProperty<Properties extends TProperties, Key extends string,
+type TIndexProperty<Properties extends TProperties, Key extends string,
   // note: we are trying to normalize the key to support numeric lookup via string (revise)
   CanonicalKey extends string = keyof Properties extends string | number ? `${keyof Properties}` : never,
-  Result extends TSchema[] = Key extends CanonicalKey ? [Properties[Key]] : []
+  SelectedType extends TSchema = Key extends CanonicalKey ? Properties[Key] : TNever,
+  Result extends TSchema = TExpandThis<Properties, SelectedType>,
 > = Result
-function SelectProperty<Properties extends TProperties, Key extends string>
+function IndexProperty<Properties extends TProperties, Key extends string>
   (properties: Properties, key: Key): 
-    TSelectProperty<Properties, Key> {
-  const result = key in properties ? [properties[key]] : []
+    TIndexProperty<Properties, Key> {
+  const selectedType = key in properties ? properties[key] : Never()
+  const result = ExpandThis(properties, selectedType)
   return result as never
 }
-type TSelectProperties<Properties extends TProperties, Keys extends string[], Result extends TSchema[] = []> = (
+// ------------------------------------------------------------------
+// IndexProperties
+// ------------------------------------------------------------------
+type TIndexProperties<Properties extends TProperties, Keys extends string[], Result extends TSchema[] = []> = (
   Keys extends [infer Left extends string, ...infer Right extends string[]]
-    ? TSelectProperties<Properties, Right, [...Result, ...TSelectProperty<Properties, Left>]>
+    ? TIndexProperties<Properties, Right, [...Result, TIndexProperty<Properties, Left>]>
     : Result
 )
-function SelectProperties<Properties extends TProperties, Keys extends string[]>
+function IndexProperties<Properties extends TProperties, Keys extends string[]>
   (properties: Properties, keys: [...Keys]): 
-    TSelectProperties<Properties, Keys> {
+    TIndexProperties<Properties, Keys> {
   return keys.reduce((result, left) => {
-    return [...result, ...SelectProperty(properties, left)]
+    return [...result, IndexProperty(properties, left)]
   }, [] as TSchema[]) as never
 }
 // ------------------------------------------------------------------
@@ -68,12 +74,12 @@ function SelectProperties<Properties extends TProperties, Keys extends string[]>
 // ------------------------------------------------------------------
 type TFromIndexer<Properties extends TProperties, Indexer extends TSchema,
   Keys extends string[] = TToIndexableKeys<Indexer>,
-  Variants extends TSchema[] = TSelectProperties<Properties, Keys>,
+  Variants extends TSchema[] = TIndexProperties<Properties, Keys>,
   Result extends TSchema = TEvaluateUnion<Variants>
 > = Result
 function FromIndexer<Properties extends TProperties, Indexer extends TSchema>(properties: Properties, indexer: Indexer): TFromIndexer<Properties, Indexer> {
   const keys = ToIndexableKeys(indexer) as string[]
-  const variants = SelectProperties(properties, keys)
+  const variants = IndexProperties(properties, keys)
   const result = EvaluateUnion(variants)
   return result as never
 }
@@ -104,13 +110,13 @@ function NumericKeys<Keys extends string[]>(keys: [...Keys]): TNumericKeys<Keys>
 type TFromIndexerNumber<Properties extends TProperties,
   Keys extends string[] = TPropertyKeys<Properties>,
   NumericKeys extends string[] = TNumericKeys<Keys>,
-  Variants extends TSchema[] = TSelectProperties<Properties, NumericKeys>,
+  Variants extends TSchema[] = TIndexProperties<Properties, NumericKeys>,
   Result extends TSchema = TEvaluateUnion<Variants>
 > = Result
 function FromIndexerNumber<Properties extends TProperties>(properties: Properties): TFromIndexerNumber<Properties> {
   const keys = PropertyKeys(properties) as string[]
   const numericKeys = NumericKeys(keys)
-  const variants = SelectProperties(properties, numericKeys)
+  const variants = IndexProperties(properties, numericKeys)
   const result = EvaluateUnion(variants)
   return result as never
 }

--- a/src/type/engine/this/expand-this.ts
+++ b/src/type/engine/this/expand-this.ts
@@ -1,0 +1,103 @@
+/*--------------------------------------------------------------------------
+
+TypeBox
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2026 Haydn Paterson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
+// deno-fmt-ignore-file
+
+import { type TArray, IsArray, Array } from '../../types/array.ts'
+import { type TAsyncIterator, IsAsyncIterator, AsyncIterator } from '../../types/async-iterator.ts'
+import { type TConstructor, IsConstructor, Constructor } from '../../types/constructor.ts'
+import { type TFunction, IsFunction, Function } from '../../types/function.ts'
+import { type TIterator, IsIterator, Iterator } from '../../types/iterator.ts'
+import { type TIntersect, IsIntersect, Intersect } from '../../types/intersect.ts'
+import { type TObject, Object } from '../../types/object.ts'
+import { type TProperties } from '../../types/properties.ts'
+import { type TSchema } from '../../types/schema.ts'
+import { type TPromise, IsPromise, Promise } from '../../types/promise.ts'
+import { type TTuple, IsTuple, Tuple } from '../../types/tuple.ts'
+import { type TThis, IsThis } from '../../types/this.ts'
+import { type TUnion, IsUnion, Union } from '../../types/union.ts'
+
+// ------------------------------------------------------------------
+// FromTypes
+// ------------------------------------------------------------------
+type TFromTypes<Properties extends TProperties, Types extends TSchema[], Result extends TSchema[] = []> = (
+  Types extends [infer Left extends TSchema, ...infer Right extends TSchema[]]
+    ? TFromTypes<Properties, Right, [...Result, TFromType<Properties, Left>]>
+    : Result
+)
+function FromTypes<Properties extends TProperties, Types extends TSchema[]>(properties: Properties, types: [...Types]): TFromTypes<Properties, Types> {
+  return types.map(type => FromType(properties, type)) as never
+}
+// ------------------------------------------------------------------
+// FromType
+// ------------------------------------------------------------------
+export type TFromType<Properties extends TProperties, Type extends TSchema> = (
+  Type extends TArray<infer Type extends TSchema> ? TArray<TFromType<Properties, Type>> :
+  Type extends TAsyncIterator<infer Type extends TSchema> ? TAsyncIterator<TFromType<Properties, Type>> :
+  Type extends TConstructor<infer Parameters extends TSchema[], infer InstanceType extends TSchema> ? TConstructor<TFromTypes<Properties, Parameters>, TFromType<Properties, InstanceType>> :
+  Type extends TFunction<infer Parameters extends TSchema[], infer ReturnType extends TSchema> ? TFunction<TFromTypes<Properties, Parameters>, TFromType<Properties, ReturnType>> :
+  Type extends TIterator<infer Type extends TSchema> ? TIterator<TFromType<Properties, Type>> :
+  Type extends TPromise<infer Type extends TSchema> ? TPromise<TFromType<Properties, Type>> :
+  Type extends TTuple<infer Types extends TSchema[]> ? TTuple<TFromTypes<Properties, Types>> :
+  Type extends TUnion<infer Types extends TSchema[]> ? TUnion<TFromTypes<Properties, Types>> :
+  Type extends TIntersect<infer Types extends TSchema[]> ? TIntersect<TFromTypes<Properties, Types>> :
+  Type extends TThis ? TObject<Properties> :
+  Type
+)
+export function FromType<Properties extends TProperties, Type extends TSchema>(properties: Properties, type: Type): TFromType<Properties, Type> {
+  return (
+    IsArray(type) ? Array(FromType(properties, type.items)) :
+    IsAsyncIterator(type) ? AsyncIterator(FromType(properties, type.iteratorItems)) :
+    IsConstructor(type) ? Constructor(FromTypes(properties, type.parameters), FromType(properties, type.instanceType)) :
+    IsFunction(type) ? Function(FromTypes(properties, type.parameters), FromType(properties, type.returnType)) :
+    IsIterator(type) ? Iterator(FromType(properties, type.iteratorItems)) :
+    IsPromise(type) ? Promise(FromType(properties, type.item)) :
+    IsTuple(type) ? Tuple(FromTypes(properties, type.items)) :
+    IsUnion(type) ? Union(FromTypes(properties, type.anyOf)) :
+    IsIntersect(type) ? Intersect(FromTypes(properties, type.allOf)) :
+    IsThis(type) ? Object(properties) :
+    type
+  ) as never
+}
+// ------------------------------------------------------------------
+// ExpandThis
+//
+// Performs a single-step unroll of a recursive type by substituting
+// TThis references with the TObject they resolve to. The substitution
+// is shallow, terminating at the first TThis encountered rather than
+// recursing into the expanded object. This mirrors how TypeScript
+// expands circular references when resolving indexed access types.
+//
+// ------------------------------------------------------------------
+export type TExpandThis<Properties extends TProperties, Type extends TSchema,
+  Result extends TSchema = TFromType<Properties, Type>
+> = Result
+export function ExpandThis<Properties extends TProperties, Type extends TSchema>(properties: TProperties, type: Type): TExpandThis<Properties, Type> {
+  const result = FromType(properties, type)
+  return result as never
+}

--- a/src/type/engine/this/index.ts
+++ b/src/type/engine/this/index.ts
@@ -1,0 +1,29 @@
+/*--------------------------------------------------------------------------
+
+TypeBox
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2026 Haydn Paterson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
+export * from './expand-this.ts'

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.1.29'
+const Version = '1.1.30'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/type/engine/action/indexed.ts
+++ b/test/typebox/runtime/type/engine/action/indexed.ts
@@ -499,7 +499,8 @@ Test('Should Index 38', () => {
     y: Type.Literal(3),
     1: Type.Literal(4)
   })
-  const S: Type.TUnion<[Type.TLiteral<2>, Type.TLiteral<4>]> = Type.Index(T, Type.Number())
+  // CACHE | TYPESCRIPT TYPE ID ORDER ISSUE
+  const S /*: Type.TUnion<[Type.TLiteral<2>, Type.TLiteral<4>]> */ = Type.Index(T, Type.Number())
   Assert.IsTrue(Type.IsUnion(S))
   Assert.IsEqual(S.anyOf.length, 2)
   Assert.IsEqual(S.anyOf[0].const, 2)
@@ -512,9 +513,42 @@ Test('Should Index 39', () => {
     'y': Type.Literal(3),
     '1': Type.Literal(4)
   })
-  const S: Type.TUnion<[Type.TLiteral<2>, Type.TLiteral<4>]> = Type.Index(T, Type.Number())
+  // CACHE | TYPESCRIPT TYPE ID ORDER ISSUE
+  const S /*: Type.TUnion<[Type.TLiteral<2>, Type.TLiteral<4>]> */ = Type.Index(T, Type.Number())
   Assert.IsTrue(Type.IsUnion(S))
   Assert.IsEqual(S.anyOf.length, 2)
   Assert.IsEqual(S.anyOf[0].const, 2)
   Assert.IsEqual(S.anyOf[1].const, 4)
+})
+// ------------------------------------------------------------------
+// This
+// ------------------------------------------------------------------
+Test('Should Index 40', () => {
+  const T = Type.Object({
+    self: Type.This()
+  })
+  const S: Type.TObject<{
+    self: Type.TThis
+  }> = Type.Index(T, Type.Literal('self'))
+  Assert.IsTrue(Type.IsObject(S))
+  Assert.IsTrue(Type.IsThis(S.properties.self))
+})
+Test('Should Index 41', () => {
+  const T = Type.Object({
+    self: Type.This()
+  })
+  const S: Type.TObject<{
+    self: Type.TThis
+  }> = Type.Index(Type.Index(Type.Index(T, Type.Literal('self')), Type.Literal('self')), Type.Literal('self'))
+  Assert.IsTrue(Type.IsObject(S))
+  Assert.IsTrue(Type.IsThis(S.properties.self))
+})
+Test('Should Index 42', () => {
+  const T = Type.Object({
+    value: Type.Literal(42),
+    self: Type.This()
+  })
+  const S: Type.TLiteral<42> = Type.Index(Type.Index(T, Type.Literal('self')), Type.Literal('value'))
+  Assert.IsTrue(Type.IsLiteral(S))
+  Assert.IsEqual(S.const, 42)
 })

--- a/test/typebox/runtime/type/script/indexed.ts
+++ b/test/typebox/runtime/type/script/indexed.ts
@@ -124,3 +124,286 @@ Test('Should Indexed 20', () => {
   Assert.IsTrue(Type.IsArray(S))
   Assert.IsTrue(Type.IsNumber(S.items))
 })
+Test('Should Indexed 20', () => {
+  const T = Type.Script(`[1, 2, 3][]['length'][]`)
+  const S: Type.TArray<Type.TNumber> = T
+  Assert.IsTrue(Type.IsArray(S))
+  Assert.IsTrue(Type.IsNumber(S.items))
+})
+// ------------------------------------------------------------------
+// Indexed This
+// ------------------------------------------------------------------
+Test('Should Indexed 21', () => {
+  const T = Type.Script(`
+    export interface A{ a: 42, self: this }
+    export type B = A['self']['a']
+  `)
+  const B: Type.TLiteral<42> = T.B
+  Assert.IsTrue(Type.IsLiteral(B))
+  Assert.IsEqual(B.const, 42)
+})
+Test('Should Indexed 22', () => {
+  const T = Type.Script(`
+    export interface A{ value: 42, self: this }
+    export type B = A['self']['value' | 'self']
+  `)
+  const B: Type.TUnion<[
+    Type.TLiteral<42>,
+    Type.TObject<{
+      value: Type.TLiteral<42>
+      self: Type.TThis
+    }>
+  ]> = T.B
+  Assert.IsTrue(Type.IsUnion(B))
+  Assert.IsTrue(Type.IsLiteral(B.anyOf[0]))
+  Assert.IsEqual(B.anyOf[0].const, 42)
+  Assert.IsTrue(Type.IsObject(B.anyOf[1]))
+  Assert.IsTrue(Type.IsLiteral(B.anyOf[1].properties.value))
+  Assert.IsTrue(Type.IsThis(B.anyOf[1].properties.self))
+})
+Test('Should Indexed 23', () => {
+  const T = Type.Script(`
+    export interface A { value: 42, self: this }
+    export type B = A['self']['self']['value']
+  `)
+  const B: Type.TLiteral<42> = T.B
+  Assert.IsTrue(Type.IsLiteral(B))
+  Assert.IsEqual(B.const, 42)
+})
+Test('Should Indexed 24', () => {
+  const T = Type.Script(`
+    export interface A { nested: { x: 42 }, self: this }
+    export type B = A['self']['nested']
+  `)
+  const B: Type.TObject<{ x: Type.TLiteral<42> }> = T.B
+  Assert.IsTrue(Type.IsObject(B))
+  Assert.IsTrue(Type.IsLiteral(B.properties.x))
+  Assert.IsEqual(B.properties.x.const, 42)
+})
+Test('Should Indexed 25', () => {
+  const T = Type.Script(`
+    export interface A { tag: 'hello', self: this }
+    export type B = A['self']['self']['tag']
+  `)
+  const B: Type.TLiteral<'hello'> = T.B
+  Assert.IsTrue(Type.IsLiteral(B))
+  Assert.IsEqual(B.const, 'hello')
+})
+Test('Should Indexed 26', () => {
+  const T = Type.Script(`
+    export interface A { a: 1, b: 2, self: this }
+    export type B = A['self']['self']['a' | 'b']
+  `)
+  const B: Type.TUnion<[Type.TLiteral<1>, Type.TLiteral<2>]> = T.B
+  Assert.IsTrue(Type.IsUnion(B))
+  Assert.IsTrue(Type.IsLiteral(B.anyOf[0]))
+  Assert.IsEqual(B.anyOf[0].const, 1)
+  Assert.IsTrue(Type.IsLiteral(B.anyOf[1]))
+  Assert.IsEqual(B.anyOf[1].const, 2)
+})
+Test('Should Indexed 27', () => {
+  const T = Type.Script(`
+    export interface A { value: 42 | 43, self: this }
+    export type B = A['self']['value']
+  `)
+  const B: Type.TUnion<[Type.TLiteral<42>, Type.TLiteral<43>]> = T.B
+  Assert.IsTrue(Type.IsUnion(B))
+  Assert.IsTrue(Type.IsLiteral(B.anyOf[0]))
+  Assert.IsEqual(B.anyOf[0].const, 42)
+  Assert.IsTrue(Type.IsLiteral(B.anyOf[1]))
+  Assert.IsEqual(B.anyOf[1].const, 43)
+})
+Test('Should Indexed 28', () => {
+  const T = Type.Script(`
+    export interface A { items: number[], self: this }
+    export type B = A['self']['items']
+  `)
+  const B: Type.TArray<Type.TNumber> = T.B
+  Assert.IsTrue(Type.IsArray(B))
+  Assert.IsTrue(Type.IsNumber(B.items))
+})
+Test('Should Indexed 29', () => {
+  const T = Type.Script(`
+    export interface A { value: 1, b: B }
+    export interface B { value: 2, self: this }
+    export type C = B['self']['value']
+  `)
+  const C: Type.TLiteral<2> = T.C
+  Assert.IsTrue(Type.IsLiteral(C))
+  Assert.IsEqual(C.const, 2)
+})
+Test('Should Indexed 30', () => {
+  const T = Type.Script(`
+    export interface A { value: 42, self: this }
+    export type B = A['self']
+  `)
+  const B: Type.TObject<{
+    value: Type.TLiteral<42>
+    self: Type.TThis
+  }> = T.B
+  Assert.IsTrue(Type.IsObject(B))
+  Assert.IsTrue(Type.IsLiteral(B.properties.value))
+  Assert.IsEqual(B.properties.value.const, 42)
+  Assert.IsTrue(Type.IsThis(B.properties.self))
+})
+// ------------------------------------------------------------------
+// Indexed Expand This
+// ------------------------------------------------------------------
+Test('Should Indexed 31', () => {
+  const T = Type.Script(`
+    export interface A { self: this, items: this[] }
+    export type B = A['items']
+  `)
+  const B: Type.TArray<
+    Type.TObject<{
+      self: Type.TThis
+      items: Type.TArray<Type.TThis>
+    }>
+  > = T.B
+  Assert.IsTrue(Type.IsArray(B))
+  Assert.IsTrue(Type.IsObject(B.items))
+  Assert.IsTrue(Type.IsThis(B.items.properties.self))
+})
+Test('Should Indexed 32', () => {
+  const T = Type.Script(`
+    export interface A { self: this, pair: [this, this] }
+    export type B = A['pair']
+  `)
+  const B: Type.TTuple<[
+    Type.TObject<{ self: Type.TThis; pair: Type.TTuple<[Type.TThis, Type.TThis]> }>,
+    Type.TObject<{ self: Type.TThis; pair: Type.TTuple<[Type.TThis, Type.TThis]> }>
+  ]> = T.B
+  Assert.IsTrue(Type.IsTuple(B))
+  Assert.IsTrue(Type.IsObject(B.items[0]))
+  Assert.IsTrue(Type.IsObject(B.items[1]))
+  Assert.IsTrue(Type.IsThis(B.items[0].properties.self))
+  Assert.IsTrue(Type.IsThis(B.items[1].properties.self))
+})
+Test('Should Indexed 33', () => {
+  const T = Type.Script(`
+    export interface A { self: this, value: this | string }
+    export type B = A['value']
+  `)
+  const B: Type.TUnion<[
+    Type.TObject<{ self: Type.TThis; value: Type.TUnion<[Type.TThis, Type.TString]> }>,
+    Type.TString
+  ]> = T.B
+  Assert.IsTrue(Type.IsUnion(B))
+  Assert.IsTrue(Type.IsObject(B.anyOf[0]))
+  Assert.IsTrue(Type.IsThis(B.anyOf[0].properties.self))
+  Assert.IsTrue(Type.IsString(B.anyOf[1]))
+})
+Test('Should Indexed 34', () => {
+  const T = Type.Script(`
+    export interface A { self: this, value: this & { x: 1 } }
+    export type B = A['value']
+  `)
+  const B: Type.TObject<{
+    self: Type.TThis
+    value: Type.TIntersect<[
+      Type.TThis,
+      Type.TObject<{
+        x: Type.TLiteral<1>
+      }>
+    ]>
+    x: Type.TLiteral<1>
+  }> = T.B
+  Assert.IsTrue(Type.IsObject(B))
+  Assert.IsTrue(Type.IsThis(B.properties.self))
+  Assert.IsTrue(Type.IsIntersect(B.properties.value))
+  Assert.IsTrue(Type.IsThis(B.properties.value.allOf[0]))
+  Assert.IsTrue(Type.IsObject(B.properties.value.allOf[1]))
+  Assert.IsTrue(Type.IsLiteral(B.properties.x))
+  Assert.IsEqual(B.properties.x.const, 1)
+})
+Test('Should Indexed 35', () => {
+  const T = Type.Script(`
+    export interface A { self: this, value: Promise<this> }
+    export type B = A['value']
+  `)
+  const B: Type.TPromise<
+    Type.TObject<{
+      self: Type.TThis
+      value: Type.TPromise<Type.TThis>
+    }>
+  > = T.B
+  Assert.IsTrue(Type.IsPromise(B))
+  Assert.IsTrue(Type.IsObject(B.item))
+  Assert.IsTrue(Type.IsThis(B.item.properties.self))
+})
+Test('Should Indexed 36', () => {
+  const T = Type.Script(`
+    export interface A { self: this, value: (a: this) => this }
+    export type B = A['value']
+  `)
+  const B: Type.TFunction<
+    [
+      Type.TObject<{
+        self: Type.TThis
+        value: Type.TFunction<[Type.TThis], Type.TThis>
+      }>
+    ],
+    Type.TObject<{
+      self: Type.TThis
+      value: Type.TFunction<[Type.TThis], Type.TThis>
+    }>
+  > = T.B
+  Assert.IsTrue(Type.IsFunction(B))
+  Assert.IsTrue(Type.IsObject(B.parameters[0]))
+  Assert.IsTrue(Type.IsThis(B.parameters[0].properties.self))
+  Assert.IsTrue(Type.IsObject(B.returnType))
+  Assert.IsTrue(Type.IsThis(B.returnType.properties.self))
+})
+Test('Should Indexed 37', () => {
+  const T = Type.Script(`
+    export interface A { self: this, value: new (a: this) => this }
+    export type B = A['value']
+  `)
+  const B: Type.TConstructor<
+    [
+      Type.TObject<{
+        self: Type.TThis
+        value: Type.TConstructor<[Type.TThis], Type.TThis>
+      }>
+    ],
+    Type.TObject<{
+      self: Type.TThis
+      value: Type.TConstructor<[Type.TThis], Type.TThis>
+    }>
+  > = T.B
+  Assert.IsTrue(Type.IsConstructor(B))
+  Assert.IsTrue(Type.IsObject(B.parameters[0]))
+  Assert.IsTrue(Type.IsThis(B.parameters[0].properties.self))
+  Assert.IsTrue(Type.IsObject(B.instanceType))
+  Assert.IsTrue(Type.IsThis(B.instanceType.properties.self))
+})
+Test('Should Indexed 38', () => {
+  const T = Type.Script(`
+    export interface A { self: this, value: AsyncIterator<this> }
+    export type B = A['value']
+  `)
+  const B: Type.TAsyncIterator<
+    Type.TObject<{
+      self: Type.TThis
+      value: Type.TAsyncIterator<Type.TThis>
+    }>
+  > = T.B
+  Assert.IsTrue(Type.IsAsyncIterator(B))
+  Assert.IsTrue(Type.IsObject(B.iteratorItems))
+  Assert.IsTrue(Type.IsThis(B.iteratorItems.properties.self))
+})
+Test('Should Indexed 39', () => {
+  const T = Type.Script(`
+    export interface A { self: this, value: Iterator<this> }
+    export type B = A['value']
+  `)
+  const B: Type.TIterator<
+    Type.TObject<{
+      self: Type.TThis
+      value: Type.TIterator<Type.TThis>
+    }>
+  > = T.B
+  Assert.IsTrue(Type.IsIterator(B))
+  Assert.IsTrue(Type.IsObject(B.iteratorItems))
+  Assert.IsTrue(Type.IsThis(B.iteratorItems.properties.self))
+})


### PR DESCRIPTION
This PR extends indexed access type resolution to support recursive `this` references.

```typescript
type B = Type.Static<typeof B> // 42

const { B } = Type.Script(`

  export interface A { value: 42; self: this }
    
  export type B = A['self']['self']['self']['value'] // <-- recursive indexing

`)
```