### PR TITLE
Version 1.1.35

### DIFF
--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.1.35](https://github.com/sinclairzx81/typebox/pull/1591)
+  - AdditionalItems Inference Optimization (JSON Schema)
 - [Revision 1.1.34](https://github.com/sinclairzx81/typebox/pull/1588)
   - Interior Module Paths to Use Snake Case (Underscore)
 - [Revision 1.1.33](https://github.com/sinclairzx81/typebox/pull/1587)

--- a/src/schema/static/_elements.ts
+++ b/src/schema/static/_elements.ts
@@ -61,8 +61,11 @@ type XWithMaxItems<Schema extends XSchema, Elements extends unknown[],
 // 3. XNeedsAdditionalItems - Does MaxItems constrain all Elements?
 // ------------------------------------------------------------------
 type XNeedsAdditionalItems<Schema extends XSchema, Elements extends unknown[],
-  MaxItems extends number | null = Schema extends XMaxItems<infer MaxItems extends number> ? MaxItems : null,
-  Result extends boolean = MaxItems extends number ? XLessThan<Elements['length'], MaxItems> : true
+  Result extends boolean = (
+    Schema extends XMaxItems<infer MaxItems extends number> 
+      ? XLessThan<Elements['length'], MaxItems> 
+      : true
+  )
 > = Result
 // ------------------------------------------------------------------
 // 4. XWithMinItems - Optional Indices > MinItems
@@ -100,3 +103,4 @@ export type XStaticElements<Stack extends string[], Root extends XSchema, Schema
     ? XWithAdditionalItems<Stack, Root, Schema, WithMinItems>
     : WithMinItems
 > = WithAdditionalItems
+

--- a/src/schema/static/_elements.ts
+++ b/src/schema/static/_elements.ts
@@ -103,4 +103,3 @@ export type XStaticElements<Stack extends string[], Root extends XSchema, Schema
     ? XWithAdditionalItems<Stack, Root, Schema, WithMinItems>
     : WithMinItems
 > = WithAdditionalItems
-

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.1.34'
+const Version = '1.1.35'
 
 // ------------------------------------------------------------------
 // Build


### PR DESCRIPTION
This PR applies a small optimization to determine if tuple-like JSON Schema structures should infer with additional elements ... `[x, y, ...unknown[]]`

> It was noted that inference was popping out for complex mappings in a remote project of mine, but could not replicate local to TypeBox. It is assumed the test to determine if additional elements should be applied was yielding a `boolean` instead of an exact `true` or `false` result. This PR makes a small change to ensure an exact result is given.

No other functional changes.