### PR TITLE
Version 1.1.38

### DIFF
--- a/changelog/1.1.0.md
+++ b/changelog/1.1.0.md
@@ -3,6 +3,9 @@
 ---
 
 ### Version Updates
+- [Revision 1.1.38](https://github.com/sinclairzx81/typebox/pull/1595)
+  - Internal Maintenance on Schema and Compile Validator implementations.
+  - Change Schema EvaluateResult from Interface to Class.
 - [Revision 1.1.37](https://github.com/sinclairzx81/typebox/pull/1594)
   - Add Prototype Pollution Guards for Value.* Functions Clone, Diff, Patch, Mutate and Pointer.
 - [Revision 1.1.36](https://github.com/sinclairzx81/typebox/pull/1592)

--- a/example/standard/standard.ts
+++ b/example/standard/standard.ts
@@ -27,7 +27,7 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 import { type Static, type TSchema } from 'typebox'
-import { TLocalizedValidationError } from 'typebox/error'
+import { type TLocalizedValidationError } from 'typebox/error'
 import { Validator } from 'typebox/schema'
 import { Guard } from 'typebox/guard'
 

--- a/readme.md
+++ b/readme.md
@@ -279,31 +279,31 @@ The following table shows compile performance for various JSON Schema structures
 
 ```python
 ┌──────────────────────┬─────────────┬─────────────┐
-│ Compile              │ TB1X        │ AJV8        │
+│ Test                 │ TB1X        │ AJV8        │
 ├──────────────────────┼─────────────┼─────────────┤
-│ Boolean              │ 28.4K ops/s │    7K ops/s │
-│ Number               │ 21.8K ops/s │  7.7K ops/s │
-│ String               │ 47.8K ops/s │  7.3K ops/s │
-│ Null                 │ 35.6K ops/s │  7.8K ops/s │
-│ Literal_String       │ 28.6K ops/s │  6.3K ops/s │
-│ Literal_Number       │ 46.6K ops/s │  6.2K ops/s │
-│ Literal_Boolean      │ 40.8K ops/s │  6.6K ops/s │
-│ Pattern              │ 29.7K ops/s │  4.9K ops/s │
-│ Object_Open          │  6.8K ops/s │  1.1K ops/s │
-│ Object_Close         │  7.4K ops/s │   833 ops/s │
-│ Object_Vector3       │ 19.4K ops/s │  2.1K ops/s │
-│ Object_Basis3        │    6K ops/s │   895 ops/s │
-│ Intersect_And        │   12K ops/s │  3.5K ops/s │
-│ Intersect_Structural │  8.4K ops/s │  1.1K ops/s │
-│ Union_Or             │ 18.2K ops/s │  2.5K ops/s │
-│ Union_Structural     │ 10.9K ops/s │  1.3K ops/s │
-│ Tuple_Values         │  7.3K ops/s │  1.6K ops/s │
-│ Tuple_Objects        │  1.9K ops/s │   339 ops/s │
-│ Array_Numbers_4      │ 29.9K ops/s │  3.4K ops/s │
-│ Array_Numbers_8      │ 20.3K ops/s │  3.4K ops/s │
-│ Array_Numbers_16     │ 29.4K ops/s │  3.3K ops/s │
-│ Array_Objects_Open   │  6.3K ops/s │   684 ops/s │
-│ Array_Objects_Close  │  7.3K ops/s │   762 ops/s │
+│ Boolean              │ 29.2K ops/s │  7.1K ops/s │
+│ Number               │ 34.5K ops/s │  7.6K ops/s │
+│ String               │ 48.9K ops/s │  8.7K ops/s │
+│ Null                 │ 39.6K ops/s │  7.6K ops/s │
+│ Literal_String       │ 46.8K ops/s │  6.8K ops/s │
+│ Literal_Number       │ 48.3K ops/s │  7.4K ops/s │
+│ Literal_Boolean      │ 48.8K ops/s │  7.3K ops/s │
+│ Pattern              │ 32.5K ops/s │  6.1K ops/s │
+│ Object_Open          │  6.6K ops/s │  1.4K ops/s │
+│ Object_Close         │  7.6K ops/s │    1K ops/s │
+│ Object_Vector3       │ 20.8K ops/s │  2.8K ops/s │
+│ Object_Basis3        │  7.5K ops/s │    1K ops/s │
+│ Intersect_And        │   23K ops/s │  3.9K ops/s │
+│ Intersect_Structural │  8.7K ops/s │  1.2K ops/s │
+│ Union_Or             │ 17.9K ops/s │  3.4K ops/s │
+│ Union_Structural     │ 11.3K ops/s │  2.1K ops/s │
+│ Tuple_Values         │  9.6K ops/s │  2.1K ops/s │
+│ Tuple_Objects        │  2.1K ops/s │   350 ops/s │
+│ Array_Numbers_4      │ 33.6K ops/s │  4.2K ops/s │
+│ Array_Numbers_8      │   39K ops/s │  3.7K ops/s │
+│ Array_Numbers_16     │ 29.6K ops/s │  3.8K ops/s │
+│ Array_Objects_Open   │  7.7K ops/s │   833 ops/s │
+│ Array_Objects_Close  │  7.6K ops/s │   860 ops/s │
 └──────────────────────┴─────────────┴─────────────┘
 ```
 
@@ -312,31 +312,31 @@ The following tables shows validation performance for various JSON Schema struct
 
 ```python
 ┌──────────────────────┬──────────────┬──────────────┐
-│ Validate             │ TB1X         │ AJV8         │
+│ Test                 │ TB1X         │ AJV8         │
 ├──────────────────────┼──────────────┼──────────────┤
-│ Boolean              │ 164.1M ops/s │ 181.5M ops/s │
-│ Number               │   107M ops/s │  50.2M ops/s │
-│ String               │ 102.2M ops/s │  61.9M ops/s │
-│ Null                 │ 112.1M ops/s │  48.2M ops/s │
-│ Literal_String       │ 102.8M ops/s │  61.5M ops/s │
-│ Literal_Number       │ 109.1M ops/s │  46.4M ops/s │
-│ Literal_Boolean      │ 109.6M ops/s │  63.3M ops/s │
-│ Pattern              │  24.7M ops/s │  20.3M ops/s │
-│ Object_Open          │  75.4M ops/s │  37.3M ops/s │
-│ Object_Close         │  35.9M ops/s │  21.9M ops/s │
-│ Object_Vector3       │  77.6M ops/s │  47.4M ops/s │
-│ Object_Basis3        │    37M ops/s │  24.3M ops/s │
-│ Intersect_And        │  93.3M ops/s │  61.1M ops/s │
-│ Intersect_Structural │    83M ops/s │  36.4M ops/s │
-│ Union_Or             │  99.7M ops/s │   8.6M ops/s │
-│ Union_Structural     │  81.3M ops/s │  43.5M ops/s │
-│ Tuple_Values         │  72.4M ops/s │  41.7M ops/s │
-│ Tuple_Objects        │  32.6M ops/s │  22.4M ops/s │
-│ Array_Numbers_4      │  94.1M ops/s │  42.8M ops/s │
-│ Array_Numbers_8      │  90.6M ops/s │  42.3M ops/s │
-│ Array_Numbers_16     │  77.5M ops/s │  40.2M ops/s │
-│ Array_Objects_Open   │  26.3M ops/s │  19.6M ops/s │
-│ Array_Objects_Close  │   9.1M ops/s │    10M ops/s │
+│ Boolean              │ 192.2M ops/s │ 189.5M ops/s │
+│ Number               │ 112.4M ops/s │    61M ops/s │
+│ String               │ 113.7M ops/s │  64.1M ops/s │
+│ Null                 │ 112.8M ops/s │  64.9M ops/s │
+│ Literal_String       │   108M ops/s │  62.9M ops/s │
+│ Literal_Number       │ 113.5M ops/s │  63.2M ops/s │
+│ Literal_Boolean      │ 109.2M ops/s │  64.1M ops/s │
+│ Pattern              │  26.5M ops/s │  22.4M ops/s │
+│ Object_Open          │    78M ops/s │  47.2M ops/s │
+│ Object_Close         │  38.6M ops/s │  27.6M ops/s │
+│ Object_Vector3       │    91M ops/s │  51.3M ops/s │
+│ Object_Basis3        │  41.1M ops/s │  27.4M ops/s │
+│ Intersect_And        │ 107.6M ops/s │  59.9M ops/s │
+│ Intersect_Structural │  83.6M ops/s │  46.3M ops/s │
+│ Union_Or             │    95M ops/s │   7.9M ops/s │
+│ Union_Structural     │  84.5M ops/s │  52.3M ops/s │
+│ Tuple_Values         │  74.7M ops/s │    53M ops/s │
+│ Tuple_Objects        │  32.9M ops/s │  22.3M ops/s │
+│ Array_Numbers_4      │  93.3M ops/s │  55.1M ops/s │
+│ Array_Numbers_8      │  90.3M ops/s │  50.8M ops/s │
+│ Array_Numbers_16     │  76.8M ops/s │  39.6M ops/s │
+│ Array_Objects_Open   │  28.7M ops/s │  20.4M ops/s │
+│ Array_Objects_Close  │  10.3M ops/s │  10.8M ops/s │
 └──────────────────────┴──────────────┴──────────────┘
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -279,7 +279,7 @@ The following table shows compile performance for various JSON Schema structures
 
 ```python
 ┌──────────────────────┬─────────────┬─────────────┐
-│ Test                 │ TB1X        │ AJV8        │
+│ Compile              │ TB1X        │ AJV8        │
 ├──────────────────────┼─────────────┼─────────────┤
 │ Boolean              │ 29.2K ops/s │  7.1K ops/s │
 │ Number               │ 34.5K ops/s │  7.6K ops/s │
@@ -312,7 +312,7 @@ The following tables shows validation performance for various JSON Schema struct
 
 ```python
 ┌──────────────────────┬──────────────┬──────────────┐
-│ Test                 │ TB1X         │ AJV8         │
+│ Validate             │ TB1X         │ AJV8         │
 ├──────────────────────┼──────────────┼──────────────┤
 │ Boolean              │ 192.2M ops/s │ 189.5M ops/s │
 │ Number               │ 112.4M ops/s │    61M ops/s │

--- a/src/compile/code.ts
+++ b/src/compile/code.ts
@@ -76,8 +76,8 @@ function FunctionSection(build: BuildResult): string[] {
 // ------------------------------------------------------------------
 function ExportSection(build: BuildResult): string[] {
   const body = build.UseUnevaluated() 
-    ? `const context = new CheckContext({}, {}); return ${build.Call()}` 
-    : `return ${build.Call()}`
+    ? `const context = new CheckContext({}, {}); return ${build.Entry()}` 
+    : `return ${build.Entry()}`
   return [
     Separator(),
     TsIgnore(),

--- a/src/compile/validator.ts
+++ b/src/compile/validator.ts
@@ -30,11 +30,10 @@ THE SOFTWARE.
 
 import { Settings } from '../system/settings/index.ts'
 import { Arguments } from '../system/arguments/index.ts'
-import { Environment } from '../system/environment/index.ts'
 import { type TLocalizedValidationError } from '../error/index.ts'
 import { type StaticDecode, type StaticEncode, type TProperties, type TSchema, Base } from '../type/index.ts'
 import { Errors, Clean, Convert, Create, Default, Decode, Encode, HasCodec, Parser, ParseError } from '../value/index.ts'
-import { Build } from '../schema/index.ts'
+import { Build, BuildResult, EvaluateResult } from '../schema/index.ts'
 
 // ------------------------------------------------------------------
 // Validator<...>
@@ -43,40 +42,34 @@ export class Validator<Context extends TProperties = TProperties, Type extends T
   Encode extends unknown = StaticEncode<Type, Context>,
   Decode extends unknown = StaticDecode<Type, Context>
 > extends Base<Encode> {
-  private readonly context: Context
-  private readonly type: Type
-  private readonly isAccelerated: boolean
   private readonly hasCodec: boolean
-  private readonly code: string
-  private readonly check: (value: unknown) => boolean
+  private readonly buildResult: BuildResult
+  private readonly evaluateResult: EvaluateResult
   /** Constructs a Validator with the given Context and Type. */
   constructor(context: Context, type: Type)
   /** Constructs a Validator with the given arguments. */
-  constructor(context: Context, type: Type, isEvaluated: boolean, hasCodec: boolean, code: string, check: (value: unknown) => boolean)
+  constructor(hasCodec: boolean, buildResult: BuildResult, evaluateResult: EvaluateResult)
   /** Constructs a Validator. */
   constructor(...args: unknown[]) {
     super()
-    const matched: [Context, Type, boolean, boolean, string, (value: unknown) => boolean] | [Context, Type] = Arguments.Match(args, {
-      6: (context, type, isEvalulated, hasCodec, code, check) => [context, type, isEvalulated, hasCodec, code, check],
+    const matched: [boolean, BuildResult, EvaluateResult] | [Context, Type] = Arguments.Match(args, {
+      3: (hasCodec, buildResult, evaluateResult) => [hasCodec, buildResult, evaluateResult],
       2: (context, type) => [context, type]
     })
-    if(matched.length === 6) {
-      const [context, type, isEvaluated, hasCodec, code, check] = matched
-      this.context = context
-      this.type = type
-      this.isAccelerated = isEvaluated
+    // Note: The Base type requires this Validator to be Clone, but where we cannot safely clone
+    // the BuildResult or the EvaluateResult. For now we need pass the Validator constructor a 
+    // cloned instance of BuildResult and EvaluateResult such that the Validator clone shares 
+    // the same pre-compiled fields. We should remove this overload when Base is removed.
+    if(matched.length === 3 && matched[1] instanceof BuildResult && matched[2] instanceof EvaluateResult) {
+      const [hasCodec, buildResult, evaluateResult] = matched
       this.hasCodec = hasCodec
-      this.code = code
-      this.check = check
+      this.buildResult = buildResult
+      this.evaluateResult = evaluateResult
     } else {
       const [context, type] = matched as [Context, Type]
-      const result = Build(context, type).Evaluate()
       this.hasCodec = HasCodec(context, type)
-      this.context = context
-      this.type = type
-      this.isAccelerated = result.IsAccelerated
-      this.code = result.Code
-      this.check = result.Check as never
+      this.buildResult = Build(context, type)
+      this.evaluateResult = this.buildResult.Evaluate()
     }
   }
   // ----------------------------------------------------------------
@@ -84,80 +77,82 @@ export class Validator<Context extends TProperties = TProperties, Type extends T
   // ----------------------------------------------------------------
   /** Returns true if this Validator is using JIT acceleration. */
   public IsAccelerated(): boolean {
-    return this.isAccelerated
+    return this.evaluateResult.IsAccelerated()
   }
   // ----------------------------------------------------------------
-  // Context | Type
+  // Context & Type
   // ----------------------------------------------------------------
   /** Returns the Context for this validator. */
   public Context(): Context {
-    return this.context
+    return this.buildResult.Context() as never
   }
   /** Returns the underlying Type used to construct this Validator. */
   public Type(): Type {
-    return this.type
+    return this.buildResult.Schema() as never
   }
   // ----------------------------------------------------------------
   // Code
   // ----------------------------------------------------------------
   /** Returns the generated code for this validator. */
   public Code(): string {
-    return this.code
+    return this.evaluateResult.Code()
   }
   // ----------------------------------------------------------------
-  // Base<...>
+  // Standard Validator
   // ----------------------------------------------------------------
   /** Performs a type-guard check on the provided value. */
   public override Check(value: unknown): value is Encode {
-    return this.check(value)
-  }
-  /** Inspects a value and returns a detailed list of validation errors. */
-  public override Errors(value: unknown): TLocalizedValidationError[] {
-    if (Environment.CanEvaluate() && this.check(value)) return []
-    return Errors(this.context, this.type, value)
-  }
-  /** Cleans a value using the Validator type. */
-  public override Clean(value: unknown): unknown {
-    return Clean(this.context, this.type, value)
-  }
-  /** Converts a value using the Validator type. */
-  public override Convert(value: unknown): unknown {
-    return Convert(this.context, this.type, value)
-  }
-  /** Creates a value using the Validator type. */
-  public override Create(): Encode {
-    return Create(this.context, this.type)
-  }
-  /** Creates defaults using the Validator type. */
-  public override Default(value: unknown): unknown {
-    return Default(this.context, this.type, value)
-  }
-  /** Clones this validator. */
-  public override Clone(): Validator<Context, Type> {
-    return new Validator<Context, Type>(
-      this.context,
-      this.type, 
-      this.isAccelerated, 
-      this.hasCodec, 
-      this.code, 
-      this.check
-    )
+    return this.evaluateResult.Check(value)
   }
   /** Validates a value and returns it. Will throw if invalid. */
   public Parse(value: unknown): Encode {
     const checked = this.Check(value)
     if(checked) return value as never
-    if(Settings.Get().correctiveParse) return Parser(this.context, this.type, value) as never
+    if(Settings.Get().correctiveParse) return Parser(this.Context(), this.Type(), value) as never
     throw new ParseError(value, this.Errors(value))
+  }
+  /** Inspects a value and returns a detailed list of validation errors. */
+  public override Errors(value: unknown): TLocalizedValidationError[] {
+    if (this.IsAccelerated() && this.Check(value)) return []
+    return Errors(this.Context(), this.Type(), value)
+  }
+  // ----------------------------------------------------------------
+  // Value.* Operations
+  // ----------------------------------------------------------------
+  /** Cleans a value using the Validator type. */
+  public override Clean(value: unknown): unknown {
+    return Clean(this.Context(), this.Type(), value)
+  }
+  /** Converts a value using the Validator type. */
+  public override Convert(value: unknown): unknown {
+    return Convert(this.Context(), this.Type(), value)
+  }
+  /** Creates a value using the Validator type. */
+  public override Create(): Encode {
+    return Create(this.Context(), this.Type())
+  }
+  /** Creates defaults using the Validator type. */
+  public override Default(value: unknown): unknown {
+    return Default(this.Context(), this.Type(), value)
   }
   /** Decodes a value */
   public Decode(value: unknown): Decode {
-    const result = this.hasCodec ? Decode(this.context, this.type, value) : this.Parse(value)
+    const result = this.hasCodec ? Decode(this.Context(), this.Type(), value) : this.Parse(value)
     return result as never
   }
   /** Encodes a value */
   public Encode(value: unknown): Encode {
-    const result = this.hasCodec ? Encode(this.context, this.type, value) : this.Parse(value)
+    const result = this.hasCodec ? Encode(this.Context(), this.Type(), value) : this.Parse(value)
     return result as never
+  }
+  // ----------------------------------------------------------------
+  // Deprecations
+  // ----------------------------------------------------------------
+  /** 
+   * @deprecated Validator instances should not support Clone because they are owners of JIT evaluated functions. This function will be 
+   * removed in the next version of TypeBox (relates to Type.Base deprecation)
+   */
+  public override Clone(): Validator<Context, Type> {
+    return new Validator<Context, Type>(this.hasCodec, this.buildResult, this.evaluateResult)
   }
 }

--- a/src/compile/validator.ts
+++ b/src/compile/validator.ts
@@ -57,9 +57,9 @@ export class Validator<Context extends TProperties = TProperties, Type extends T
       2: (context, type) => [context, type]
     })
     // Note: The Base type requires this Validator to be Clone, but where we cannot safely clone
-    // the BuildResult or the EvaluateResult. For now we need pass the Validator constructor a 
-    // cloned instance of BuildResult and EvaluateResult such that the Validator clone shares 
-    // the same pre-compiled fields. We should remove this overload when Base is removed.
+    // the BuildResult or the EvaluateResult. For now we pass the Validator constructor a shared 
+    // reference of BuildResult and EvaluateResult to mitigate re-compile on Clone. We must remove 
+    // this overload when Base is removed (memory-gc-ref)
     if(matched.length === 3 && matched[1] instanceof BuildResult && matched[2] instanceof EvaluateResult) {
       const [hasCodec, buildResult, evaluateResult] = matched
       this.hasCodec = hasCodec

--- a/src/schema/build.ts
+++ b/src/schema/build.ts
@@ -44,8 +44,8 @@ import * as Schema from './types/index.ts'
 function CreateCode(build: BuildResult): string {
   const functions = build.Functions().join(';\n')
   const statements = build.UseUnevaluated()
-    ? ['const context = new CheckContext({}, {})', `return ${build.Call()}`]
-    : [`return ${build.Call()}`]
+    ? ['const context = new CheckContext({}, {})', `return ${build.Entry()}`]
+    : [`return ${build.Entry()}`]
   return `${functions}; return (value) => { ${statements.join('; ')} }`
 }
 // ------------------------------------------------------------------
@@ -79,10 +79,21 @@ export type CheckFunction = (value: unknown) => boolean
 // ------------------------------------------------------------------
 // EvaluateResult
 // ------------------------------------------------------------------
-export interface EvaluateResult {
-  IsAccelerated: boolean
-  Code: string
-  Check: CheckFunction
+export class EvaluateResult {
+  constructor(
+    private readonly isAccelerated: boolean,
+    private readonly code: string,
+    private readonly check: CheckFunction
+  ) {}
+  public IsAccelerated() {
+    return this.isAccelerated
+  }
+  public Code(): string {
+    return this.code
+  }
+  public Check(value: unknown): boolean {
+    return this.check(value)
+  }
 }
 // ------------------------------------------------------------------
 // BuildResult
@@ -93,7 +104,7 @@ export class BuildResult {
     private readonly schema: Schema.XSchema,
     private readonly external: Engine.TExternal,
     private readonly functions: string[],
-    private readonly call: string,
+    private readonly entry: string,
     private readonly useUnevaluated: boolean
   ) { }
   /** Returns the Context used for this build */
@@ -117,14 +128,14 @@ export class BuildResult {
     return this.functions
   }
   /** Return entry function call. */
-  public Call(): string {
-    return this.call
+  public Entry(): string {
+    return this.entry
   }
   /** Evaluates the build into a validation function */
   public Evaluate(): EvaluateResult {
-    const Code = CreateCode(this)
-    const Check = CreateCheck(this, Code)
-    return { IsAccelerated: Environment.CanEvaluate(), Code, Check }
+    const code = CreateCode(this)
+    const check = CreateCheck(this, code)
+    return new EvaluateResult(Environment.CanEvaluate(), code, check)
   }
 }
 // ------------------------------------------------------------------

--- a/src/schema/compile.ts
+++ b/src/schema/compile.ts
@@ -32,8 +32,8 @@ THE SOFTWARE.
 import { Arguments } from '../system/arguments/index.ts'
 import { type TLocalizedValidationError } from '../error/index.ts'
 import { type Static } from '../type/types/static.ts'
-import * as Build from './build.ts'
 import * as Schema from './types/index.ts'
+import * as Build from './build.ts'
 import { Errors } from './errors.ts'
 import { ParseError } from './parse.ts'
 
@@ -43,33 +43,33 @@ import { ParseError } from './parse.ts'
 export class Validator<const Schema extends Schema.XSchema = Schema.XSchema, 
   Value extends unknown = Static<Schema>
 >  {
-  private readonly build: Build.BuildResult
-  private readonly result: Build.EvaluateResult
+  private readonly buildResult: Build.BuildResult
+  private readonly evaluateResult: Build.EvaluateResult
   constructor(context: Record<string, Schema.XSchema>, schema: Schema) {
-    this.build = Build.Build(context, schema)
-    this.result = this.build.Evaluate()
+    this.buildResult = Build.Build(context, schema)
+    this.evaluateResult = this.buildResult.Evaluate()
   }
   /** Returns true if this Validator is using JIT acceleration. */
   public IsAccelerated(): boolean {
-    return this.result.IsAccelerated
+    return this.evaluateResult.IsAccelerated()
   }
   /** Returns the underlying Schema used to construct this Validator. */
   public Schema(): Schema {
-    return this.build.Schema() as never
+    return this.buildResult.Schema() as never
   }
   /** Performs a type-guard check on the provided value. */
   public Check(value: unknown): value is Value {
-    return this.result.Check(value)
+    return this.evaluateResult.Check(value)
   }
   /** Validates a value and returns it. Will throw if invalid. */
   public Parse(value: unknown): Value {
-    if(this.result.Check(value)) return value as never
-    const [_result, errors] = Errors(this.build.Context(), this.build.Schema(), value)
-    throw new ParseError(this.build.Schema(), value, errors)
+    if(this.evaluateResult.Check(value)) return value as never
+    const [_result, errors] = Errors(this.buildResult.Context(), this.buildResult.Schema(), value)
+    throw new ParseError(this.buildResult.Schema(), value, errors)
   }
   /** Inspects a value and returns a detailed list of validation errors. */
   public Errors(value: unknown): [result: boolean, errors: TLocalizedValidationError[]] {
-    return Errors(this.build.Context(), this.build.Schema(), value)
+    return Errors(this.buildResult.Context(), this.buildResult.Schema(), value)
   }
 }
 // ------------------------------------------------------------------

--- a/src/schema/engine/_context.ts
+++ b/src/schema/engine/_context.ts
@@ -59,7 +59,7 @@ export function HasUnevaluated(context: Record<PropertyKey, unknown>, schema: un
 // BuildContext
 // ------------------------------------------------------------------
 export class BuildContext {
-  constructor(private readonly hasUnevaluated: boolean) {}
+  constructor(private readonly hasUnevaluated: boolean) { }
   public UseUnevaluated(): boolean {
     return this.hasUnevaluated
   }

--- a/src/schema/engine/_externals.ts
+++ b/src/schema/engine/_externals.ts
@@ -54,5 +54,5 @@ export function ResetExternal(): void {
 // GetExternals
 // ------------------------------------------------------------------
 export function GetExternal(): TExternal {
-  return { ... state }
+  return { ...state }
 }

--- a/src/schema/engine/additionalItems.ts
+++ b/src/schema/engine/additionalItems.ts
@@ -59,7 +59,7 @@ export function BuildAdditionalItems(stack: Stack, context: BuildContext, schema
 export function CheckAdditionalItems(stack: Stack, context: CheckContext, schema: Schema.XAdditionalItems, value: unknown[]): boolean {
   if (!IsValid(schema)) return true
   const isAdditionalItems = value.every((item, index) => {
-    return G.IsLessThan(index, schema.items.length) 
+    return G.IsLessThan(index, schema.items.length)
       || (CheckSchemaPushStack(stack, context, schema.additionalItems, item) && context.AddIndex(index))
   })
   return isAdditionalItems
@@ -72,7 +72,7 @@ export function ErrorAdditionalItems(stack: Stack, context: ErrorContext, schema
   const isAdditionalItems = value.every((item, index) => {
     const nextSchemaPath = `${schemaPath}/additionalItems`
     const nextInstancePath = `${instancePath}/${index}`
-    return G.IsLessThan(index, schema.items.length) || 
+    return G.IsLessThan(index, schema.items.length) ||
       (ErrorSchemaPushStack(stack, context, nextSchemaPath, nextInstancePath, schema.additionalItems, item) && context.AddIndex(index))
   })
   return isAdditionalItems

--- a/src/schema/engine/additionalProperties.ts
+++ b/src/schema/engine/additionalProperties.ts
@@ -92,7 +92,7 @@ export function BuildAdditionalPropertiesStandard(stack: Stack, context: BuildCo
   const isKey = E.Call(E.Member(regexp, 'test'), [key])
   const addKey = context.AddKey(key)
   const guarded = context.UseUnevaluated() ? E.Or(isKey, E.And(isSchema, addKey)) : E.Or(isKey, isSchema)
-  const result =  E.Every(E.Keys(value), E.Constant(0), [key, _index], guarded)
+  const result = E.Every(E.Keys(value), E.Constant(0), [key, _index], guarded)
   return result
 }
 // ------------------------------------------------------------------
@@ -109,7 +109,7 @@ export function BuildAdditionalProperties(stack: Stack, context: BuildContext, s
 export function CheckAdditionalProperties(stack: Stack, context: CheckContext, schema: S.XAdditionalProperties, value: Record<PropertyKey, unknown>): boolean {
   const regexp = new RegExp(GetPropertiesPattern(schema))
   const isAdditionalProperties = G.Every(G.Keys(value), 0, (key, _index) => {
-    return regexp.test(key) || 
+    return regexp.test(key) ||
       (CheckSchemaPushStack(stack, context, schema.additionalProperties, value[key]) && context.AddKey(key))
   })
   return isAdditionalProperties
@@ -124,8 +124,8 @@ export function ErrorAdditionalProperties(stack: Stack, context: ErrorContext, s
     const nextSchemaPath = `${schemaPath}/additionalProperties`
     const nextInstancePath = `${instancePath}/${key}`
     const nextContext = new AccumulatedErrorContext()
-    const isAdditionalProperty = regexp.test(key) || 
-      (ErrorSchemaPushStack(stack, nextContext, nextSchemaPath, nextInstancePath, schema.additionalProperties, value[key]) && context.AddKey(key))    
+    const isAdditionalProperty = regexp.test(key) ||
+      (ErrorSchemaPushStack(stack, nextContext, nextSchemaPath, nextInstancePath, schema.additionalProperties, value[key]) && context.AddKey(key))
 
     if (!isAdditionalProperty) additionalProperties.push(key)
     return isAdditionalProperty
@@ -133,7 +133,7 @@ export function ErrorAdditionalProperties(stack: Stack, context: ErrorContext, s
   return isAdditionalProperties || context.AddError({
     keyword: 'additionalProperties',
     schemaPath,
-    instancePath: instancePath,
+    instancePath,
     params: { additionalProperties },
   })
 }

--- a/src/schema/engine/allOf.ts
+++ b/src/schema/engine/allOf.ts
@@ -45,8 +45,8 @@ function BuildAllOfFast(stack: Stack, context: BuildContext, schema: Schema.XAll
   return E.ReduceAnd(schema.allOf.map((schema) => BuildSchema(stack, context, schema, value)))
 }
 export function BuildAllOf(stack: Stack, context: BuildContext, schema: Schema.XAllOf, value: string): string {
-  return context.UseUnevaluated() 
-    ? BuildAllOfStandard(stack, context, schema, value) 
+  return context.UseUnevaluated()
+    ? BuildAllOfStandard(stack, context, schema, value)
     : BuildAllOfFast(stack, context, schema, value)
 }
 // ------------------------------------------------------------------

--- a/src/schema/engine/anyOf.ts
+++ b/src/schema/engine/anyOf.ts
@@ -45,8 +45,8 @@ function BuildAnyOfFast(stack: Stack, context: BuildContext, schema: Schema.XAny
   return E.ReduceOr(schema.anyOf.map((schema) => BuildSchema(stack, context, schema, value)))
 }
 export function BuildAnyOf(stack: Stack, context: BuildContext, schema: Schema.XAnyOf, value: string): string {
-  return context.UseUnevaluated() 
-    ? BuildAnyOfStandard(stack, context, schema, value) 
+  return context.UseUnevaluated()
+    ? BuildAnyOfStandard(stack, context, schema, value)
     : BuildAnyOfFast(stack, context, schema, value)
 }
 // ------------------------------------------------------------------

--- a/src/schema/engine/contains.ts
+++ b/src/schema/engine/contains.ts
@@ -57,7 +57,7 @@ export function BuildContains(stack: Stack, context: BuildContext, schema: Schem
 // ------------------------------------------------------------------
 export function CheckContains(stack: Stack, context: CheckContext, schema: Schema.XContains, value: unknown[]): boolean {
   if (!IsValid(schema)) return true
-  return !G.IsEqual(value.length, 0) && 
+  return !G.IsEqual(value.length, 0) &&
     value.some((item) => CheckSchema(stack, context, schema.contains, item))
 }
 // ------------------------------------------------------------------

--- a/src/schema/engine/dependentRequired.ts
+++ b/src/schema/engine/dependentRequired.ts
@@ -61,7 +61,7 @@ export function CheckDependentRequired(_stack: Stack, _context: CheckContext, sc
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorDependentRequired(_stack:  Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XDependentRequired, value: Record<PropertyKey, unknown>): boolean {
+export function ErrorDependentRequired(_stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XDependentRequired, value: Record<PropertyKey, unknown>): boolean {
   const isLength = G.IsEqual(G.Keys(value).length, 0)
   const isEveryEntry = G.EveryAll(G.Entries(schema.dependentRequired), 0, ([key, keys]) => {
     return !G.HasPropertyKey(value, key) || G.EveryAll(keys, 0, (dependency) => G.HasPropertyKey(value, dependency) || context.AddError({

--- a/src/schema/engine/dependentSchemas.ts
+++ b/src/schema/engine/dependentSchemas.ts
@@ -52,7 +52,7 @@ export function BuildDependentSchemas(stack: Stack, context: BuildContext, schem
 export function CheckDependentSchemas(stack: Stack, context: CheckContext, schema: Schema.XDependentSchemas, value: Record<PropertyKey, unknown>): boolean {
   const isLength = G.IsEqual(G.Keys(value).length, 0)
   const isEvery = G.Every(G.Entries(schema.dependentSchemas), 0, ([key, schema]) => {
-    return !G.HasPropertyKey(value, key) || 
+    return !G.HasPropertyKey(value, key) ||
       CheckSchema(stack, context, schema, value)
   })
   return isLength || isEvery
@@ -64,7 +64,7 @@ export function ErrorDependentSchemas(stack: Stack, context: ErrorContext, schem
   const isLength = G.IsEqual(G.Keys(value).length, 0)
   const isEvery = G.EveryAll(G.Entries(schema.dependentSchemas), 0, ([key, schema]) => {
     const nextSchemaPath = `${schemaPath}/dependentSchemas/${key}`
-    return !G.HasPropertyKey(value, key) || 
+    return !G.HasPropertyKey(value, key) ||
       ErrorSchema(stack, context, nextSchemaPath, instancePath, schema, value)
   })
   return isLength || isEvery

--- a/src/schema/engine/enum.ts
+++ b/src/schema/engine/enum.ts
@@ -48,8 +48,8 @@ export function BuildEnum(_stack: Stack, _context: BuildContext, schema: Schema.
 // Check
 // ------------------------------------------------------------------
 export function CheckEnum(_stack: Stack, _context: CheckContext, schema: Schema.XEnum, value: unknown): boolean {
-  return schema.enum.some(option => G.IsValueLike(option) 
-    ? G.IsEqual(value, option) 
+  return schema.enum.some(option => G.IsValueLike(option)
+    ? G.IsEqual(value, option)
     : G.IsDeepEqual(value, option))
 }
 // ------------------------------------------------------------------

--- a/src/schema/engine/if.ts
+++ b/src/schema/engine/if.ts
@@ -40,8 +40,8 @@ import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
 export function BuildIf(stack: Stack, context: BuildContext, schema: Schema.XIf, value: string): string {
   const thenSchema = Schema.IsThen(schema) ? schema.then : true
   const elseSchema = Schema.IsElse(schema) ? schema.else : true
-  return E.Ternary(BuildSchema(stack, context, schema.if, value), 
-    BuildSchema(stack, context, thenSchema, value), 
+  return E.Ternary(BuildSchema(stack, context, schema.if, value),
+    BuildSchema(stack, context, thenSchema, value),
     BuildSchema(stack, context, elseSchema, value))
 }
 // ------------------------------------------------------------------
@@ -50,8 +50,8 @@ export function BuildIf(stack: Stack, context: BuildContext, schema: Schema.XIf,
 export function CheckIf(stack: Stack, context: CheckContext, schema: Schema.XIf, value: unknown): boolean {
   const thenSchema = Schema.IsThen(schema) ? schema.then : true
   const elseSchema = Schema.IsElse(schema) ? schema.else : true
-  return CheckSchema(stack, context, schema.if, value) 
-    ? CheckSchema(stack, context, thenSchema, value) 
+  return CheckSchema(stack, context, schema.if, value)
+    ? CheckSchema(stack, context, thenSchema, value)
     : CheckSchema(stack, context, elseSchema, value)
 }
 // ------------------------------------------------------------------

--- a/src/schema/engine/items.ts
+++ b/src/schema/engine/items.ts
@@ -48,7 +48,7 @@ function BuildItemsSized(stack: Stack, context: BuildContext, schema: Schema.XIt
 }
 function CheckItemsSized(stack: Stack, context: CheckContext, schema: Schema.XItemsSized, value: unknown[]): boolean {
   return G.Every(schema.items, 0, (schema, index) => {
-    return G.IsLessEqualThan(value.length, index) 
+    return G.IsLessEqualThan(value.length, index)
       || (CheckSchemaPushStack(stack, context, schema, value[index]) && context.AddIndex(index))
   })
 }
@@ -56,7 +56,7 @@ function ErrorItemsSized(stack: Stack, context: ErrorContext, schemaPath: string
   return G.EveryAll(schema.items, 0, (schema, index) => {
     const nextSchemaPath = `${schemaPath}/items/${index}`
     const nextInstancePath = `${instancePath}/${index}`
-    return G.IsLessEqualThan(value.length, index) 
+    return G.IsLessEqualThan(value.length, index)
       || (ErrorSchemaPushStack(stack, context, nextSchemaPath, nextInstancePath, schema, value[index]) && context.AddIndex(index))
   })
 }
@@ -73,7 +73,7 @@ function BuildItemsUnsized(stack: Stack, context: BuildContext, schema: Schema.X
 function CheckItemsUnsized(stack: Stack, context: CheckContext, schema: Schema.XItemsUnsized, value: unknown[]): boolean {
   const offset = Schema.IsPrefixItems(schema) ? schema.prefixItems.length : 0
   return G.Every(value, offset, (element, index) => {
-    return CheckSchemaPushStack(stack, context, schema.items, element) 
+    return CheckSchemaPushStack(stack, context, schema.items, element)
       && context.AddIndex(index)
   })
 }
@@ -82,7 +82,7 @@ function ErrorItemsUnsized(stack: Stack, context: ErrorContext, schemaPath: stri
   return G.EveryAll(value, offset, (element, index) => {
     const nextSchemaPath = `${schemaPath}/items`
     const nextInstancePath = `${instancePath}/${index}`
-    return ErrorSchemaPushStack(stack, context, nextSchemaPath, nextInstancePath, schema.items, element) 
+    return ErrorSchemaPushStack(stack, context, nextSchemaPath, nextInstancePath, schema.items, element)
       && context.AddIndex(index)
   })
 }

--- a/src/schema/engine/ref.ts
+++ b/src/schema/engine/ref.ts
@@ -70,7 +70,7 @@ export function CheckRef(stack: Stack, context: CheckContext, schema: Schema.XRe
   const target = stack.Ref(schema) ?? false
   const nextContext = new CheckContext()
   const result = (Schema.IsSchema(target) && CheckSchema(stack, nextContext, target, value))
-  if(result) context.Merge([nextContext])
+  if (result) context.Merge([nextContext])
   return result
 }
 // ------------------------------------------------------------------
@@ -80,7 +80,7 @@ export function ErrorRef(stack: Stack, context: ErrorContext, _schemaPath: strin
   const target = stack.Ref(schema) ?? false
   const nextContext = new AccumulatedErrorContext()
   const result = (Schema.IsSchema(target) && ErrorSchema(stack, nextContext, '#', instancePath, target, value))
-  if(result) context.Merge([nextContext])
-  if(!result) nextContext.GetErrors().forEach(error => context.AddError(error))
+  if (result) context.Merge([nextContext])
+  if (!result) nextContext.GetErrors().forEach(error => context.AddError(error))
   return result
 }

--- a/src/schema/engine/schema.ts
+++ b/src/schema/engine/schema.ts
@@ -222,7 +222,6 @@ export function BuildSchema(stack: Stack, context: BuildContext, schema: Schema.
     const guarded = E.Or(E.Not(E.Or(E.IsNumber(value), E.IsBigInt(value))), reduced)
     conditions.push(HasNumberType(schema) ? reduced : guarded)
   }
-  
   if (Schema.IsRef(schema)) conditions.push(BuildRef(stack, context, schema, value))
   if (Schema.IsRecursiveRef(schema)) conditions.push(BuildRecursiveRef(stack, context, schema, value))
   if (Schema.IsDynamicRef(schema)) conditions.push(BuildDynamicRef(stack, context, schema, value))
@@ -287,7 +286,6 @@ export function CheckSchema(stack: Stack, context: CheckContext, schema: Schema.
       (!Schema.IsMinimum(schema) || CheckMinimum(stack, context, schema, value)) &&
       (!Schema.IsMultipleOf(schema) || CheckMultipleOf(stack, context, schema, value))
     )) &&
-    
     (!Schema.IsRef(schema) || CheckRef(stack, context, schema, value)) &&
     (!Schema.IsRecursiveRef(schema) || CheckRecursiveRef(stack, context, schema, value)) &&
     (!Schema.IsDynamicRef(schema) || CheckDynamicRef(stack, context, schema, value)) &&

--- a/src/schema/engine/type.ts
+++ b/src/schema/engine/type.ts
@@ -47,7 +47,7 @@ function BuildTypeName(_stack: Stack, _context: BuildContext, type: string, valu
     G.IsEqual(type, 'null') ? E.IsNull(value) :
     G.IsEqual(type, 'string') ? E.IsString(value) :
     // xschema
-    G.IsEqual(type, 'asyncIterator') ? E.IsAsyncIterator(value) : 
+    G.IsEqual(type, 'asyncIterator') ? E.IsAsyncIterator(value) :
     G.IsEqual(type, 'bigint') ? E.IsBigInt(value) :
     G.IsEqual(type, 'constructor') ? E.IsConstructor(value) :
     G.IsEqual(type, 'function') ? E.IsFunction(value) :

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.1.37'
+const Version = '1.1.38'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/schema/additional.ts
+++ b/test/typebox/runtime/schema/additional.ts
@@ -13,13 +13,13 @@ const Test = Assert.Context('Schema.Additional')
 // When unevaluatedItems is present, prefixItems should register their indices.
 // This behavior is used for build-time optimization only.
 Test('Should Coverage 1', () => {
-  const check = Schema.Build({
+  const evaluateResult = Schema.Build({
     prefixItems: [{ const: 1 }, { const: 2 }],
     unevaluatedItems: false
-  }).Evaluate().Check
+  }).Evaluate()
 
-  Assert.IsTrue(check([1, 2]))
-  Assert.IsFalse(check([1, 2, 3]))
+  Assert.IsTrue(evaluateResult.Check([1, 2]))
+  Assert.IsFalse(evaluateResult.Check([1, 2, 3]))
 })
 
 // Test 2: Ensures unknown type values are handled correctly.

--- a/test/typebox/runtime/schema/build.ts
+++ b/test/typebox/runtime/schema/build.ts
@@ -10,18 +10,18 @@ import { Guard } from 'typebox/guard'
 const Test = Assert.Context('Schema.Build:Result')
 
 Test('Should Build 1', () => {
-  const build = Schema.Build({ A: { type: 'string' } }, { $ref: 'A' })
-  Assert.IsTrue(Guard.IsBoolean(build.UseUnevaluated()))
+  const buildResult = Schema.Build({ A: { type: 'string' } }, { $ref: 'A' })
+  Assert.IsTrue(Guard.IsBoolean(buildResult.UseUnevaluated()))
 })
 Test('Should Build 2', () => {
-  const build = Schema.Build({ type: 'string' })
-  Assert.IsTrue(Guard.IsString(build.Call()))
+  const buildResult = Schema.Build({ type: 'string' })
+  Assert.IsTrue(Guard.IsString(buildResult.Entry()))
 })
 Test('Should Build 3', () => {
-  const build = Schema.Build({ type: 'string' })
-  const variables = build.External()
-  Assert.HasPropertyKey(variables, 'identifier')
-  Assert.HasPropertyKey(variables, 'variables')
+  const buildResult = Schema.Build({ type: 'string' })
+  const external = buildResult.External()
+  Assert.HasPropertyKey(external, 'identifier')
+  Assert.HasPropertyKey(external, 'variables')
 })
 Test('Should Build 4', () => {
   const build = Schema.Build({ A: { type: 'string' } }, { $ref: 'A' })


### PR DESCRIPTION
This PR is a general internal maintenance update where it cleans the Compile, Schema Validator implementations and also changes the EvaluateResult from an interface to a class. The BuildResult is `Call()` function also renamed to `Entry()`, where this `Entry()` indicates which generated validator function should be called to perform a validation.

General Updates

* Clean up Compiler and Schema Validator Implementations
* Make EvaluateResult a class
* Deprecate Notice for Clone function on Compile Validator type.
* General Manual Code / Document Formatting across Schema Engine.

There should be no breaking changes on this PR.