### PR TITLE
Version 1.1.32

### DIFF
--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.1.32](https://github.com/sinclairzx81/typebox/pull/1586)
+  - TakeLeft Guard Function
 - [Revision 1.1.31](https://github.com/sinclairzx81/typebox/pull/1585)
   - Flag Awaited, Promise, Iterator and AsyncIterator for Deprecation
 - [Revision 1.1.30](https://github.com/sinclairzx81/typebox/pull/1584)

--- a/src/guard/guard.ts
+++ b/src/guard/guard.ts
@@ -180,6 +180,14 @@ export function EveryAll<T>(value: T[], offset: number, callback: (value: T, ind
   }
   return result
 }
+// ------------------------------------------------------------------
+// TakeLeft
+// ------------------------------------------------------------------
+export type TakeLeftTrue<T> = (left: T, right: T[]) => unknown
+export type TakeLeftFalse = () => unknown
+export function TakeLeft<T, True extends TakeLeftTrue<T>, False extends TakeLeftFalse>(array: T[], true_: True, false_: False): ReturnType<True> | ReturnType<False> {
+  return (IsEqual(array.length, 0) ? false_() : true_(array[0], array.slice(1))) as never
+}
 // --------------------------------------------------------------------------
 // Object
 // --------------------------------------------------------------------------

--- a/src/guard/guard.ts
+++ b/src/guard/guard.ts
@@ -167,12 +167,14 @@ export function IsMinLength(value: string, length: number): boolean {
 // --------------------------------------------------------------------------
 // Array
 // --------------------------------------------------------------------------
+/** Returns true if all elements from offset satisfy the callback, short-circuiting on the first failure */
 export function Every<T>(value: T[], offset: number, callback: (value: T, index: number) => boolean): boolean {
   for (let index = offset; index < value.length; index++) {
     if (!callback(value[index], index)) return false
   }
   return true
 }
+/** Returns true if all elements from offset satisfy the callback, visiting every element regardless of failure */
 export function EveryAll<T>(value: T[], offset: number, callback: (value: T, index: number) => boolean): boolean {
   let result = true
   for (let index = offset; index < value.length; index++) {
@@ -180,9 +182,7 @@ export function EveryAll<T>(value: T[], offset: number, callback: (value: T, ind
   }
   return result
 }
-// ------------------------------------------------------------------
-// TakeLeft
-// ------------------------------------------------------------------
+/** Takes the left-most element from an array and dispatches to the true arm, or the false arm if empty */
 export function TakeLeft<T, True extends (left: T, right: T[]) => unknown, False extends () => unknown>(array: T[], true_: True, false_: False): ReturnType<True> | ReturnType<False> {
   return (IsEqual(array.length, 0) ? false_() : true_(array[0], array.slice(1))) as never
 }

--- a/src/guard/guard.ts
+++ b/src/guard/guard.ts
@@ -183,9 +183,7 @@ export function EveryAll<T>(value: T[], offset: number, callback: (value: T, ind
 // ------------------------------------------------------------------
 // TakeLeft
 // ------------------------------------------------------------------
-export type TakeLeftTrue<T> = (left: T, right: T[]) => unknown
-export type TakeLeftFalse = () => unknown
-export function TakeLeft<T, True extends TakeLeftTrue<T>, False extends TakeLeftFalse>(array: T[], true_: True, false_: False): ReturnType<True> | ReturnType<False> {
+export function TakeLeft<T, True extends (left: T, right: T[]) => unknown, False extends () => unknown>(array: T[], true_: True, false_: False): ReturnType<True> | ReturnType<False> {
   return (IsEqual(array.length, 0) ? false_() : true_(array[0], array.slice(1))) as never
 }
 // --------------------------------------------------------------------------

--- a/src/type/engine/call/resolve-arguments.ts
+++ b/src/type/engine/call/resolve-arguments.ts
@@ -77,8 +77,8 @@ function BindArguments<Context extends TProperties, State extends TState, Parame
     TBindArguments<Context, State, ParameterLeft, ParameterRight, Arguments> {
   const instantiatedExtends = InstantiateType(context, state, parameterLeft.extends)
   const instantiatedEquals = InstantiateType(context, state, parameterLeft.equals)
-  return Guard.TakeLeft(arguments_,
-    (left, right) => BindParameters(BindArgument(context, state, parameterLeft['name'], instantiatedExtends, left), state, parameterRight, right),
+  return Guard.TakeLeft(arguments_, (left, right) => 
+    BindParameters(BindArgument(context, state, parameterLeft['name'], instantiatedExtends, left), state, parameterRight, right),
     () => BindParameters(BindArgument(context, state, parameterLeft['name'], instantiatedExtends, instantiatedEquals), state, parameterRight, [])
   ) as never
 }
@@ -93,8 +93,8 @@ type TBindParameters<Context extends TProperties, State extends TState, Paramete
 function BindParameters<Context extends TProperties, State extends TState, Parameters extends TParameter[], Arguments extends TSchema[]>
   (context: Context, state: State, parameters: [...Parameters], arguments_: [...Arguments]):
     TBindParameters<Context, State, Parameters, Arguments> {
-  return Guard.TakeLeft(parameters,
-    (left, right) => BindArguments(context, state, left, right, arguments_),
+  return Guard.TakeLeft(parameters, (left, right) => 
+    BindArguments(context, state, left, right, arguments_),
     () => context
   ) as never
 }

--- a/src/type/engine/call/resolve-arguments.ts
+++ b/src/type/engine/call/resolve-arguments.ts
@@ -28,8 +28,9 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
+import { Guard } from '../../../guard/index.ts'
 import { Memory } from '../../../system/memory/index.ts'
-import { type TSchema, IsSchema } from '../../types/schema.ts'
+import { type TSchema } from '../../types/schema.ts'
 import { type TParameter } from '../../types/parameter.ts'
 import { type TProperties } from '../../types/properties.ts'
 import { type TState, type TInstantiateType, InstantiateType } from '../instantiate.ts'
@@ -76,11 +77,9 @@ function BindArguments<Context extends TProperties, State extends TState, Parame
     TBindArguments<Context, State, ParameterLeft, ParameterRight, Arguments> {
   const instantiatedExtends = InstantiateType(context, state, parameterLeft.extends)
   const instantiatedEquals = InstantiateType(context, state, parameterLeft.equals)
-  const [left, ...right] = arguments_
-  return (
-    IsSchema(left)
-      ? BindParameters(BindArgument(context, state, parameterLeft['name'], instantiatedExtends, left), state, parameterRight, right)
-      : BindParameters(BindArgument(context, state, parameterLeft['name'], instantiatedExtends, instantiatedEquals), state, parameterRight, [])
+  return Guard.TakeLeft(arguments_,
+    (left, right) => BindParameters(BindArgument(context, state, parameterLeft['name'], instantiatedExtends, left), state, parameterRight, right),
+    () => BindParameters(BindArgument(context, state, parameterLeft['name'], instantiatedExtends, instantiatedEquals), state, parameterRight, [])
   ) as never
 }
 // ------------------------------------------------------------------
@@ -94,11 +93,9 @@ type TBindParameters<Context extends TProperties, State extends TState, Paramete
 function BindParameters<Context extends TProperties, State extends TState, Parameters extends TParameter[], Arguments extends TSchema[]>
   (context: Context, state: State, parameters: [...Parameters], arguments_: [...Arguments]):
     TBindParameters<Context, State, Parameters, Arguments> {
-  const [left, ...right] = parameters
-  return (
-    IsSchema(left)
-      ? BindArguments(context, state, left, right, arguments_)
-      : context
+  return Guard.TakeLeft(parameters,
+    (left, right) => BindArguments(context, state, left, right, arguments_),
+    () => context
   ) as never
 }
 // ------------------------------------------------------------------

--- a/src/type/engine/cyclic/check.ts
+++ b/src/type/engine/cyclic/check.ts
@@ -28,7 +28,8 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { type TSchema, IsSchema } from '../../types/schema.ts'
+import { Guard } from '../../../guard/index.ts'
+import { type TSchema } from '../../types/schema.ts'
 import { type TArray, IsArray } from '../../types/array.ts'
 import { type TAsyncIterator, IsAsyncIterator } from '../../types/async-iterator.ts'
 import { type TConstructor, IsConstructor } from '../../types/constructor.ts'
@@ -81,21 +82,20 @@ function FromProperties<Stack extends string[], Context extends TProperties, Pro
 type TFromTypes<Stack extends string[], Context extends TProperties, Types extends TSchema[]> =
   Types extends [infer Left extends TSchema, ...infer Right extends TSchema[]]
   ? TFromType<Stack, Context, Left> extends true
-  ? true
-  : TFromTypes<Stack, Context, Right>
+    ? true
+    : TFromTypes<Stack, Context, Right>
   : false
 
 function FromTypes<Stack extends string[], Context extends TProperties, Types extends TSchema[]>
   (stack: [...Stack], context: Context, types: [...Types]):
   TFromTypes<Stack, Context, Types> {
-  const [left, ...right] = types
-  return (
-    IsSchema(left)
-      ? FromType(stack, context, left)
-        ? true
-        : FromTypes(stack, context, right)
-      : false
+  return Guard.TakeLeft(types, (left, right) => 
+    FromType(stack, context, left)
+      ? true
+      : FromTypes(stack, context, right),
+    () => false
   ) as never
+
 }
 // ------------------------------------------------------------------
 // Type

--- a/src/type/engine/evaluate/distribute.ts
+++ b/src/type/engine/evaluate/distribute.ts
@@ -30,7 +30,7 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import { Guard } from '../../../guard/index.ts'
-import { type TSchema, IsSchema } from '../../types/schema.ts'
+import { type TSchema } from '../../types/schema.ts'
 import { type TUnion, IsUnion } from '../../types/union.ts'
 import { type TObject, IsObject } from '../../types/object.ts'
 import { type TTuple, IsTuple } from '../../types/tuple.ts'
@@ -105,14 +105,11 @@ type TDistributeType<Type extends TSchema, Distribution extends TSchema[], Resul
       : Result
 )
 function DistributeType<Type extends TSchema, Distribution extends TSchema[]>(type: Type, types: [...Distribution], result: TSchema[] = []): TDistributeType<Type, Distribution> {
-  const [left, ...right]  = types
-  return (
-    !Guard.IsUndefined(left) // TSchema[]
-      ? DistributeType(type, right, [...result, DistributeOperation(type, left)])
-      : result.length === 0
-        ? [type]
-        : result
-  ) as never
+  return Guard.TakeLeft(types, (left, right) => 
+    DistributeType(type, right, [...result, DistributeOperation(type, left)]),
+    () => Guard.IsEqual(result.length, 0)
+      ? [type]
+      : result) as never
 }
 // -----------------------------------------------------------------------------------------
 // DistributeUnion
@@ -123,12 +120,9 @@ type TDistributeUnion<Types extends TSchema[], Distribution extends TSchema[], R
    : Result
 )
 function DistributeUnion<Types extends TSchema[], Distribution extends TSchema[]>(types: [...Types], distribution: [...Distribution], result: TSchema[] = []): TDistributeUnion<Types, Distribution> {
-  const [left, ...right] = types
-  return (
-    IsSchema(left)
-      ? DistributeUnion(right, distribution, [...result, ...Distribute([left], distribution)])
-      : result
-  ) as never
+  return Guard.TakeLeft(types, (left, right) => 
+    DistributeUnion(right, distribution, [...result, ...Distribute([left], distribution)]),
+    () => result) as never
 }
 // -----------------------------------------------------------------------------------------
 // Distribute
@@ -141,12 +135,9 @@ export type TDistribute<Types extends TSchema[], Result extends TSchema[] = []> 
     : Result
 )
 export function Distribute<Types extends TSchema[]>(types: [...Types], result: TSchema[] = []): TDistribute<Types> {
-  const [left, ...right] = types
-  return (
-    IsSchema(left)
-      ? IsUnion(left) 
-        ? Distribute(right, DistributeUnion(left.anyOf, result))
-        : Distribute(right, DistributeType(left, result))
-      : result
-  ) as never
+  return Guard.TakeLeft(types, (left, right) => 
+    IsUnion(left)
+      ? Distribute(right, DistributeUnion(left.anyOf, result))
+      : Distribute(right, DistributeType(left, result)),
+    () => result) as never
 }

--- a/src/type/engine/instantiate.ts
+++ b/src/type/engine/instantiate.ts
@@ -118,8 +118,8 @@ export type TCanInstantiate<Types extends TSchema[]> =
       : TCanInstantiate<Right>
     : true
 export function CanInstantiate<Types extends TSchema[]>(types: [...Types]): TCanInstantiate<Types> {
-  return Guard.TakeLeft(types,
-    (left, right) => IsRef(left) 
+  return Guard.TakeLeft(types, (left, right) => 
+    IsRef(left) 
       ? false 
       : CanInstantiate(right),
     () => true

--- a/src/type/engine/instantiate.ts
+++ b/src/type/engine/instantiate.ts
@@ -118,13 +118,11 @@ export type TCanInstantiate<Types extends TSchema[]> =
       : TCanInstantiate<Right>
     : true
 export function CanInstantiate<Types extends TSchema[]>(types: [...Types]): TCanInstantiate<Types> {
-  const [left, ...right] = types
-  return (
-    IsSchema(left)
-      ? IsRef(left)
-        ? false
-        : CanInstantiate(right)
-      : true 
+  return Guard.TakeLeft(types,
+    (left, right) => IsRef(left) 
+      ? false 
+      : CanInstantiate(right),
+    () => true
   ) as never
 }
 // ------------------------------------------------------------------

--- a/src/type/engine/object/from-union.ts
+++ b/src/type/engine/object/from-union.ts
@@ -28,9 +28,9 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { type TUnreachable, Unreachable } from '../../../system/unreachable/index.ts'
 import { Guard } from '../../../guard/index.ts'
-import { type TSchema, IsSchema } from '../../types/schema.ts'
+import { type TUnreachable, Unreachable } from '../../../system/unreachable/index.ts'
+import { type TSchema } from '../../types/schema.ts'
 import { type TProperties } from '../../types/properties.ts'
 import { type TEvaluateUnion, EvaluateUnion } from '../evaluate/evaluate.ts'
 import { type TFromType, FromType } from './from-type.ts'
@@ -45,8 +45,8 @@ type TCollapseUnionProperties<Left extends TProperties, Right extends TPropertie
   }
 > = Result
 function CollapseUnionProperties<Left extends TProperties, Right extends TProperties>
-  (left: Left, right: Right): 
-    TCollapseUnionProperties<Left, Right> {
+  (left: Left, right: Right):
+  TCollapseUnionProperties<Left, Right> {
   const sharedKeys = Guard.Keys(left).filter((key) => key in right)
   const result = sharedKeys.reduce((result, key) => {
     return { ...result, [key]: EvaluateUnion([left[key], right[key]]) }
@@ -63,13 +63,10 @@ type TReduceVariants<Types extends TSchema[], Result extends TProperties> = (
 )
 function ReduceVariants<Types extends TSchema[], Result extends TProperties>
   (types: [...Types], result: Result):
-    TReduceVariants<Types, Result> {
-  const [left, ...right] = types
-  return (
-    IsSchema(left)
-      ? ReduceVariants(right, CollapseUnionProperties(result, FromType(left)))
-      : result
-  ) as never
+  TReduceVariants<Types, Result> {
+  return Guard.TakeLeft(types, (left, right) =>
+    ReduceVariants(right, CollapseUnionProperties(result, FromType(left))),
+    () => result) as never
 }
 // ------------------------------------------------------------------
 // FromUnion
@@ -86,13 +83,10 @@ export type TFromUnion<Types extends TSchema[]> = (
   : TUnreachable
 )
 export function FromUnion<Types extends TSchema[]>
-  (types: [...Types]): 
-    TFromUnion<Types> {
-  const [left, ...right] = types
-  return (
-    IsSchema(left)
-      ? ReduceVariants(right, FromType(left))
-      : Unreachable()
-  ) as never
+  (types: [...Types]):
+  TFromUnion<Types> {
+  return Guard.TakeLeft(types, (left, right) =>
+    ReduceVariants(right, FromType(left)),
+    () => Unreachable()) as never
 }
 // deno-coverage-ignore-stop

--- a/src/type/engine/template-literal/decode.ts
+++ b/src/type/engine/template-literal/decode.ts
@@ -28,11 +28,11 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { TUnreachable, Unreachable } from '../../../system/unreachable/index.ts'
 import { Guard } from '../../../guard/index.ts'
+import { TUnreachable, Unreachable } from '../../../system/unreachable/index.ts'
 
+import { type TSchema } from '../../types/schema.ts'
 import { type TLiteral, type TLiteralValue, Literal, IsLiteral } from '../../types/literal.ts'
-import { type TSchema, IsSchema } from '../../types/schema.ts'
 import { type TString, String } from '../../types/string.ts'
 import { type TTemplateLiteral, IsTemplateLiteral } from '../../types/template-literal.ts'
 import { type TUnion, Union, IsUnion } from '../../types/union.ts'
@@ -44,14 +44,15 @@ import { TemplateLiteralCreate } from './create.ts'
 // ------------------------------------------------------------------
 // FromLiteral
 // ------------------------------------------------------------------
-type TFromLiteralPush<Variants extends string[], Value extends TLiteralValue, Result extends string[] = []> = 
+type TFromLiteralPush<Variants extends string[], Value extends TLiteralValue, Result extends string[] = []> =
   Variants extends [infer Left extends string, ...infer Right extends string[]]
-    ? TFromLiteralPush<Right, Value, [...Result, `${Left}${Value}`]>
-    : Result
+  ? TFromLiteralPush<Right, Value, [...Result, `${Left}${Value}`]>
+  : Result
 
 function FromLiteralPush<Variants extends string[], Value extends TLiteralValue>(variants: [...Variants], value: Value, result: string[] = []): TFromLiteralPush<Variants, Value> {
-  const [left, ...right] = variants
-  return (Guard.IsString(left) ? FromLiteralPush(right, value, [...result, `${left}${value}`]): result) as never
+  return Guard.TakeLeft(variants, (left, right) =>
+    FromLiteralPush(right, value, [...result, `${left}${value}`]),
+    () => result) as never
 }
 type TFromLiteral<Variants extends string[], Value extends TLiteralValue> =
   Variants extends [] ? [`${Value}`] : TFromLiteralPush<Variants, Value>
@@ -64,14 +65,12 @@ function FromLiteral<Variants extends string[], Value extends TLiteralValue>(var
 // ------------------------------------------------------------------
 type TFromUnion<Variants extends string[], Types extends TSchema[], Result extends string[] = []> =
   Types extends [infer Left extends TSchema, ...infer Right extends TSchema[]]
-    ? TFromUnion<Variants, Right, [...Result, ...TFromType<Variants, Left>]>
-    : Result
+  ? TFromUnion<Variants, Right, [...Result, ...TFromType<Variants, Left>]>
+  : Result
 function FromUnion<Variants extends string[], Types extends TSchema[]>(variants: [...Variants], types: [...Types], result: string[] = []): TFromUnion<Variants, Types> {
-  const [left, ...right] = types
-  return (
-    IsSchema(left) 
-      ? FromUnion(variants, right, [...result, ...FromType(variants, left)])
-      : result
+  return Guard.TakeLeft(types, (left, right) =>
+    FromUnion(variants, right, [...result, ...FromType(variants, left)]),
+    () => result
   ) as never
 }
 // ------------------------------------------------------------------
@@ -106,23 +105,22 @@ function FromType<Variants extends string[], Type extends TSchema>(variants: [..
 // ------------------------------------------------------------------
 // FromSpan
 // ------------------------------------------------------------------
-type TDecodeFromSpan<Variants extends string[], Types extends TSchema[]> = 
+type TDecodeFromSpan<Variants extends string[], Types extends TSchema[]> =
   Types extends [infer Left extends TSchema, ...infer Right extends TSchema[]]
-    ? TDecodeFromSpan<TFromType<Variants, Left>, Right>
-    : Variants
+  ? TDecodeFromSpan<TFromType<Variants, Left>, Right>
+  : Variants
 function DecodeFromSpan<Variants extends string[], Types extends TSchema[]>(variants: [...Variants], types: [...Types]): TDecodeFromSpan<Variants, Types> {
-  const [left, ...right] = types
-  return (
-    IsSchema(left) ? DecodeFromSpan(FromType(variants, left) as string[], right) : variants
-  ) as never
+  return Guard.TakeLeft(types, (left, right) =>
+    DecodeFromSpan(FromType(variants, left) as string[], right),
+    () => variants) as never
 }
 // ------------------------------------------------------------------
 // VariantsToLiterals
 // ------------------------------------------------------------------
-type TVariantsToLiterals<Variants extends string[], Result extends TSchema[] = []> = 
+type TVariantsToLiterals<Variants extends string[], Result extends TSchema[] = []> =
   Variants extends [infer Left extends string, ...infer Right extends string[]]
-    ? TVariantsToLiterals<Right, [...Result, TLiteral<Left>]>
-    : Result
+  ? TVariantsToLiterals<Right, [...Result, TLiteral<Left>]>
+  : Result
 function VariantsToLiterals<Variants extends string[]>(variants: [...Variants]): TVariantsToLiterals<Variants> {
   return variants.map(variant => Literal(variant)) as never
 }
@@ -167,7 +165,7 @@ function DecodeTypes<Types extends TSchema[]>(types: [...Types]): TDecodeTypes<T
     Guard.IsEqual(types.length, 1) && IsLiteral(types[0]) ? types[0] :
     DecodeTypesAsUnion(types)
   ) as never
-} 
+}
 // deno-coverage-ignore-stop
 // ------------------------------------------------------------------
 // TemplateLiteralDecodeUnsafe
@@ -177,10 +175,10 @@ export type TTemplateLiteralDecodeUnsafe<Pattern extends string,
   Types extends TSchema[] = TParsePatternIntoTypes<Pattern>,
   Result extends TSchema = (
     Types extends []                            // Failed to Parse | IsTemplateLiteralPattern
-      ? TString
-      : TIsTemplateLiteralFinite<Types> extends true
-        ? TDecodeTypes<Types>
-        : TTemplateLiteral<Pattern>
+    ? TString
+    : TIsTemplateLiteralFinite<Types> extends true
+    ? TDecodeTypes<Types>
+    : TTemplateLiteral<Pattern>
   )
 > = Result
 /**
@@ -193,7 +191,7 @@ export function TemplateLiteralDecodeUnsafe<Pattern extends string>(pattern: Pat
   const types = ParsePatternIntoTypes(pattern)
   const result = Guard.IsEqual(types.length, 0) // Failed to Parse | IsTemplateLiteralPattern
     ? String()                                  // ... Pattern cannot be typed, so discard
-    : IsTemplateLiteralFinite(types)              
+    : IsTemplateLiteralFinite(types)
       ? DecodeTypes(types)
       : TemplateLiteralCreate(pattern)
   return result as never

--- a/src/type/engine/template-literal/encode.ts
+++ b/src/type/engine/template-literal/encode.ts
@@ -28,7 +28,8 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { type TSchema, IsSchema } from '../../types/schema.ts'
+import { Guard } from '../../../guard/index.ts'
+import { type TSchema } from '../../types/schema.ts'
 import { type TEnum, type TEnumValue, IsEnum } from '../../types/enum.ts'
 import { type TLiteral, type TLiteralValue, Literal, IsLiteral } from '../../types/literal.ts'
 import { type TUnion, Union, IsUnion } from '../../types/union.ts'
@@ -42,7 +43,6 @@ import { NeverPattern } from '../../types/never.ts'
 import { TemplateLiteralCreate } from './create.ts'
 
 import { type TEnumValuesToVariants, EnumValuesToVariants } from '../enum/enum-to-union.ts'
-
 import { type TTemplateLiteralAction, TemplateLiteralAction } from './instantiate.ts'
 
 // ------------------------------------------------------------------
@@ -188,12 +188,9 @@ type TEncodeUnion<Types extends TSchema[], Right extends TSchema[], Pattern exte
 function EncodeUnion<Types extends TSchema[], Right extends TSchema[], Pattern extends string>
   (types: [...Types], right: Right, pattern: Pattern, result: string[] = []): 
     TEncodeUnion<Types, Right, Pattern> {
-  const [head, ...tail] = types
-  return (
-    IsSchema(head)
-      ? EncodeUnion(tail, right, pattern, [...result, EncodeType(head, [], '')])
-      : EncodeTypes(right, `${pattern}(${JoinString(result)})`)
-  ) as never
+  return Guard.TakeLeft(types, (head, tail) => 
+    EncodeUnion(tail, right, pattern, [...result, EncodeType(head, [], '')]),
+    () => EncodeTypes(right, `${pattern}(${JoinString(result)})`)) as never
 }
 // ------------------------------------------------------------------
 // EncodeType
@@ -238,12 +235,9 @@ type TEncodeTypes<Types extends TSchema[], Pattern extends string> = (
 )
 function EncodeTypes<Types extends TSchema[], Pattern extends string>
   (types: [...Types], pattern: Pattern): TEncodeTypes<Types, Pattern> {
-  const [left, ...right] = types
-  return (
-    IsSchema(left)
-      ? EncodeType(left, right, pattern)
-      : pattern
-  ) as never
+  return Guard.TakeLeft(types, (left, right) => 
+    EncodeType(left, right, pattern),
+    () => pattern) as never
 }
 // ------------------------------------------------------------------
 // EncodePattern

--- a/src/type/engine/template-literal/is-finite.ts
+++ b/src/type/engine/template-literal/is-finite.ts
@@ -74,8 +74,8 @@ type TFromType<Type extends TSchema> =
 function FromType<Type extends TSchema>(type: Type): TFromType<Type> {
   return (
     IsUnion(type) ? FromTypes(type.anyOf) :
-      IsLiteral(type) ? FromLiteral(type.const) :
-        false
+    IsLiteral(type) ? FromLiteral(type.const) :
+    false
   ) as never
 }
 // ------------------------------------------------------------------

--- a/src/type/engine/template-literal/is-finite.ts
+++ b/src/type/engine/template-literal/is-finite.ts
@@ -29,7 +29,7 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import { Guard } from '../../../guard/index.ts'
-import { type TSchema, IsSchema } from '../../types/schema.ts'
+import { type TSchema } from '../../types/schema.ts'
 import { type TLiteral, type TLiteralValue, IsLiteral } from '../../types/literal.ts'
 import { type TUnion, IsUnion } from '../../types/union.ts'
 
@@ -45,20 +45,17 @@ function FromLiteral<Value extends TLiteralValue>(_value: Value): TFromLiteral<V
 // ------------------------------------------------------------------
 type TFromTypesReduce<Types extends TSchema[]> = (
   Types extends [infer Left extends TSchema, ...infer Right extends TSchema[]]
-    ? TFromType<Left> extends true
-      ? TFromTypesReduce<Right>
-      : false
-    : true
+  ? TFromType<Left> extends true
+    ? TFromTypesReduce<Right>
+    : false
+  : true
 )
 function FromTypesReduce<Types extends TSchema[]>(types: [...Types]): TFromTypesReduce<Types> {
-  const [left, ...right] = types
-  return (
-    IsSchema(left)
-      ? FromType(left)
-        ? FromTypesReduce(right)
-        : false
-      : true
-  ) as never
+  return Guard.TakeLeft(types, (left, right) =>
+    FromType(left)
+      ? FromTypesReduce(right)
+      : false,
+    () => true) as never
 }
 type TFromTypes<Types extends TSchema[],
   Result extends boolean = Types extends [] ? false : TFromTypesReduce<Types>
@@ -72,13 +69,13 @@ function FromTypes<Types extends TSchema[]>(types: [...Types]): TFromTypes<Types
 // ------------------------------------------------------------------
 type TFromType<Type extends TSchema> =
   Type extends TUnion<infer Types extends TSchema[]> ? TFromTypes<Types> :
-  Type extends TLiteral<infer Value extends TLiteralValue> ? TFromLiteral<Value> : 
+  Type extends TLiteral<infer Value extends TLiteralValue> ? TFromLiteral<Value> :
   false
 function FromType<Type extends TSchema>(type: Type): TFromType<Type> {
   return (
     IsUnion(type) ? FromTypes(type.anyOf) :
-    IsLiteral(type) ? FromLiteral(type.const) :
-    false
+      IsLiteral(type) ? FromLiteral(type.const) :
+        false
   ) as never
 }
 // ------------------------------------------------------------------

--- a/src/type/extends/extends-right.ts
+++ b/src/type/extends/extends-right.ts
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
+import { Guard } from '../../guard/index.ts'
 import { Memory } from '../../system/memory/index.ts'
 import { type TSchema } from '../types/schema.ts'
 import { type TProperties } from '../types/properties.ts'
@@ -106,7 +107,7 @@ type TExtendsRightIntersect<Inferred extends TProperties, Left extends TSchema, 
 function ExtendsRightIntersect<Inferred extends TProperties, Left extends TSchema, Right extends TSchema[]>
   (inferred: Inferred, left: Left, right: Right): 
     TExtendsRightIntersect<Inferred, Left, Right> {
-  return Result.TakeLeft(right, (head, tail) => 
+  return Guard.TakeLeft(right, (head, tail) => 
     Result.Match(ExtendsLeft(inferred, left, head),
       inferred => ExtendsRightIntersect(inferred, left, tail),
       () => Result.ExtendsFalse()),
@@ -137,7 +138,7 @@ type TExtendsRightUnion<Inferred extends TProperties, Left extends TSchema, Righ
 function ExtendsRightUnion<Inferred extends TProperties, Left extends TSchema, Right extends TSchema[]>
   (inferred: Inferred, left: Left, right: Right):
   TExtendsRightUnion<Inferred, Left, Right> {
-  return Result.TakeLeft(right, (head, tail) =>
+  return Guard.TakeLeft(right, (head, tail) =>
     Result.Match(ExtendsLeft(inferred, left, head),
       inferred => Result.ExtendsTrue(inferred),
       () => ExtendsRightUnion(inferred, left, tail)),

--- a/src/type/extends/inference.ts
+++ b/src/type/extends/inference.ts
@@ -146,7 +146,7 @@ type TryInferResults<Rest extends TSchema[], Right extends TSchema, Result exten
     : Result
 )
 function TryInferResults<Rest extends TSchema[], Right extends TSchema>(rest: [...Rest], right: Right, result: TSchema[] = []): TryInferResults<Rest, Right> {
-  return Result.TakeLeft(rest, (head, tail) =>
+  return Guard.TakeLeft(rest, (head, tail) =>
     Result.Match(ExtendsLeft({}, head, right),
       () => TryInferResults(tail, right, [...result, head]),
       () => undefined),

--- a/src/type/extends/parameters.ts
+++ b/src/type/extends/parameters.ts
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
+import { Guard } from '../../guard/index.ts'
 import { type TInfer, IsInfer } from '../types/infer.ts'
 import { type TSchema } from '../types/schema.ts'
 import { type TOptional, IsOptional } from '../types/_optional.ts'
@@ -80,7 +81,7 @@ type TParameterRight<Inferred extends TProperties, Left extends TSchema, LeftRes
 function ParameterRight<Inferred extends TProperties, Left extends TSchema, LeftRest extends TSchema[], RightRest extends TSchema[]>
   (inferred: Inferred, left: Left, leftRest: LeftRest, rightRest: RightRest):
   TParameterRight<Inferred, Left, LeftRest, RightRest> {
-  return Result.TakeLeft(rightRest, (head, tail) =>
+  return Guard.TakeLeft(rightRest, (head, tail) =>
     ParameterCompare(inferred, left, leftRest, head, tail),
     () => IsOptional(left)                // 'right-did-not-have-enough-elements'
       ? Result.ExtendsTrue(inferred)      // 'ok: left was optional'
@@ -97,7 +98,7 @@ type TParameterLeft<Inferred extends TProperties, LeftRest extends TSchema[], Ri
 function ParametersLeft<Inferred extends TProperties, Left extends TSchema[], Right extends TSchema[]>
   (inferred: Inferred, left: Left, rightRest: Right): 
     TParameterLeft<Inferred, Left, Right> {
-  return Result.TakeLeft(left, (head, tail) => 
+  return Guard.TakeLeft(left, (head, tail) => 
     ParameterRight(inferred, head, tail, rightRest),
     () => Result.ExtendsTrue(inferred)) as never // 'ok: no-more-elements-in-left'
 }

--- a/src/type/extends/result.ts
+++ b/src/type/extends/result.ts
@@ -100,11 +100,3 @@ export type MatchFalse = () => unknown
 export function Match(result: TResult, true_: MatchTrueLike, false_: MatchFalse): unknown {
   return IsExtendsTrueLike(result) ? true_(result.inferred) : false_()
 }
-// ------------------------------------------------------------------
-// TakeLeft
-// ------------------------------------------------------------------
-export type TakeLeftTrue<T> = (left: T, right: T[]) => unknown
-export type TakeLeftFalse = () => unknown
-export function TakeLeft<T>(array: T[], true_: TakeLeftTrue<T>, false_: TakeLeftFalse): unknown {
-  return Guard.IsEqual(array.length, 0) ? false_() : true_(array[0], array.slice(1))
-}

--- a/src/type/extends/tuple.ts
+++ b/src/type/extends/tuple.ts
@@ -150,7 +150,7 @@ function ElementsLeft<Inferred extends TProperties, Reversed extends boolean, Le
     // Rest Inferrable Right Means we delegate to TInferTupleResult to Generate a Result
     IsInferable(inferable)
       ? InferTupleResult(inferred, inferable['name'], ApplyReverse(leftRest, reversed), inferable['type'])
-      : Result.TakeLeft(leftRest, (head, tail) => 
+      : Guard.TakeLeft(leftRest, (head, tail) => 
         ElementsCompare(inferred, reversed, head, tail, right, rightRest),
         () => Result.ExtendsFalse())
   ) as never
@@ -181,7 +181,7 @@ type TElementsRight<Inferred extends TProperties, Reversed extends boolean, Left
 function ElementsRight<Inferred extends TProperties, Reversed extends boolean, LeftRest extends TSchema[], RightRest extends TSchema[]>
   (inferred: Inferred, reversed: Reversed, leftRest: [...LeftRest], rightRest: [...RightRest]):
   TElementsRight<Inferred, Reversed, LeftRest, RightRest> {
-  return Result.TakeLeft(rightRest, (head, tail) =>
+  return Guard.TakeLeft(rightRest, (head, tail) =>
     ElementsLeft(inferred, reversed, leftRest, head, tail),
     () => Guard.IsEqual(leftRest.length, 0)
       ? Result.ExtendsTrue(inferred)     // 'Ok: right-empty-and-left-empty'
@@ -233,7 +233,7 @@ function ExtendsTupleToArray<Inferred extends TProperties, Left extends TSchema[
   return (
     IsInferable(inferrable)
       ? InferUnionResult(inferred, inferrable['name'], left, inferrable['type'])
-      : Result.TakeLeft(left, (head, tail) => 
+      : Guard.TakeLeft(left, (head, tail) => 
         Result.Match(ExtendsLeft(inferred, head, right), inferred => 
           ExtendsTupleToArray(inferred, tail, right),
           () => Result.ExtendsFalse()),

--- a/src/type/extends/union.ts
+++ b/src/type/extends/union.ts
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
+import { Guard } from '../../guard/index.ts'
 import { type TProperties } from '../types/properties.ts'
 import { type TSchema } from '../types/schema.ts'
 import { type TUnion, IsUnion } from '../types/union.ts'
@@ -56,7 +57,7 @@ type TExtendsUnionSome<Inferred extends TProperties, Type extends TSchema, Union
 function ExtendsUnionSome<Inferred extends TProperties, Type extends TSchema, UnionTypes extends TSchema[]>
   (inferred: Inferred, type: Type, unionTypes: [...UnionTypes]): 
     TExtendsUnionSome<Inferred, Type, UnionTypes> {
-  return Result.TakeLeft(unionTypes, (head, tail) => 
+  return Guard.TakeLeft(unionTypes, (head, tail) => 
     Result.Match(ExtendsLeft(inferred, type, head), inferred => 
       Result.ExtendsTrue(inferred),
       () => ExtendsUnionSome(inferred, type, tail)),
@@ -73,7 +74,7 @@ type TExtendsUnionLeft<Inferred extends TProperties, Left extends TSchema[], Rig
   : Result.TExtendsTrue<Inferred>
 )
 function ExtendsUnionLeft<Inferred extends TProperties, Left extends TSchema[], Right extends TSchema[]>(inferred: Inferred, left: [...Left], right: [...Right]): TExtendsUnionLeft<Inferred, Left, Right> {
-  return Result.TakeLeft(left, (head, tail) => 
+  return Guard.TakeLeft(left, (head, tail) => 
     Result.Match(ExtendsUnionSome(inferred, head, right), inferred => 
       ExtendsUnionLeft(inferred, tail, right),
       () => Result.ExtendsFalse()),

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.1.31'
+const Version = '1.1.32'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/jsonschema/cases/draft2019-09/optional/refOfUnknownKeyword.json
+++ b/test/jsonschema/cases/draft2019-09/optional/refOfUnknownKeyword.json
@@ -95,7 +95,6 @@
     "description": "reference internals of known non-applicator",
     "schema": {
       "$schema": "https://json-schema.org/draft/2019-09/schema",
-      "$id": "/base",
       "examples": [
         {
           "type": "string"

--- a/test/jsonschema/cases/draft2020-12/optional/refOfUnknownKeyword.json
+++ b/test/jsonschema/cases/draft2020-12/optional/refOfUnknownKeyword.json
@@ -95,7 +95,6 @@
     "description": "reference internals of known non-applicator",
     "schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "/base",
       "examples": [
         {
           "type": "string"

--- a/test/jsonschema/cases/v1/optional/refOfUnknownKeyword.json
+++ b/test/jsonschema/cases/v1/optional/refOfUnknownKeyword.json
@@ -95,7 +95,6 @@
     "description": "reference internals of known non-applicator",
     "schema": {
       "$schema": "https://json-schema.org/v1",
-      "$id": "/base",
       "examples": [
         {
           "type": "string"

--- a/test/typebox/runtime/guard/guard.ts
+++ b/test/typebox/runtime/guard/guard.ts
@@ -324,3 +324,25 @@ Test('Should IsClassInstance 15', () => {
   const strObj = new String('abc')
   Assert.IsEqual(Guard.IsClassInstance(strObj), true)
 })
+
+// ------------------------------------------------------------------
+// Guard.TakeLeft
+// ------------------------------------------------------------------
+Test('Should TakeLeft 1', () => {
+  const result: any = Guard.TakeLeft([], (left, right) => ({ left, right }), () => 'empty')
+  Assert.IsEqual(result, 'empty')
+})
+Test('Should TakeLeft 2', () => {
+  const result: string | {
+    left: number
+    right: number[]
+  } = Guard.TakeLeft([1, 2, 3], (left, right) => ({ left, right }), () => 'empty')
+  Assert.IsEqual(result, { left: 1, right: [2, 3] })
+})
+Test('Should TakeLeft 3', () => {
+  const result: string | {
+    left: number
+    right: number[]
+  } = Guard.TakeLeft([42], (left, right) => ({ left, right }), () => 'empty')
+  Assert.IsEqual(result, { left: 42, right: [] })
+})


### PR DESCRIPTION
This PR is a internal update to promote TakeLeft to be top level Guard function. Formerly this function was reserved to Extends checks; this PR promotes the function and updates all instances where TB needs to safely destructure Tuple elements from the left.

```typescript
// Before

function EncodeTypes<Types extends TSchema[], Pattern extends string>
  (types: [...Types], pattern: Pattern): TEncodeTypes<Types, Pattern> {
  const [left, ...right] = types
  return (
    IsSchema(left)
      ? EncodeType(left, right, pattern)
      : pattern
  ) as never
}

// After

function EncodeTypes<Types extends TSchema[], Pattern extends string>
  (types: [...Types], pattern: Pattern): TEncodeTypes<Types, Pattern> {
  return Guard.TakeLeft(types, (left, right) => 
    EncodeType(left, right, pattern),
    () => pattern) as never
}
```

This update is done to make it easier to locate potential Map/Reduce logic, draw greater symmetry with the associated TypeScript type and to give the destructuring pattern a formal name. Note: TypeBox has no instances of TakeRight.