### PR TITLE
Version 1.1.36

### DIFF
--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.1.36](https://github.com/sinclairzx81/typebox/pull/1592)
+  - Ensure no Type Distribution when Mapping for Min/Max Tuple Elements (JSON Schema)
 - [Revision 1.1.35](https://github.com/sinclairzx81/typebox/pull/1591)
   - AdditionalItems Inference Optimization (JSON Schema)
 - [Revision 1.1.34](https://github.com/sinclairzx81/typebox/pull/1588)

--- a/src/schema/static/_elements.ts
+++ b/src/schema/static/_elements.ts
@@ -54,8 +54,9 @@ type XWithMaxItemsRemap<Elements extends unknown[], MaxItems extends number, Res
   : Result
 )
 type XWithMaxItems<Schema extends XSchema, Elements extends unknown[],
-  MaxItems extends number | null = Schema extends XMaxItems<infer MaxItems extends number> ? MaxItems : null,
-  Result extends unknown[] = MaxItems extends number ? XWithMaxItemsRemap<Elements, MaxItems> : Elements
+  Result extends unknown[] = Schema extends XMaxItems<infer MaxItems extends number> 
+    ? XWithMaxItemsRemap<Elements, MaxItems> 
+    : Elements
 > = Result
 // ------------------------------------------------------------------
 // 3. XNeedsAdditionalItems - Does MaxItems constrain all Elements?

--- a/src/schema/static/required.ts
+++ b/src/schema/static/required.ts
@@ -35,9 +35,10 @@ import type { XProperties } from '../types/properties.ts'
 // ------------------------------------------------------------------
 // XStaticRequired
 // ------------------------------------------------------------------
-export type XStaticRequired<Stack extends string[], Root extends XSchema, Schema extends XSchema, Keys extends string[],
-  // Note: We only produce a property set if the Required keyword is isolated without Properties. This is because the
-  // Properties inference will handle Required in full, but where an isolated Required implies that the defined keys 
-  // are required but should accept anything (unknown).
+export type XStaticRequired<_Stack extends string[], _Root extends XSchema, Schema extends XSchema, Keys extends string[],
+  // If the 'properties' keyword is present, we return {} and trust the 'Properties' inference 
+  // path to resolve the 'required' keyword. If 'properties' is absent, we generate an object 
+  // where each key is assigned an 'unknown' type, as 'required' without 'properties' 
+  // still implies that the keys should exist on the object.
   Result extends Record<PropertyKey, unknown> = Schema extends XProperties ? {} : Record<Keys[number], unknown>
 > = Result

--- a/src/schema/static/required.ts
+++ b/src/schema/static/required.ts
@@ -36,6 +36,8 @@ import type { XProperties } from '../types/properties.ts'
 // XStaticRequired
 // ------------------------------------------------------------------
 export type XStaticRequired<Stack extends string[], Root extends XSchema, Schema extends XSchema, Keys extends string[],
-  // note: We only produce an property set if 'required' is present without 'properties'
+  // Note: We only produce a property set if the Required keyword is isolated without Properties. This is because the
+  // Properties inference will handle Required in full, but where an isolated Required implies that the defined keys 
+  // are required but should accept anything (unknown).
   Result extends Record<PropertyKey, unknown> = Schema extends XProperties ? {} : Record<Keys[number], unknown>
 > = Result

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.1.35'
+const Version = '1.1.36'
 
 // ------------------------------------------------------------------
 // Build


### PR DESCRIPTION
This PR is a follow on from 1.1.35 which implements an additional optimization Elements/MaxItems to ensure type distribution does not occur when mapping for min/max tuple elements.

No functional changes.