### PR TITLE
Version 1.2.9

### DIFF
--- a/changelog/1.2.0.md
+++ b/changelog/1.2.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.2.9](https://github.com/sinclairzx81/typebox/pull/1616)
+  - Ensure With\<T, ...\> Types Statically Evaluate
 - [Revision 1.2.8](https://github.com/sinclairzx81/typebox/pull/1614)
   - URN-prefixed UUID is Invalid [Reference](https://github.com/sinclairzx81/typebox/pull/1614)
 - [Revision 1.2.7](https://github.com/sinclairzx81/typebox/pull/1613)

--- a/src/type/engine/evaluate/distribute.ts
+++ b/src/type/engine/evaluate/distribute.ts
@@ -31,6 +31,7 @@ THE SOFTWARE.
 
 import { Guard } from '../../../guard/index.ts'
 import { type TSchema } from '../../types/schema.ts'
+import { type TProperties } from '../../types/properties.ts'
 import { type TUnion, IsUnion } from '../../types/union.ts'
 import { type TObject, IsObject } from '../../types/object.ts'
 import { type TTuple, IsTuple } from '../../types/tuple.ts'
@@ -41,10 +42,14 @@ import { type TEvaluateType, EvaluateType } from './evaluate.ts'
 import { type TEvaluateIntersect, EvaluateIntersect } from './evaluate.ts'
 
 // ------------------------------------------------------------------
-// IsObjectLike
+// IsObjectLike (We need explicit destructuring here to ensure
+// that wrapped TWith<T..> types can be observed as ObjectLike)
 // ------------------------------------------------------------------
-type TIsObjectLike<Type extends TSchema> 
-  = Type extends TObject | TTuple ? true : false
+type TIsObjectLike<Type extends TSchema> = (
+  Type extends TObject<infer _ extends TProperties> ? true :
+  Type extends TTuple<infer _ extends TSchema[]> ? true : 
+  false
+)
 function IsObjectLike<Type extends TSchema>(type: Type) {
   return IsObject(type) || IsTuple(type)
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.2.8'
+const Version = '1.2.9'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/type/engine/action/evaluate.ts
+++ b/test/typebox/runtime/type/engine/action/evaluate.ts
@@ -1212,3 +1212,61 @@ Test('Should Evaluate 109', () => {
   const T: Type.TString = Type.Evaluate(Type.TemplateLiteral('hello${string}'))
   Assert.IsTrue(Type.IsString(T))
 })
+// ------------------------------------------------------------------
+// With
+// ------------------------------------------------------------------
+Test('Should Evaluate 110', () => {
+  const A: Type.TWith<
+    Type.TObject<{
+      a: Type.TNumber
+      b: Type.TNumber
+    }>,
+    {
+      readonly foo: 1
+    }
+  > = Type.With(Type.Object({ a: Type.Number(), b: Type.Number() }), { foo: 1 })
+
+  const B: Type.TWith<
+    Type.TObject<{
+      c: Type.TNumber
+      d: Type.TNumber
+    }>,
+    {
+      readonly bar: 1
+    }
+  > = Type.With(Type.Object({ c: Type.Number(), d: Type.Number() }), { bar: 1 })
+
+  const C: Type.TWith<
+    Type.TObject<{
+      a: Type.TNumber
+      b: Type.TNumber
+      c: Type.TNumber
+      d: Type.TNumber
+    }>,
+    {
+      readonly baz: 1
+    }
+  > = Type.With(Type.Evaluate(Type.Intersect([A, B])), { baz: 1 })
+
+  Assert.IsTrue(Type.IsObject(A))
+  Assert.IsTrue(Type.IsNumber(A.properties.a))
+  Assert.IsTrue(Type.IsNumber(A.properties.b))
+  Assert.HasPropertyKey(A, 'foo')
+  Assert.IsEqual(A.foo, 1)
+
+  Assert.IsTrue(Type.IsObject(B))
+  Assert.IsTrue(Type.IsNumber(B.properties.c))
+  Assert.IsTrue(Type.IsNumber(B.properties.d))
+  Assert.HasPropertyKey(B, 'bar')
+  Assert.IsEqual(B.bar, 1)
+
+  Assert.IsTrue(Type.IsObject(C))
+  Assert.IsTrue(Type.IsNumber(C.properties.a))
+  Assert.IsTrue(Type.IsNumber(C.properties.b))
+  Assert.IsTrue(Type.IsNumber(C.properties.c))
+  Assert.IsTrue(Type.IsNumber(C.properties.d))
+  Assert.NotHasPropertyKey(C, 'foo')
+  Assert.NotHasPropertyKey(C, 'bar')
+  Assert.HasPropertyKey(C, 'baz')
+  Assert.IsEqual(C.baz, 1)
+})


### PR DESCRIPTION
This PR is a static-only fix for evaluated `With` types. The fix relates to object deconstructing during calls to distribute, and where With types were not detected as valid TObject/TTuple types.

```typescript
// 1.2.8: With types not detected here
type TIsObjectLike<Type extends TSchema> = (
  Type extends TObject | TTuple ? true : false
)

// 1.2.9: Ensure destructuring
type TIsObjectLike<Type extends TSchema> = (
  Type extends TObject<infer _ extends TProperties> ? true :
  Type extends TTuple<infer _ extends TSchema[]> ? true : 
  false
)
```

Where the update allows correct evaluation of wrapped `TWith<T, ...>` types

```typescript
// 1.2.8: T is { c: number, d: number }
const { T } = Type.Script(`
  type A = { a: number, b: number } with { foo: 1 }
  type B = { c: number, d: number } with { bar: 1 }
  type T = Evaluate<A & B>
`)

// 1.2.9: T is { a: number, b: number, c: number, d: number }
const { T } = Type.Script(`
  type A = { a: number, b: number } with { foo: 1 }
  type B = { c: number, d: number } with { bar: 1 }
  type T = Evaluate<A & B>
`)
```