### PR TITLE
Version 1.1.31

### DIFF
--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.1.31](https://github.com/sinclairzx81/typebox/pull/1585)
+  - Flag Awaited, Promise, Iterator and AsyncIterator for Deprecation
 - [Revision 1.1.30](https://github.com/sinclairzx81/typebox/pull/1584)
   - Support Recursive Indexed This
 - [Revision 1.1.29](https://github.com/sinclairzx81/typebox/pull/1583)

--- a/src/type/action/awaited.ts
+++ b/src/type/action/awaited.ts
@@ -50,7 +50,11 @@ export function AwaitedDeferred<Type extends TSchema>(type: Type, options: TSche
 export type TAwaited<Type extends TSchema> = (
   TAwaitedAction<Type>
 )
-/** Applies an Awaited action to a type. */
+/** 
+ * Applies an Awaited action to a type. 
+ * 
+ * @deprecated This action is being removed in the next version of TypeBox.
+ */
 export function Awaited<Type extends TSchema>(type: Type, options: TSchemaOptions = {}): TAwaited<Type> {
   return AwaitedAction(type, options)
 }

--- a/src/type/types/async-iterator.ts
+++ b/src/type/types/async-iterator.ts
@@ -51,7 +51,11 @@ export interface TAsyncIterator<Type extends TSchema = TSchema> extends TSchema 
 // ------------------------------------------------------------------
 // Factory
 // ------------------------------------------------------------------
-/** Creates a AsyncIterator type. */
+/** 
+ * Creates a AsyncIterator type. 
+ * 
+ * @deprecated This type is being removed in the next version of TypeBox. A fallback will be provided under examples.
+ */
 export function AsyncIterator<Type extends TSchema>(iteratorItems: Type, options?: TSchemaOptions): TAsyncIterator<Type> {
   return Memory.Create({ '~kind': 'AsyncIterator' }, { type: 'asyncIterator', iteratorItems }, options) as never
 }

--- a/src/type/types/iterator.ts
+++ b/src/type/types/iterator.ts
@@ -51,7 +51,11 @@ export interface TIterator<Type extends TSchema = TSchema> extends TSchema {
 // ------------------------------------------------------------------
 // Factory
 // ------------------------------------------------------------------
-/** Creates a Iterator type. */
+/** 
+ * Creates a Iterator type. 
+ * 
+ * @deprecated This type is being removed in the next version of TypeBox. A fallback will be provided under examples.
+ */
 export function Iterator<Type extends TSchema>(iteratorItems: Type, options?: TSchemaOptions): TIterator<Type> {
   return Memory.Create({ '~kind': 'Iterator' }, { type: 'iterator', iteratorItems }, options) as never
 }

--- a/src/type/types/promise.ts
+++ b/src/type/types/promise.ts
@@ -51,7 +51,11 @@ export interface TPromise<Type extends TSchema = TSchema> extends TSchema {
 // ------------------------------------------------------------------
 // Factory
 // ------------------------------------------------------------------
-/** Creates a Promise type. */
+/** 
+ * Creates a Promise type. 
+ * 
+ * @deprecated This type is being removed in the next version of TypeBox. A fallback will be provided under examples.
+ */
 export function _Promise_<Type extends TSchema>(item: Type, options?: TSchemaOptions): TPromise<Type> {
   return Memory.Create({ ['~kind']: 'Promise' }, { type: 'promise', item }, options) as never
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.1.30'
+const Version = '1.1.31'
 
 // ------------------------------------------------------------------
 // Build


### PR DESCRIPTION
This PR adds deprecation notices for Awaited, Promise, AsyncIterator, Iterator. 

The Promise, AsyncIterator and Iterator types are considered higher-order types whose functions and signatures can technically be expressed by the 1.x type system. In addition, these types are not entirely portable to languages that lack asynchronous primitives, or iterators. As these types add a lot of overhead for very little utility, a decision has been made to remove them in the next version.

The Awaited action is being removed as Promise is no longer supported. An Awaited fallback may be possible via Type.Generic + Recursive Unwrap, but would not have the same inference performance as the native supported version. A fallback may be considered for the next version regardless.

### Promise

The following is the planned fallback for Promise

```typescript
export function Promise<Type extends Type.TSchema>
 (_type: Type): Type.TUnsafe<globalThis.Promise<Type.Static<Type>>> {
  return Type.Refine(Type.Object({}), 
    value => value instanceof globalThis.Promise,
    () => `Expected Promise`) as never
}
```

### AsyncIterator

The following is the planned fallback for AsyncIterator

```typescript
export function AsyncIterator<Type extends Type.TSchema>
  (_type: Type): Type.TUnsafe<globalThis.AsyncIterableIterator<Type.Static<Type>>> {
  return Type.Refine(Type.Object({}), 
    value => Symbol.asyncIterator in value,
    () => `Expected AsyncIterator`) as never
}
```

### Iterator

The following is the planned fallback for Iterator

```typescript
export function Iterator<Type extends Type.TSchema>
  (_type: Type): Type.TUnsafe<globalThis.IterableIterator<Type.Static<Type>>> {
  return Type.Refine(Type.Object({}), 
    value => Symbol.iterator in value,
    () => `Expected Iterator`) as never
}
```

These types are being removed to add a degree of cross language interoperability, and to reduce overall library bundle size. These types were originally added to express RPC interface return types, but have not be utilized in years. Their omission is considered to be low impact.