### PR TITLE
Version 1.1.37

### DIFF
--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.1.37](https://github.com/sinclairzx81/typebox/pull/1594)
+  - Add Prototype Pollution Guards for Value.* Functions Clone, Diff, Patch, Mutate and Pointer.
 - [Revision 1.1.36](https://github.com/sinclairzx81/typebox/pull/1592)
   - Ensure no Type Distribution when Mapping for Min/Max Tuple Elements (JSON Schema)
 - [Revision 1.1.35](https://github.com/sinclairzx81/typebox/pull/1591)

--- a/src/guard/guard.ts
+++ b/src/guard/guard.ts
@@ -189,10 +189,13 @@ export function TakeLeft<T, True extends (left: T, right: T[]) => unknown, False
 // --------------------------------------------------------------------------
 // Object
 // --------------------------------------------------------------------------
+/** Returns true if the PropertyKey is Unsafe (ref: prototype-pollution). */
+export function IsUnsafePropertyKey(key: PropertyKey): boolean {
+  return IsEqual(key, '__proto__') || IsEqual(key, 'constructor') || IsEqual(key, 'prototype')
+}
 /** Returns true if this value has this property key */
 export function HasPropertyKey<Key extends PropertyKey>(value: object, key: Key): value is { [_ in Key]: unknown } {
-  const isProtoField = IsEqual(key, '__proto__') || IsEqual(key, 'constructor')
-  return isProtoField ? Object.prototype.hasOwnProperty.call(value, key) : key in value
+  return IsUnsafePropertyKey(key) ? Object.prototype.hasOwnProperty.call(value, key) : key in value
 }
 /** Returns object entries as `[RegExp, Value][]` */
 export function EntriesRegExp<Value extends unknown = unknown>(value: Record<PropertyKey, Value>): [RegExp, Value][] {
@@ -202,7 +205,7 @@ export function EntriesRegExp<Value extends unknown = unknown>(value: Record<Pro
 export function Entries<Value extends unknown = unknown>(value: Record<PropertyKey, Value>): [string, Value][] {
   return Object.entries(value)
 }
-/** Returns the property keys for this object via `Object.getOwnPropertyKeys({ ... })` */
+/** Returns property keys for this object via `Object.getOwnPropertyKeys({ ... })` */
 export function Keys(value: Record<PropertyKey, unknown>): string[] {
   return Object.getOwnPropertyNames(value)
 }

--- a/src/schema/pointer/pointer.ts
+++ b/src/schema/pointer/pointer.ts
@@ -33,11 +33,17 @@ import { Guard } from '../../guard/index.ts'
 // ------------------------------------------------------------------
 // Asserts
 // ------------------------------------------------------------------
-function AssertNotRoot(indices: string[]) {
-  if(indices.length === 0) throw Error('Cannot set root')
+function AssertNotRoot(indices: string[]): void {
+  if (indices.length === 0) throw Error('Cannot set root')
 }
 function AssertCanSet(value: unknown): asserts value is Record<string, unknown> {
-  if(!Guard.IsObject(value)) throw Error('Cannot set value')
+  if (!Guard.IsObject(value)) throw Error('Cannot set value')
+}
+function AssertIndex(index: string): void {
+  if (Guard.IsUnsafePropertyKey(index)) throw Error('Pointer contains unsafe property key')
+}
+function AssertIndices(indices: string[]): void {
+  for (const index of indices) AssertIndex(index)
 }
 // ------------------------------------------------------------------
 // Indices
@@ -55,7 +61,7 @@ function HasIndex(index: string, value: unknown): value is Record<string, unknow
   return Guard.IsObject(value) && Guard.HasPropertyKey(value, index)
 }
 function GetIndex(index: string, value: unknown): unknown {
-  return Guard.IsObject(value) ? value[index] : undefined
+  return Guard.IsObject(value) && !Guard.IsUnsafePropertyKey(index) ? value[index] : undefined
 }
 function GetIndices(indices: string[], value: unknown): unknown {
   return indices.reduce((value, index) => GetIndex(index, value), value)
@@ -76,7 +82,7 @@ export function Indices(pointer: string): string[] {
 export function Has(value: unknown, pointer: string): unknown {
   let current = value
   return Indices(pointer).every(index => {
-    if(!HasIndex(index, current)) return false
+    if (!HasIndex(index, current)) return false
     current = current[index]
     return true
   })
@@ -96,6 +102,7 @@ export function Get(value: unknown, pointer: string): unknown {
 export function Set(value: unknown, pointer: string, next: unknown): unknown {
   const indices = Indices(pointer)
   AssertNotRoot(indices)
+  AssertIndices(indices)
   const [head, index] = TakeIndexRight(indices)
   const parent = GetIndices(head, value)
   AssertCanSet(parent)
@@ -109,10 +116,11 @@ export function Set(value: unknown, pointer: string, next: unknown): unknown {
 export function Delete(value: unknown, pointer: string): unknown {
   const indices = Indices(pointer)
   AssertNotRoot(indices)
+  AssertIndices(indices)
   const [head, index] = TakeIndexRight(indices)
   const parent = GetIndices(head, value)
   AssertCanSet(parent)
-  if(Guard.IsArray(parent) && IsNumericIndex(index)) {
+  if (Guard.IsArray(parent) && IsNumericIndex(index)) {
     parent.splice(+index, 1)
   } else {
     delete parent[index]

--- a/src/value/clone/clone.ts
+++ b/src/value/clone/clone.ts
@@ -48,16 +48,15 @@ function FromClassInstance(value: Record<PropertyKey, unknown>): Record<Property
 // ------------------------------------------------------------------
 function FromObjectInstance(value: Record<PropertyKey, unknown>): Record<PropertyKey, unknown> {
   const result = {} as Record<PropertyKey, unknown>
-  for (const key of Object.getOwnPropertyNames(value)) {
+  for (const key of Guard.Keys(value)) {
+    if (Guard.IsUnsafePropertyKey(key)) continue // (ignore: prototype-pollution)
     result[key] = Clone(value[key])
   }
-  for (const key of Object.getOwnPropertySymbols(value)) {
+  for (const key of Guard.Symbols(value)) {
     result[key] = Clone(value[key])
   }
   return result
 }
-
-Object.create({})
 // ------------------------------------------------------------------
 // Object
 // ------------------------------------------------------------------

--- a/src/value/delta/diff.ts
+++ b/src/value/delta/diff.ts
@@ -66,6 +66,7 @@ function* FromObject(path: string, left: Record<PropertyKey, unknown>, right: un
   // ----------------------------------------------------------------
   for (const key of rightKeys) {
     if (Guard.HasPropertyKey(left, key)) continue
+    if (Guard.IsUnsafePropertyKey(key)) continue
     yield CreateInsert(`${path}/${key}`, right[key])
   }
   // ----------------------------------------------------------------
@@ -73,6 +74,7 @@ function* FromObject(path: string, left: Record<PropertyKey, unknown>, right: un
   // ----------------------------------------------------------------
   for (const key of leftKeys) {
     if (!Guard.HasPropertyKey(right, key)) continue
+    if (Guard.IsUnsafePropertyKey(key)) continue
     if (Equal(left, right)) continue
     yield* FromValue(`${path}/${key}`, left[key], right[key])
   }
@@ -81,6 +83,7 @@ function* FromObject(path: string, left: Record<PropertyKey, unknown>, right: un
   // ----------------------------------------------------------------
   for (const key of leftKeys) {
     if (Guard.HasPropertyKey(right, key)) continue
+    if (Guard.IsUnsafePropertyKey(key)) continue
     yield CreateDelete(`${path}/${key}`)
   }
 }
@@ -107,10 +110,10 @@ function* FromArray(path: string, left: unknown[], right: unknown): IterableIter
 function* FromTypedArray(path: string, left: GlobalsGuard.TTypeArray, right: unknown): IterableIterator<TEdit> {
   const typeLeft = globalThis.Object.getPrototypeOf(left).constructor.name
   const typeRight = globalThis.Object.getPrototypeOf(right).constructor.name
-  const predicate = GlobalsGuard.IsTypeArray(right) 
+  const predicate = GlobalsGuard.IsTypeArray(right)
     && Guard.IsEqual(left.length, right.length)
     && Guard.IsEqual(typeLeft, typeRight)
-  if(predicate) {
+  if (predicate) {
     for (let index = 0; index < Math.min(left.length, right.length); index++) {
       yield* FromValue(`${path}/${index}`, left[index], right[index])
     }
@@ -131,9 +134,9 @@ function* FromUnknown(path: string, left: unknown, right: unknown): IterableIter
 function* FromValue(path: string, left: unknown, right: unknown): IterableIterator<TEdit> {
   return (
     GlobalsGuard.IsTypeArray(left) ? yield* FromTypedArray(path, left, right) :
-    Guard.IsArray(left) ? yield* FromArray(path, left, right) :
-    Guard.IsObject(left) ?  yield* FromObject(path, left, right) :
-    yield* FromUnknown(path, left, right)
+      Guard.IsArray(left) ? yield* FromArray(path, left, right) :
+        Guard.IsObject(left) ? yield* FromObject(path, left, right) :
+          yield* FromUnknown(path, left, right)
   )
 }
 // ------------------------------------------------------------------

--- a/src/value/delta/diff.ts
+++ b/src/value/delta/diff.ts
@@ -134,9 +134,9 @@ function* FromUnknown(path: string, left: unknown, right: unknown): IterableIter
 function* FromValue(path: string, left: unknown, right: unknown): IterableIterator<TEdit> {
   return (
     GlobalsGuard.IsTypeArray(left) ? yield* FromTypedArray(path, left, right) :
-      Guard.IsArray(left) ? yield* FromArray(path, left, right) :
-        Guard.IsObject(left) ? yield* FromObject(path, left, right) :
-          yield* FromUnknown(path, left, right)
+    Guard.IsArray(left) ? yield* FromArray(path, left, right) :
+    Guard.IsObject(left) ? yield* FromObject(path, left, right) :
+    yield* FromUnknown(path, left, right)
   )
 }
 // ------------------------------------------------------------------

--- a/src/value/mutate/from_object.ts
+++ b/src/value/mutate/from_object.ts
@@ -35,6 +35,15 @@ import { Clone } from '../clone/index.ts'
 import { type TMutable } from './mutate.ts'
 import { FromValue } from './from_value.ts'
 
+// ------------------------------------------------------------------
+// AssertKey
+// ------------------------------------------------------------------
+function AssertKey(key: string): void {
+  if(Guard.IsUnsafePropertyKey(key)) throw Error('Attempted to Mutate with unsafe property key')
+}
+// ------------------------------------------------------------------
+// AssertKey
+// ------------------------------------------------------------------
 export function FromObject(root: TMutable, path: string, current: unknown, next: Record<string, unknown>): void {
   if (!Guard.IsObjectNotArray(current)) {
     Pointer.Set(root, path, Clone(next))
@@ -42,16 +51,19 @@ export function FromObject(root: TMutable, path: string, current: unknown, next:
     const currentKeys = Guard.Keys(current)
     const nextKeys = Guard.Keys(next)
     for (const currentKey of currentKeys) {
+      AssertKey(currentKey)
       if (!nextKeys.includes(currentKey)) {
         delete current[currentKey]
       }
     }
     for (const nextKey of nextKeys) {
+      AssertKey(nextKey)
       if (!currentKeys.includes(nextKey)) {
         current[nextKey] = next[nextKey]
       }
     }
     for (const nextKey of nextKeys) {
+      AssertKey(nextKey)
       FromValue(root, `${path}/${nextKey}`, current[nextKey], next[nextKey])
     }
   }

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.1.36'
+const Version = '1.1.37'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/schema/pointer/pointer.ts
+++ b/test/typebox/runtime/schema/pointer/pointer.ts
@@ -83,9 +83,9 @@ Test('Should Indices 20', () => {
   const R = [...Schema.Pointer.Indices('/x/a~1b///')]
   Assert.IsEqual(R, ['x', 'a/b', '', '', ''])
 })
-//-----------------------------------------------
+//-------------------------------------------------------------------
 // Get
-//-----------------------------------------------
+//-------------------------------------------------------------------
 Test('Should Get 1', () => {
   const V = [0, 1, 2, 3]
   Assert.IsEqual(Schema.Pointer.Get(V, ''), [0, 1, 2, 3])
@@ -108,9 +108,9 @@ Test('Should Get 2', () => {
   Assert.IsEqual(Schema.Pointer.Get(V, '/2/x'), 2)
   Assert.IsEqual(Schema.Pointer.Get(V, '/3/x'), 3)
 })
-//-----------------------------------------------
+//-------------------------------------------------------------------
 // Delete
-//-----------------------------------------------
+//-------------------------------------------------------------------
 Test('Should Delete 1', () => {
   const V = { x: {} }
   const R = Schema.Pointer.Delete(V, '/x/x')
@@ -131,9 +131,9 @@ Test('Should Delete 3', () => {
   const R = Schema.Pointer.Delete(V, '/100')
   Assert.IsEqual(R, [1, 2, 3])
 })
-//-----------------------------------------------
+//-------------------------------------------------------------------
 // Has
-//-----------------------------------------------
+//-------------------------------------------------------------------
 Test('Should Has 1', () => {
   const V: any = undefined
   Assert.IsEqual(Schema.Pointer.Has(V, ''), true)
@@ -154,9 +154,9 @@ Test('Should Has 5', () => {
   const V = { x: { y: {} } }
   Assert.IsEqual(Schema.Pointer.Has(V, '/x/y/z'), false)
 })
-//-----------------------------------------------
+//-------------------------------------------------------------------
 // Throw
-//-----------------------------------------------
+//-------------------------------------------------------------------
 Test('Should throw 1', () => {
   const V = {}
   Assert.Throws(() => Schema.Pointer.Set(V, '', { x: 1 }))
@@ -169,9 +169,9 @@ Test('Should throw 3', () => {
   const V = { x: 1 }
   Assert.Throws(() => Schema.Pointer.Set(V, '/x/y', 3))
 })
-//-----------------------------------------------
+//-------------------------------------------------------------------
 // Escapes
-//-----------------------------------------------
+//-------------------------------------------------------------------
 Test('Should support get ~0 Schema.Pointer escape', () => {
   const V = {
     x: { '~': { x: 1 } }
@@ -184,4 +184,52 @@ Test('Should support get ~1 Schema.Pointer escape', () => {
     x: { '/': { x: 1 } }
   }
   Assert.IsEqual(Schema.Pointer.Get(V, '/x/~1'), { x: 1 })
+})
+//-------------------------------------------------------------------
+// Unsafe Property Keys
+//-------------------------------------------------------------------
+Test('Should return undefined if attempting to Get an unsafe property key', () => {
+  Assert.IsEqual(Schema.Pointer.Get({}, '/__proto__'), undefined)
+  Assert.IsEqual(Schema.Pointer.Get({}, '/constructor'), undefined)
+  Assert.IsEqual(Schema.Pointer.Get({}, '/prototype'), undefined)
+})
+Test('Should return undefined if attempting to Get a nested unsafe property key', () => {
+  Assert.IsEqual(Schema.Pointer.Get({ a: {} }, '/a/__proto__'), undefined)
+  Assert.IsEqual(Schema.Pointer.Get({ a: {} }, '/a/constructor'), undefined)
+  Assert.IsEqual(Schema.Pointer.Get({ a: {} }, '/a/prototype'), undefined)
+})
+Test('Should return false if attempting to Has an unsafe property key', () => {
+  Assert.IsEqual(Schema.Pointer.Has({}, '/__proto__'), false)
+  Assert.IsEqual(Schema.Pointer.Has({}, '/constructor'), false)
+  Assert.IsEqual(Schema.Pointer.Has({}, '/prototype'), false)
+})
+Test('Should return false if attempting to Has a nested unsafe property key', () => {
+  Assert.IsEqual(Schema.Pointer.Has({ a: {} }, '/a/__proto__'), false)
+  Assert.IsEqual(Schema.Pointer.Has({ a: {} }, '/a/constructor'), false)
+  Assert.IsEqual(Schema.Pointer.Has({ a: {} }, '/a/prototype'), false)
+})
+Test('Should throw if attempting to Set an unsafe property key', () => {
+  Assert.Throws(() => Schema.Pointer.Set({}, '/__proto__', 1))
+  Assert.Throws(() => Schema.Pointer.Set({}, '/constructor', 1))
+  Assert.Throws(() => Schema.Pointer.Set({}, '/prototype', 1))
+})
+Test('Should throw if attempting to Set a nested unsafe property key', () => {
+  Assert.Throws(() => Schema.Pointer.Set({ a: {} }, '/a/__proto__', 1))
+  Assert.Throws(() => Schema.Pointer.Set({ a: {} }, '/a/constructor', 1))
+  Assert.Throws(() => Schema.Pointer.Set({ a: {} }, '/a/prototype', 1))
+})
+Test('Should throw if attempting to Delete an unsafe property key', () => {
+  Assert.Throws(() => Schema.Pointer.Delete({}, '/__proto__'))
+  Assert.Throws(() => Schema.Pointer.Delete({}, '/constructor'))
+  Assert.Throws(() => Schema.Pointer.Delete({}, '/prototype'))
+})
+Test('Should throw if attempting to Delete a nested unsafe property key', () => {
+  Assert.Throws(() => Schema.Pointer.Delete({ a: {} }, '/a/__proto__'))
+  Assert.Throws(() => Schema.Pointer.Delete({ a: {} }, '/a/constructor'))
+  Assert.Throws(() => Schema.Pointer.Delete({ a: {} }, '/a/prototype'))
+})
+Test('Should not throw for property names that contain but do not equal unsafe names', () => {
+  Assert.IsEqual(Schema.Pointer.Get({ my_constructor: 1 }, '/my_constructor'), 1)
+  Assert.IsEqual(Schema.Pointer.Get({ prototypes: 1 }, '/prototypes'), 1)
+  Assert.IsEqual(Schema.Pointer.Get({ not__proto__: 1 }, '/not__proto__'), 1)
 })

--- a/test/typebox/runtime/value/clone/clone.ts
+++ b/test/typebox/runtime/value/clone/clone.ts
@@ -79,3 +79,41 @@ Test('Should Clone 12', () => {
   const B = Value.Clone(A)
   Assert.IsTrue(A === B)
 })
+// ----------------------------------------------------------------
+// Pollution Guards: Ensure No Unsafe Property is Cloned
+//
+// https://github.com/sinclairzx81/typebox/pull/1593
+// ----------------------------------------------------------------
+Test('Should Clone 13', () => {
+  const A = { value: 1, constructor: 2 }
+  const B = Value.Clone(A)
+  Assert.IsEqual(B, { value: 1 })
+})
+Test('Should Clone 14', () => {
+  const A = { value: 1, prototype: 2 }
+  const B = Value.Clone(A)
+  Assert.IsEqual(B, { value: 1 })
+})
+Test('Should Clone 15', () => {
+  const A = { value: 1 }
+  Object.defineProperty(A, '__proto__', { value: 2, enumerable: true })
+  const B = Value.Clone(A)
+  Assert.IsEqual(B, { value: 1 })
+})
+// Nested
+Test('Should Clone 16', () => {
+  const A = { outer: { value: 1, constructor: 2 } }
+  const B = Value.Clone(A)
+  Assert.IsEqual(B, { outer: { value: 1 } })
+})
+Test('Should Clone 17', () => {
+  const A = { outer: { value: 1, prototype: 2 } }
+  const B = Value.Clone(A)
+  Assert.IsEqual(B, { outer: { value: 1 } })
+})
+Test('Should Clone 18', () => {
+  const A = { outer: { value: 1 } }
+  Object.defineProperty(A.outer, '__proto__', { value: 2, enumerable: true })
+  const B = Value.Clone(A)
+  Assert.IsEqual(B, { outer: { value: 1 } })
+})

--- a/test/typebox/runtime/value/delta/diff.ts
+++ b/test/typebox/runtime/value/delta/diff.ts
@@ -394,3 +394,61 @@ Test('Should generate no diff for undefined properties of current and next', () 
   const E = [] as any
   Assert.IsEqual(D, E)
 })
+// ----------------------------------------------------------------
+// Pollution Guards: Ensure Unsafe Properties produce no Edits
+//
+// https://github.com/sinclairzx81/typebox/pull/1593
+// ----------------------------------------------------------------
+Test('Should not generate edits for unsafe properties on INSERT', () => {
+  const A = {}
+  const B = {
+    value: 1,
+    '__proto__': 1,
+    'constructor': 1,
+    'prototype': 1
+  }
+  const C = Value.Diff(A, B)
+  Assert.IsEqual(C, [{ type: 'insert', path: '/value', value: 1 }])
+})
+Test('Should not generate edits for unsafe properties on UPDATE', () => {
+  const A = {
+    value: 1,
+    '__proto__': 1,
+    'constructor': 1,
+    'prototype': 1
+  }
+  const B = {
+    value: 2,
+    '__proto__': 2,
+    'constructor': 2,
+    'prototype': 2
+  }
+  const C = Value.Diff(A, B)
+  Assert.IsEqual(C, [{ type: 'update', path: '/value', value: 2 }])
+})
+Test('Should not generate edits for nested unsafe properties on DELETE', () => {
+  const A = {
+    outer: {
+      value: 1,
+      '__proto__': 1,
+      'constructor': 1,
+      'prototype': 1
+    }
+  }
+  const B = { outer: {} }
+  const C = Value.Diff(A, B)
+  Assert.IsEqual(C, [{ type: 'delete', path: '/outer/value' }])
+})
+Test('Should not generate edits for nested unsafe properties on INSERT', () => {
+  const A = { outer: {} }
+  const B = {
+    outer: {
+      value: 1,
+      '__proto__': 1,
+      'constructor': 1,
+      'prototype': 1
+    }
+  }
+  const C = Value.Diff(A, B)
+  Assert.IsEqual(C, [{ type: 'insert', path: '/outer/value', value: 1 }])
+})

--- a/test/typebox/runtime/value/delta/patch.ts
+++ b/test/typebox/runtime/value/delta/patch.ts
@@ -433,3 +433,207 @@ Test('Should not result in sparse arrays', () => {
   Assert.IsEqual(B, E)
   Assert.IsEqual(E.length, B.length)
 })
+// ----------------------------------------------------------------
+// Pollution Guards: Ensure No Unsafe Property is Written
+//
+// https://github.com/sinclairzx81/typebox/pull/1593
+// ----------------------------------------------------------------
+Test('Should should throw if attempting to INSERT Unsafe properties', () => {
+  Assert.IsEqual(
+    Value.Patch({}, [
+      { type: 'insert', path: '/value', value: 1 }
+    ]),
+    { value: 1 }
+  )
+  Assert.Throws(() =>
+    Value.Patch({}, [
+      { type: 'insert', path: '/constructor', value: 1 }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({}, [
+      { type: 'insert', path: '/prototype', value: 1 }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({}, [
+      { type: 'insert', path: '/__proto__', value: 1 }
+    ])
+  )
+})
+Test('Should should throw if attempting to DELETE Unsafe properties', () => {
+  Assert.IsEqual(
+    Value.Patch({ value: 1 }, [
+      { type: 'delete', path: '/value' }
+    ]),
+    {}
+  )
+  Assert.Throws(() =>
+    Value.Patch({ constructor: 1 }, [
+      { type: 'delete', path: '/constructor' }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({ prototype: 1 }, [
+      { type: 'delete', path: '/prototype' }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({ __proto__: 1 }, [
+      { type: 'delete', path: '/__proto__' }
+    ])
+  )
+})
+Test('Should should throw if attempting to UPDATE Unsafe properties', () => {
+  Assert.IsEqual(
+    Value.Patch({ value: 1 }, [
+      { type: 'update', path: '/value', value: 2 }
+    ]),
+    { value: 2 }
+  )
+  Assert.Throws(() =>
+    Value.Patch({ constructor: 1 }, [
+      { type: 'update', path: '/constructor', value: 2 }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({ prototype: 1 }, [
+      { type: 'update', path: '/prototype', value: 2 }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({ __proto__: 1 }, [
+      { type: 'update', path: '/__proto__', value: 2 }
+    ])
+  )
+})
+// ----------------------------------------------------------------
+// Pollution Guards: Ensure No Unsafe Property is Written (Nested)
+// ----------------------------------------------------------------
+Test('Should should throw if attempting to INSERT Unsafe properties', () => {
+  Assert.IsEqual(
+    Value.Patch({ value: {} }, [
+      { type: 'insert', path: '/value/x', value: 1 }
+    ]),
+    { value: { x: 1 } }
+  )
+  Assert.Throws(() =>
+    Value.Patch({ constructor: {} }, [
+      { type: 'insert', path: '/constructor/x', value: 1 }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({ prototype: {} }, [
+      { type: 'insert', path: '/prototype/x', value: 1 }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({ __proto__: {} }, [
+      { type: 'insert', path: '/__proto__/x', value: 1 }
+    ])
+  )
+})
+Test('Should should throw if attempting to DELETE Unsafe properties', () => {
+  Assert.IsEqual(
+    Value.Patch({ value: { x: 1 } }, [
+      { type: 'delete', path: '/value/x' }
+    ]),
+    { value: {} }
+  ) // {} not undefined
+  Assert.Throws(() =>
+    Value.Patch({ constructor: { x: 1 } }, [
+      { type: 'delete', path: '/constructor/x' }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({ prototype: { x: 1 } }, [
+      { type: 'delete', path: '/prototype/x' }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({ __proto__: { x: 1 } }, [
+      { type: 'delete', path: '/__proto__/x' }
+    ])
+  )
+})
+Test('Should should throw if attempting to UPDATE Unsafe properties', () => {
+  Assert.IsEqual(
+    Value.Patch({ value: { x: 1 } }, [
+      { type: 'update', path: '/value/x', value: 2 }
+    ]),
+    { value: { x: 2 } }
+  )
+  Assert.Throws(() =>
+    Value.Patch({ constructor: { x: 1 } }, [
+      { type: 'update', path: '/constructor/x', value: 2 }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({ prototype: { x: 1 } }, [
+      { type: 'update', path: '/prototype/x', value: 2 }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({ __proto__: { x: 1 } }, [
+      { type: 'update', path: '/__proto__/x', value: 2 }
+    ])
+  )
+})
+// ----------------------------------------------------------------
+// Pollution Guards: Edge Cases
+// ----------------------------------------------------------------
+Test('Should throw if attempting to INSERT Unsafe properties at deep nested paths', () => {
+  Assert.IsEqual(
+    Value.Patch({ a: { b: {} } }, [
+      { type: 'insert', path: '/a/b/x', value: 1 }
+    ]),
+    { a: { b: { x: 1 } } }
+  )
+  Assert.Throws(() =>
+    Value.Patch({ a: { constructor: {} } }, [
+      { type: 'insert', path: '/a/constructor/x', value: 1 }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({ a: { prototype: {} } }, [
+      { type: 'insert', path: '/a/prototype/x', value: 1 }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({ a: { __proto__: {} } }, [
+      { type: 'insert', path: '/a/__proto__/x', value: 1 }
+    ])
+  )
+})
+Test('Should throw if path contains multiple Unsafe segments', () => {
+  Assert.Throws(() =>
+    Value.Patch({}, [
+      { type: 'insert', path: '/constructor/prototype', value: 1 }
+    ])
+  )
+  Assert.Throws(() =>
+    Value.Patch({}, [
+      { type: 'insert', path: '/__proto__/constructor', value: 1 }
+    ])
+  )
+})
+Test('Should not throw for property names that contain but do not equal Unsafe names', () => {
+  Assert.IsEqual(
+    Value.Patch({}, [
+      { type: 'insert', path: '/my_constructor', value: 1 }
+    ]),
+    { my_constructor: 1 }
+  )
+  Assert.IsEqual(
+    Value.Patch({}, [
+      { type: 'insert', path: '/prototypes', value: 1 }
+    ]),
+    { prototypes: 1 }
+  )
+  Assert.IsEqual(
+    Value.Patch({}, [
+      { type: 'insert', path: '/not__proto__', value: 1 }
+    ]),
+    { not__proto__: 1 }
+  )
+})

--- a/test/typebox/runtime/value/mutate/mutate.ts
+++ b/test/typebox/runtime/value/mutate/mutate.ts
@@ -1,6 +1,5 @@
 import { Value } from 'typebox/value'
 import { Assert } from 'test'
-import type { prototype } from 'node:events'
 
 const Test = Assert.Context('Value.Mutate')
 

--- a/test/typebox/runtime/value/mutate/mutate.ts
+++ b/test/typebox/runtime/value/mutate/mutate.ts
@@ -1,5 +1,6 @@
 import { Value } from 'typebox/value'
 import { Assert } from 'test'
+import type { prototype } from 'node:events'
 
 const Test = Assert.Context('Value.Mutate')
 
@@ -126,4 +127,27 @@ Test('Should Mutate 19', () => {
   const A = { x: 1, y: 2, z: 3 }
   Value.Mutate(A, { x: 4, y: 5, z: 4, w: 5 })
   Assert.IsEqual(A, { x: 4, y: 5, z: 4, w: 5 })
+})
+// ----------------------------------------------------------------
+// Pollution Guards: Should ignore and throw on unsafe key.
+//
+// https://github.com/sinclairzx81/typebox/pull/1593
+// ----------------------------------------------------------------
+Test('Should Clone 20', () => {
+  const A = { x: 1 } // basis
+  Value.Mutate(A, { x: 1, y: 1 })
+  Assert.IsEqual(A, { x: 1, y: 1 })
+})
+Test('Should Clone 21', () => {
+  const A = { x: 1, y: 1 }
+  Value.Mutate(A, { x: 1, y: 1, __proto__: 1 })
+  Assert.IsEqual(A, { x: 1, y: 1 })
+})
+Test('Should Clone 22', () => {
+  const A = { x: 1 }
+  Assert.Throws(() => Value.Mutate(A, { x: 1, constructor: 1 }))
+})
+Test('Should Clone 23', () => {
+  const A = { x: 1 }
+  Assert.Throws(() => Value.Mutate(A, { x: 1, prototype: 1 }))
 })


### PR DESCRIPTION
This PR adds a new Guard.* function to test for Unsafe Property Keys as well as implements a number of prototype pollution guards for several Value.* operations.

---

### Guard

An Unsafe Property Key is defined as the following:

```typescript
/** Returns true if the PropertyKey appears unsafe (prototype-pollution). */
export function IsUnsafePropertyKey(key: PropertyKey): boolean {
  return IsEqual(key, '__proto__') || IsEqual(key, 'constructor') || IsEqual(key, 'prototype')
}
```

---

### Update

The following Value.* have been updated to check for Unsafe Property Keys.

- Value.Diff(...) - Do not generate Edits for Unsafe Property Keys
- Value.Patch(...) - Do not apply Edits for Unsafe Property Keys
- Value.Clone(...) - Ignore Unsafe Properties During Clone Enumeration
- Value.Mutate(...) - Throw if Mutation involves Unsafe Property Keys
- Value.Pointer(...) - Throw (Write) or Ignore (Read) Unsafe Property Keys

---

### Additional Notes

This PR is a controlled implementation provided via https://github.com/sinclairzx81/typebox/pull/1593 and is implemented explicitly as the issue was flagged as a potential security issue. This PR builds on the provided implementation while also centralizing Unsafe key checking to the Guard.* namespace for potential usage elsewhere. 

This PR also implements test coverage tests for each Value* operation.

CC: @homanp