### PR TITLE
Version 1.2.5

### DIFF
--- a/changelog/1.2.0.md
+++ b/changelog/1.2.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.2.5](https://github.com/sinclairzx81/typebox/pull/1610)
+  - Modules Only Output Declarations
 - [Revision 1.2.4](https://github.com/sinclairzx81/typebox/pull/1609)
   - Integrate Modifier Instantiation via Deferred Actions
 - [Revision 1.2.3](https://github.com/sinclairzx81/typebox/pull/1607)

--- a/src/type/action/module.ts
+++ b/src/type/action/module.ts
@@ -32,27 +32,28 @@ THE SOFTWARE.
 import { type TSchemaOptions } from '../types/schema.ts'
 import { type TProperties } from '../types/properties.ts'
 import { type TDeferred, Deferred } from '../types/deferred.ts'
-import { type TInstantiate, Instantiate } from '../engine/instantiate.ts'
+import { type TState, State } from '../engine/instantiate.ts'
+import { type TModuleInstantiate, ModuleInstantiate } from '../engine/module/instantiate.ts'
 
 // ------------------------------------------------------------------
 // Deferred
 // ------------------------------------------------------------------
 /** Creates a deferred Module action. */
-export type TModuleDeferred<Context extends TProperties> = (
-  TDeferred<'Module', [Context]>
+export type TModuleDeferred<Declarations extends TProperties> = (
+  TDeferred<'Module', [Declarations]>
 )
 /** Creates a deferred Module action. */
-export function ModuleDeferred<Context extends TProperties>(context: Context, options: TSchemaOptions = {}): TModuleDeferred<Context> {
-  return Deferred('Module', [context], options)
+export function ModuleDeferred<Declarations extends TProperties>(declarations: Declarations, options: TSchemaOptions = {}): TModuleDeferred<Declarations> {
+  return Deferred('Module', [declarations], options)
 }
 // ------------------------------------------------------------------
 // Type
 // ------------------------------------------------------------------
-/** Applies a Module transformation action to the embedded property types. */
-export type TModule<Context extends TProperties> = (
-  TInstantiate<{}, TModuleDeferred<Context>>
+/** Creates a Module with the given declarations */
+export type TModule<Declarations extends TProperties> = (
+  TModuleInstantiate<{}, TState<[], []>, Declarations>
 )
-/** Applies a Module transformation action to the embedded property types. */
-export function Module<Context extends TProperties>(context: Context, options: TSchemaOptions = {}): TModule<Context> {
-  return Instantiate({}, ModuleDeferred(context, options)) as never
+/** Creates a Module with the given declarations */
+export function Module<Declarations extends TProperties>(declarations: Declarations, options: TSchemaOptions = {}): TModule<Declarations> {
+  return ModuleInstantiate({}, State([], []), declarations, options) as never
 }

--- a/src/type/engine/instantiate.ts
+++ b/src/type/engine/instantiate.ts
@@ -196,7 +196,7 @@ type TInstantiateDeferred<Context extends TProperties, State extends TState, Act
   [Action, Parameters] extends ['KeyOf', [infer Type extends TSchema]] ? TKeyOfInstantiate<Context, State, Type> :
   [Action, Parameters] extends ['Lowercase', [infer Type extends TSchema]] ? TLowercaseInstantiate<Context, State, Type> :
   [Action, Parameters] extends ['Mapped', [infer Name extends TIdentifier, infer Key extends TSchema, infer As extends TSchema, infer Property extends TSchema]] ? TMappedInstantiate<Context, State, Name, Key, As, Property> :
-  [Action, Parameters] extends ['Module', [infer Properties extends TProperties]] ? TModuleInstantiate<Context, State, Properties> :
+  [Action, Parameters] extends ['Module', [infer Declarations extends TProperties]] ? TModuleInstantiate<Context, State, Declarations> :
   [Action, Parameters] extends ['NonNullable', [infer Type extends TSchema]] ? TNonNullableInstantiate<Context, State, Type> :
   [Action, Parameters] extends ['Pick', [infer Type extends TSchema, infer Indexer extends TSchema]] ? TPickInstantiate<Context, State, Type, Indexer> :
   [Action, Parameters] extends ['Parameters', [infer Type extends TSchema]] ? TParametersInstantiate<Context, State, Type> :

--- a/src/type/engine/module/instantiate.ts
+++ b/src/type/engine/module/instantiate.ts
@@ -45,60 +45,66 @@ import { type TInstantiateType, InstantiateType } from '../instantiate.ts'
 // ------------------------------------------------------------------
 // InstantiateCyclics
 // ------------------------------------------------------------------
-type TInstantiateCyclics<Context extends TProperties, CyclicKeys extends string[], Result extends TProperties = {
-  [Key in Extract<keyof Context, CyclicKeys[number]>]: TInstantiateCyclic<Context, Key, Context[Key]>
-}> = Result
-function InstantiateCyclics<Context extends TProperties, CyclicKeys extends string[]>
-  (context: Context, cyclicKeys: [...CyclicKeys]):
-  TInstantiateCyclics<Context, CyclicKeys> {
-  const keys = Guard.Keys(context).filter(key => cyclicKeys.includes(key))
-  return keys.reduce((result, key) => {
-    return { ...result, [key]: InstantiateCyclic(context, key, context[key]) }
+type TInstantiateCyclics<Context extends TProperties, Declarations extends TProperties, CyclicKeys extends string[], 
+  DeclarationContext extends TProperties = Memory.TAssign<Context, Declarations>,
+  Result extends TProperties = {
+    [Key in Extract<keyof Declarations, CyclicKeys[number]>]: TInstantiateCyclic<DeclarationContext, Key, Declarations[Key]>
+  }
+> = Result
+function InstantiateCyclics<Context extends TProperties, Declarations extends TProperties, CyclicKeys extends string[]>
+  (context: Context, declarations: Declarations, cyclicKeys: [...CyclicKeys]):
+  TInstantiateCyclics<Context, Declarations, CyclicKeys> {
+  const declarationContext = Memory.Assign(context, declarations)
+  const declarationKeys = Guard.Keys(declarations).filter(key => cyclicKeys.includes(key))
+  return declarationKeys.reduce((result, key) => {
+    return { ...result, [key]: InstantiateCyclic(declarationContext, key, declarations[key]) }
   }, {}) as never
 }
 // ------------------------------------------------------------------
 // InstantiateNonCyclics
 // ------------------------------------------------------------------
-type TInstantiateNonCyclics<Context extends TProperties, CyclicKeys extends string[], Result extends TProperties = {
-  [Key in Exclude<keyof Context, CyclicKeys[number]>]: TInstantiateType<Context, TState<[], []>, Context[Key]>
-}> = Result
-function InstantiateNonCyclics<Context extends TProperties, CyclicKeys extends string[]>
-  (context: Context, cyclicKeys: [...CyclicKeys]):
-  TInstantiateCyclics<Context, CyclicKeys> {
-  const keys = Guard.Keys(context).filter(key => !cyclicKeys.includes(key))
-  return keys.reduce((result, key) => {
-    return { ...result, [key]: InstantiateType(context, State([], []), context[key]) }
+type TInstantiateNonCyclics<Context extends TProperties, Declarations extends TProperties, CyclicKeys extends string[], 
+  DeclarationContext extends TProperties = Memory.TAssign<Context, Declarations>,
+  Result extends TProperties = {
+    [Key in Exclude<keyof Declarations, CyclicKeys[number]>]: TInstantiateType<DeclarationContext, TState<[], []>, Declarations[Key]>
+  }
+> = Result
+function InstantiateNonCyclics<Context extends TProperties, Declarations extends TProperties, CyclicKeys extends string[]>
+  (context: Context, declarations: Declarations, cyclicKeys: [...CyclicKeys]):
+  TInstantiateCyclics<Context, Declarations, CyclicKeys> {
+  const declarationContext = Memory.Assign(context, declarations)
+  const declarationKeys = Guard.Keys(declarations).filter(key => !cyclicKeys.includes(key))
+  return declarationKeys.reduce((result, key) => {
+    return { ...result, [key]: InstantiateType(declarationContext, State([], []), declarations[key]) }
   }, {}) as never
 }
 // ------------------------------------------------------------------
 // InstantiateModule
 // ------------------------------------------------------------------
-type TInstantiateModule<Context extends TProperties,
-  CyclicCandidates extends string[] = TCyclicCandidates<Context>,
-  InstantiatedCyclics extends TProperties = TInstantiateCyclics<Context, CyclicCandidates>,
-  InstantiatedNonCyclics extends TProperties = TInstantiateNonCyclics<Context, CyclicCandidates>,
+type TInstantiateModule<Context extends TProperties, Declarations extends TProperties,
+  CyclicCandidates extends string[] = TCyclicCandidates<Declarations>,
+  InstantiatedCyclics extends TProperties = TInstantiateCyclics<Context, Declarations, CyclicCandidates>,
+  InstantiatedNonCyclics extends TProperties = TInstantiateNonCyclics<Context, Declarations, CyclicCandidates>,
   InstantiatedModule extends TProperties = InstantiatedCyclics & InstantiatedNonCyclics
 > = { [Key in keyof InstantiatedModule]: InstantiatedModule[Key] } & {} // safe: no-key-overlap
-function InstantiateModule<Context extends TProperties>
-  (context: Context, options: TSchemaOptions):
-  TInstantiateModule<Context> {
-  const cyclicCandidates = CyclicCandidates(context) as string[]
-  const instantiatedCyclics = InstantiateCyclics(context, cyclicCandidates)
-  const instantiatedNonCyclics = InstantiateNonCyclics(context, cyclicCandidates)
+function InstantiateModule<Context extends TProperties, Declarations extends TProperties>
+  (context: Context, declarations: Declarations, options: TSchemaOptions):
+  TInstantiateModule<Context, Declarations> {
+  const cyclicCandidates = CyclicCandidates(declarations) as string[]
+  const instantiatedCyclics = InstantiateCyclics(context, declarations, cyclicCandidates)
+  const instantiatedNonCyclics = InstantiateNonCyclics(context, declarations, cyclicCandidates)
   const instantiatedModule = { ...instantiatedCyclics, ...instantiatedNonCyclics }
   return Memory.Update(instantiatedModule, {}, options) as never
 }
 // ------------------------------------------------------------------
 // Instantiate
 // ------------------------------------------------------------------
-export type TModuleInstantiate<Context extends TProperties, _State extends TState, Properties extends TProperties,
-  ModuleContext extends TProperties = Memory.TAssign<Context, Properties>,
-  InstantiatedModule extends TProperties = TInstantiateModule<ModuleContext>,
+export type TModuleInstantiate<Context extends TProperties, _State extends TState, Declarations extends TProperties,
+  InstantiatedModule extends TProperties = TInstantiateModule<Context, Declarations>,
 > = InstantiatedModule
-export function ModuleInstantiate<Context extends TProperties, State extends TState, Properties extends TProperties>
-  (context: Context, _state: State, properties: Properties, options: TSchemaOptions):
-  TModuleInstantiate<Context, State, Properties> {
-  const moduleContext = Memory.Assign(context, properties)
-  const instantiatedModule = InstantiateModule(moduleContext, options)
+export function ModuleInstantiate<Context extends TProperties, State extends TState, Declarations extends TProperties>
+  (context: Context, _state: State, declarations: Declarations, options: TSchemaOptions):
+  TModuleInstantiate<Context, State, Declarations> {
+  const instantiatedModule = InstantiateModule(context, declarations, options)
   return instantiatedModule as never
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.2.4'
+const Version = '1.2.5'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/type/engine/action/module.ts
+++ b/test/typebox/runtime/type/engine/action/module.ts
@@ -328,3 +328,25 @@ Test('Should Module 21', () => {
   Assert.IsEqual(Guard.Keys(A.A5.$defs), ['A1', 'A2', 'A3', 'A5', 'A6'])
   Assert.IsEqual(Guard.Keys(A.A6.$defs), ['A1', 'A2', 'A3', 'A5', 'A6'])
 })
+// ------------------------------------------------------------------
+// Should Only Export Declarations, (Not Parameters)
+// ------------------------------------------------------------------
+Test('Should Module 22', () => {
+  const A = Type.String()
+  const B = Type.Number()
+  const C: {
+    C: Type.TUnion<[Type.TString, Type.TNumber]>
+  } = Type.Script(
+    { A, B },
+    `
+    type C = A | B  
+  `
+  )
+  Assert.NotHasPropertyKey(C, 'A')
+  Assert.NotHasPropertyKey(C, 'B')
+  Assert.HasPropertyKey(C, 'C')
+  Assert.IsTrue(Type.IsUnion(C.C))
+  Assert.IsTrue(Type.IsString(C.C.anyOf[0]))
+  Assert.IsTrue(Type.IsNumber(C.C.anyOf[1]))
+  Assert.IsEqual(Object.keys(C).length, 1)
+})


### PR DESCRIPTION
This PR updates Module Instantiation to ensure only Declarations are Output.

```typescript
const A = Type.Number()
const B = Type.Number()

// 1.2.4: Output types A, B + Declaration T (Incorrect)
const { A, B, T } = Type.Script({ A, B }, `
  type T = [A, B]
`)

// 1.2.5: Only Outputs Declaration T (Correct)
const { T } = Type.Script({ A, B }, `
  type T = [A, B]
`)
```