### PR TITLE
fix: prototype pollution in Value.Diff, Value.Patch, and Value.Clone

### DIFF
--- a/src/schema/pointer/pointer.ts
+++ b/src/schema/pointer/pointer.ts
@@ -40,6 +40,12 @@ function AssertCanSet(value: unknown): asserts value is Record<string, unknown> 
   if(!Guard.IsObject(value)) throw Error('Cannot set value')
 }
 // ------------------------------------------------------------------
+// Security
+// ------------------------------------------------------------------
+function IsDangerousSegment(segment: string): boolean {
+  return segment === '__proto__' || segment === 'constructor' || segment === 'prototype'
+}
+// ------------------------------------------------------------------
 // Indices
 // ------------------------------------------------------------------
 function IsNumericIndex(index: string): boolean {
@@ -55,6 +61,7 @@ function HasIndex(index: string, value: unknown): value is Record<string, unknow
   return Guard.IsObject(value) && Guard.HasPropertyKey(value, index)
 }
 function GetIndex(index: string, value: unknown): unknown {
+  if (IsDangerousSegment(index)) return undefined
   return Guard.IsObject(value) ? value[index] : undefined
 }
 function GetIndices(indices: string[], value: unknown): unknown {
@@ -97,6 +104,7 @@ export function Set(value: unknown, pointer: string, next: unknown): unknown {
   const indices = Indices(pointer)
   AssertNotRoot(indices)
   const [head, index] = TakeIndexRight(indices)
+  if (IsDangerousSegment(index)) return value
   const parent = GetIndices(head, value)
   AssertCanSet(parent)
   parent[index] = next
@@ -110,6 +118,7 @@ export function Delete(value: unknown, pointer: string): unknown {
   const indices = Indices(pointer)
   AssertNotRoot(indices)
   const [head, index] = TakeIndexRight(indices)
+  if (IsDangerousSegment(index)) return value
   const parent = GetIndices(head, value)
   AssertCanSet(parent)
   if(Guard.IsArray(parent) && IsNumericIndex(index)) {

--- a/src/value/clone/clone.ts
+++ b/src/value/clone/clone.ts
@@ -49,10 +49,10 @@ function FromClassInstance(value: Record<PropertyKey, unknown>): Record<Property
 function FromObjectInstance(value: Record<PropertyKey, unknown>): Record<PropertyKey, unknown> {
   const result = {} as Record<PropertyKey, unknown>
   for (const key of Object.getOwnPropertyNames(value)) {
-    result[key] = Clone(value[key])
+    Object.defineProperty(result, key, { value: Clone(value[key]), writable: true, enumerable: true, configurable: true })
   }
   for (const key of Object.getOwnPropertySymbols(value)) {
-    result[key] = Clone(value[key])
+    Object.defineProperty(result, key, { value: Clone(value[key]), writable: true, enumerable: true, configurable: true })
   }
   return result
 }

--- a/src/value/delta/diff.ts
+++ b/src/value/delta/diff.ts
@@ -46,6 +46,12 @@ function CreateDelete(path: string): TDelete {
 }
 
 // ------------------------------------------------------------------
+// RFC 6901
+// ------------------------------------------------------------------
+function EscapePointerSegment(segment: string): string {
+  return segment.replace(/~/g, '~0').replace(/\//g, '~1')
+}
+// ------------------------------------------------------------------
 // Assert
 // ------------------------------------------------------------------
 function AssertCanDiffObject(value: unknown): asserts value is Record<string | number, unknown> {
@@ -66,7 +72,7 @@ function* FromObject(path: string, left: Record<PropertyKey, unknown>, right: un
   // ----------------------------------------------------------------
   for (const key of rightKeys) {
     if (Guard.HasPropertyKey(left, key)) continue
-    yield CreateInsert(`${path}/${key}`, right[key])
+    yield CreateInsert(`${path}/${EscapePointerSegment(key)}`, right[key])
   }
   // ----------------------------------------------------------------
   // Update
@@ -74,14 +80,14 @@ function* FromObject(path: string, left: Record<PropertyKey, unknown>, right: un
   for (const key of leftKeys) {
     if (!Guard.HasPropertyKey(right, key)) continue
     if (Equal(left, right)) continue
-    yield* FromValue(`${path}/${key}`, left[key], right[key])
+    yield* FromValue(`${path}/${EscapePointerSegment(key)}`, left[key], right[key])
   }
   // ----------------------------------------------------------------
   // Delete
   // ----------------------------------------------------------------
   for (const key of leftKeys) {
     if (Guard.HasPropertyKey(right, key)) continue
-    yield CreateDelete(`${path}/${key}`)
+    yield CreateDelete(`${path}/${EscapePointerSegment(key)}`)
   }
 }
 // ------------------------------------------------------------------

--- a/src/value/mutate/from_object.ts
+++ b/src/value/mutate/from_object.ts
@@ -35,6 +35,10 @@ import { Clone } from '../clone/index.ts'
 import { type TMutable } from './mutate.ts'
 import { FromValue } from './from_value.ts'
 
+function EscapePointerSegment(segment: string): string {
+  return segment.replace(/~/g, '~0').replace(/\//g, '~1')
+}
+
 export function FromObject(root: TMutable, path: string, current: unknown, next: Record<string, unknown>): void {
   if (!Guard.IsObjectNotArray(current)) {
     Pointer.Set(root, path, Clone(next))
@@ -52,7 +56,7 @@ export function FromObject(root: TMutable, path: string, current: unknown, next:
       }
     }
     for (const nextKey of nextKeys) {
-      FromValue(root, `${path}/${nextKey}`, current[nextKey], next[nextKey])
+      FromValue(root, `${path}/${EscapePointerSegment(nextKey)}`, current[nextKey], next[nextKey])
     }
   }
 }


### PR DESCRIPTION
## Description

When `Value.Diff` encounters a property key containing `/` (e.g. `__proto__/format`), it builds a multi-segment JSON Pointer path without RFC 6901 escaping. When that path is later applied via `Value.Patch`, `Pointer.Set` traverses into `Object.prototype` and writes attacker-controlled values there.

This becomes critical because `TypeCompiler.Compile` reads properties like `format` from the schema object's prototype chain, so polluting `Object.prototype.format` causes attacker-supplied strings to be interpolated into generated `new Function()` code, leading to arbitrary code execution.

The full chain works from a purely P2 position (attacker controls only runtime values, no schema control needed):

```
Attacker JSON: { "__proto__/format": "PAYLOAD" }
  → Value.Diff generates path /__proto__/format
  → Value.Patch writes PAYLOAD to Object.prototype.format  
  → TypeCompiler.Compile(Type.String()) picks up format from prototype
  → new Function() executes PAYLOAD
```

Separately, `Value.Clone` uses bracket assignment (`result[key] = value`) which triggers the `__proto__` setter instead of creating an own property, causing per-object prototype injection.

This PR fixes the independent issue that together case this chain.   