### PR TITLE
Fix StaticUnion regression for non-tuple Array<TSchema>

### DIFF
--- a/src/type/types/union.ts
+++ b/src/type/types/union.ts
@@ -39,7 +39,9 @@ import { type TProperties } from './properties.ts'
 export type StaticUnion<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Types extends TSchema[], Result extends unknown = never> = (
   Types extends [infer Left extends TSchema, ...infer Right extends TSchema[]]
     ? StaticUnion<Stack, Direction, Context, This, Right, Result | StaticType<Stack, Direction, Context, This, Left>>
-    : Result
+    : Types extends Array<infer Item extends TSchema>
+      ? Result | StaticType<Stack, Direction, Context, This, Item>
+      : Result
 )
 // ------------------------------------------------------------------
 // Type

--- a/test/typebox/static/type/union.ts
+++ b/test/typebox/static/type/union.ts
@@ -1,12 +1,41 @@
-import { type Static, Type } from 'typebox'
+import { type Static, type TSchema, Type } from 'typebox'
 import { Assert } from 'test'
 
-const T = Type.Union([
-  Type.Literal(1),
-  Type.Literal(2),
-  Type.Literal(3)
-])
-type T = Static<typeof T>
+// inline tuple inference
+{
+  const T = Type.Union([
+    Type.Literal(1),
+    Type.Literal(2),
+    Type.Literal(3)
+  ])
+  type T = Static<typeof T>
 
-Assert.IsExtendsMutual<T, 1 | 2 | 3>(true)
-Assert.IsExtendsMutual<T, null>(false)
+  Assert.IsExtendsMutual<T, 1 | 2 | 3>(true)
+  Assert.IsExtendsMutual<T, null>(false)
+}
+// non-tuple TSchema[] should still resolve to a union (not never)
+{
+  const Schemas: TSchema[] = [
+    Type.Literal(1),
+    Type.Literal(2),
+    Type.Literal(3)
+  ]
+  const T = Type.Union(Schemas)
+  type T = Static<typeof T>
+
+  Assert.IsExtendsMutual<T, unknown>(true)
+  Assert.IsExtendsNever<T>(false)
+}
+// narrowed element type via Array<TLiteral<...>> should resolve to the literal union
+{
+  const Schemas: Array<ReturnType<typeof Type.Literal<1 | 2 | 3>>> = [
+    Type.Literal(1 as const),
+    Type.Literal(2 as const),
+    Type.Literal(3 as const)
+  ]
+  const T = Type.Union(Schemas)
+  type T = Static<typeof T>
+
+  Assert.IsExtendsMutual<T, 1 | 2 | 3>(true)
+  Assert.IsExtendsNever<T>(false)
+}


### PR DESCRIPTION
In typebox 0.34, UnionStatic used a mapped-index-signature pattern `{[K in keyof T]: Static<T[K]>}[number]` that resolved correctly for both tuple types and general `TSchema[]` arrays.

In 1.x, StaticUnion was rewritten using head/tail destructuring with a `Result = never` default. Because `TSchema[]` does not match `[Left, ...Right]` (the array may be empty), `Static<TUnion<TSchema[]>>` falls through to `never`. This regresses any code that builds a union from a variable typed as a plain array:

```typescript
const errors = [Type.Object(...), Type.Object(...)];
const schema = Type.Union(errors);
type T = Static<typeof schema>; // resolves to `never` instead of the union
```

Fix: add an `Array<infer Item extends TSchema>` fallback that infers the element type when the input is not a tuple. Tuples still go through the fast recursive path; the new branch only fires for general arrays.

Adds static tests covering:
  - inline tuple inference (existing behaviour)
  - generic TSchema[] (must not resolve to never)
  - narrowed Array<TLiteral<1|2|3>> (must resolve to 1|2|3)