### PR TITLE
Version 1.2.11

### DIFF
--- a/changelog/1.2.0.md
+++ b/changelog/1.2.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.2.11](https://github.com/sinclairzx81/typebox/pull/1619)
+  - Implement Extends Inference Logic for Record Types
 - [Revision 1.2.10](https://github.com/sinclairzx81/typebox/pull/1618)
   - Optimize Cyclic Detection for TS7 Nightly
 - [Revision 1.2.9](https://github.com/sinclairzx81/typebox/pull/1616)

--- a/example/algorithm/axioms.ts
+++ b/example/algorithm/axioms.ts
@@ -1,24 +1,38 @@
+/*--------------------------------------------------------------------------
+
+TypeBox
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2026 Haydn Paterson 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
 // ------------------------------------------------------------------
 //
-//   Peano Arithmetic: Formal Proofs via TypeBox Type.Script
+// Peano Axioms via Type.Script(...)
 //
-//   Proves properties of the natural numbers using only
-//   type-level computation. All propositions are verified at
-//   runtime by TypeBox's Script engine. A result of
-//   { type: "string", const: "QED" } means every proof holds.
+// https://en.wikipedia.org/wiki/Peano_axioms
 //
-//   Covers:
-//     - Basic arithmetic: Add, Mul, Exp
-//     - Predecessor and truncated subtraction (monus)
-//     - Order relations: Lte, Gt
-//     - Commutativity of Add and Mul (concrete witnesses)
-//     - Add and Sub are inverses
-//     - Associativity (concrete witnesses)
-//     - Exponentiation laws
-//     - Divisibility via explicit witnesses
-//     - Order properties of Exp
-//
-//   Completes in around 30 seconds
+// Compute Time: 30 seconds approx
 //
 // ------------------------------------------------------------------
 
@@ -137,7 +151,7 @@ const { Result } = Type.Script(`
       : false
 
   // --------------------------------------------------------------
-  // Chapter 1: Basic arithmetic
+  // Basic arithmetic
   // --------------------------------------------------------------
 
   type P1  = Equal<Add<N2, N2>, N4>          // 2 + 2 = 4
@@ -147,7 +161,7 @@ const { Result } = Type.Script(`
   type P5  = Equal<Exp<N3, N3>, N27>         // 3^3 = 27
 
   // --------------------------------------------------------------
-  // Chapter 2: Identity elements
+  // Identity elements
   // --------------------------------------------------------------
 
   type P6  = Equal<Add<N0, N3>, N3>          // 0 + 3 = 3
@@ -156,14 +170,14 @@ const { Result } = Type.Script(`
   type P9  = Equal<Exp<N3, N0>, N1>          // 3^0 = 1
 
   // --------------------------------------------------------------
-  // Chapter 3: Commutativity (concrete witnesses)
+  // Commutativity (concrete witnesses)
   // --------------------------------------------------------------
 
   type P10 = Equal<Add<N1, N2>, Add<N2, N1>> // 1+2 = 2+1
   type P11 = Equal<Mul<N2, N3>, Mul<N3, N2>> // 2*3 = 3*2
 
   // --------------------------------------------------------------
-  // Chapter 4: Associativity (concrete witnesses)
+  // Associativity (concrete witnesses)
   // --------------------------------------------------------------
 
   // (1 + 2) + 3 = 1 + (2 + 3)
@@ -179,7 +193,7 @@ const { Result } = Type.Script(`
   >
 
   // --------------------------------------------------------------
-  // Chapter 5: Predecessor and subtraction
+  // Predecessor and subtraction
   // --------------------------------------------------------------
 
   type P14 = Equal<Pred<N4>, N3>             // Pred(4) = 3
@@ -188,7 +202,7 @@ const { Result } = Type.Script(`
   type P17 = Equal<Sub<N3, N5>, N0>          // 3 - 5 = 0 (monus)
 
   // --------------------------------------------------------------
-  // Chapter 6: Add and Sub are inverses
+  // Add and Sub are inverses
   // --------------------------------------------------------------
 
   // (3 + 4) - 4 = 3
@@ -199,7 +213,7 @@ const { Result } = Type.Script(`
   type P20 = Equal<Add<Sub<N7, N3>, N3>, N7>
 
   // --------------------------------------------------------------
-  // Chapter 7: Order relations
+  // Order relations
   // --------------------------------------------------------------
 
   type P21 = Lte<N2, N5>                     // 2 <= 5
@@ -210,7 +224,7 @@ const { Result } = Type.Script(`
   type P26 = Gt<Mul<N2, N3>, N4>             // 6 > 4
 
   // --------------------------------------------------------------
-  // Chapter 8: Exponentiation laws
+  // Exponentiation laws
   // --------------------------------------------------------------
 
   // 2^2 * 2^2 = 2^4   (A^M * A^N = A^(M+N))
@@ -227,7 +241,7 @@ const { Result } = Type.Script(`
   type P31 = Lte<Exp<N2, N4>, Exp<N3, N3>>  // 16 < 27
 
   // --------------------------------------------------------------
-  // Chapter 9: Divisibility witnesses
+  // Divisibility witnesses
   // --------------------------------------------------------------
 
   type P32 = Divides<N3, N3, N9>             // 3 | 9
@@ -237,7 +251,7 @@ const { Result } = Type.Script(`
   type P36 = Divides<N2, N8, N16>            // 2 | 16
 
   // --------------------------------------------------------------
-  // Conjunction of all proofs
+  // Results
   // --------------------------------------------------------------
 
   type All =

--- a/src/guard/guard.ts
+++ b/src/guard/guard.ts
@@ -182,8 +182,8 @@ export function EveryAll<T>(value: T[], offset: number, callback: (value: T, ind
   }
   return result
 }
-/** Takes the left-most element from an array and dispatches to the true arm, or the false arm if empty */
-export function TakeLeft<T, True extends (left: T, right: T[]) => unknown, False extends () => unknown>(array: T[], true_: True, false_: False): ReturnType<True> | ReturnType<False> {
+/** Shifts the left-most element from an array and dispatches to the true arm, or the false arm if empty */
+export function ShiftLeft<T, True extends (left: T, right: T[]) => unknown, False extends () => unknown>(array: T[], true_: True, false_: False): ReturnType<True> | ReturnType<False> {
   return (IsEqual(array.length, 0) ? false_() : true_(array[0], array.slice(1))) as never
 }
 // --------------------------------------------------------------------------

--- a/src/type/engine/call/distribute_arguments.ts
+++ b/src/type/engine/call/distribute_arguments.ts
@@ -114,8 +114,8 @@ type TZipDistributionArray<Arguments extends TSchema[], DistributionArray extend
 function ZipDistributionArray<Arguments extends TSchema[], DistributionArray extends boolean[]>
   (arguments_: [...Arguments], distributionArray: [...DistributionArray], result: [boolean, TSchema][] = []):
   TZipDistributionArray<Arguments, DistributionArray> {
-  return Guard.TakeLeft(arguments_, (argumentLeft, argumentRight) => 
-    Guard.TakeLeft(distributionArray, (booleanLeft, booleanRight) => 
+  return Guard.ShiftLeft(arguments_, (argumentLeft, argumentRight) => 
+    Guard.ShiftLeft(distributionArray, (booleanLeft, booleanRight) => 
       ZipDistributionArray(argumentRight as never, booleanRight as never, [...result, [booleanLeft, argumentLeft]]),
       () => result),
     () => result) as never

--- a/src/type/engine/call/resolve_arguments.ts
+++ b/src/type/engine/call/resolve_arguments.ts
@@ -77,7 +77,7 @@ function BindArguments<Context extends TProperties, State extends TState, Parame
     TBindArguments<Context, State, ParameterLeft, ParameterRight, Arguments> {
   const instantiatedExtends = InstantiateType(context, state, parameterLeft.extends)
   const instantiatedEquals = InstantiateType(context, state, parameterLeft.equals)
-  return Guard.TakeLeft(arguments_, (left, right) => 
+  return Guard.ShiftLeft(arguments_, (left, right) => 
     BindParameters(BindArgument(context, state, parameterLeft['name'], instantiatedExtends, left), state, parameterRight, right),
     () => BindParameters(BindArgument(context, state, parameterLeft['name'], instantiatedExtends, instantiatedEquals), state, parameterRight, [])
   ) as never
@@ -93,7 +93,7 @@ type TBindParameters<Context extends TProperties, State extends TState, Paramete
 function BindParameters<Context extends TProperties, State extends TState, Parameters extends TParameter[], Arguments extends TSchema[]>
   (context: Context, state: State, parameters: [...Parameters], arguments_: [...Arguments]):
     TBindParameters<Context, State, Parameters, Arguments> {
-  return Guard.TakeLeft(parameters, (left, right) => 
+  return Guard.ShiftLeft(parameters, (left, right) => 
     BindArguments(context, state, left, right, arguments_),
     () => context
   ) as never

--- a/src/type/engine/cyclic/check.ts
+++ b/src/type/engine/cyclic/check.ts
@@ -89,7 +89,7 @@ type TFromTypes<Stack extends (keyof Context)[], Context extends TProperties, Ty
 function FromTypes<Stack extends (keyof Context)[], Context extends TProperties, Types extends TSchema[]>
   (stack: [...Stack], context: Context, types: [...Types]):
     TFromTypes<Stack, Context, Types> {
-  return Guard.TakeLeft(types, (left, right) => 
+  return Guard.ShiftLeft(types, (left, right) => 
     FromType(stack, context, left)
       ? true
       : FromTypes(stack, context, right),

--- a/src/type/engine/evaluate/distribute.ts
+++ b/src/type/engine/evaluate/distribute.ts
@@ -110,7 +110,7 @@ type TDistributeType<Type extends TSchema, Distribution extends TSchema[], Resul
       : Result
 )
 function DistributeType<Type extends TSchema, Distribution extends TSchema[]>(type: Type, types: [...Distribution], result: TSchema[] = []): TDistributeType<Type, Distribution> {
-  return Guard.TakeLeft(types, (left, right) => 
+  return Guard.ShiftLeft(types, (left, right) => 
     DistributeType(type, right, [...result, DistributeOperation(type, left)]),
     () => Guard.IsEqual(result.length, 0)
       ? [type]
@@ -125,7 +125,7 @@ type TDistributeUnion<Types extends TSchema[], Distribution extends TSchema[], R
    : Result
 )
 function DistributeUnion<Types extends TSchema[], Distribution extends TSchema[]>(types: [...Types], distribution: [...Distribution], result: TSchema[] = []): TDistributeUnion<Types, Distribution> {
-  return Guard.TakeLeft(types, (left, right) => 
+  return Guard.ShiftLeft(types, (left, right) => 
     DistributeUnion(right, distribution, [...result, ...Distribute([left], distribution)]),
     () => result) as never
 }
@@ -140,7 +140,7 @@ export type TDistribute<Types extends TSchema[], Result extends TSchema[] = []> 
     : Result
 )
 export function Distribute<Types extends TSchema[]>(types: [...Types], result: TSchema[] = []): TDistribute<Types> {
-  return Guard.TakeLeft(types, (left, right) => 
+  return Guard.ShiftLeft(types, (left, right) => 
     IsUnion(left)
       ? Distribute(right, DistributeUnion(left.anyOf, result))
       : Distribute(right, DistributeType(left, result)),

--- a/src/type/engine/instantiate.ts
+++ b/src/type/engine/instantiate.ts
@@ -123,7 +123,7 @@ export type TCanInstantiate<Types extends TSchema[]> =
   : TCanInstantiate<Right>
   : true
 export function CanInstantiate<Types extends TSchema[]>(types: [...Types]): TCanInstantiate<Types> {
-  return Guard.TakeLeft(types, (left, right) =>
+  return Guard.ShiftLeft(types, (left, right) =>
     IsRef(left)
       ? false
       : CanInstantiate(right),

--- a/src/type/engine/object/from_union.ts
+++ b/src/type/engine/object/from_union.ts
@@ -64,7 +64,7 @@ type TReduceVariants<Types extends TSchema[], Result extends TProperties> = (
 function ReduceVariants<Types extends TSchema[], Result extends TProperties>
   (types: [...Types], result: Result):
   TReduceVariants<Types, Result> {
-  return Guard.TakeLeft(types, (left, right) =>
+  return Guard.ShiftLeft(types, (left, right) =>
     ReduceVariants(right, CollapseUnionProperties(result, FromType(left))),
     () => result) as never
 }
@@ -85,7 +85,7 @@ export type TFromUnion<Types extends TSchema[]> = (
 export function FromUnion<Types extends TSchema[]>
   (types: [...Types]):
   TFromUnion<Types> {
-  return Guard.TakeLeft(types, (left, right) =>
+  return Guard.ShiftLeft(types, (left, right) =>
     ReduceVariants(right, FromType(left)),
     () => Unreachable()) as never
 }

--- a/src/type/engine/template_literal/decode.ts
+++ b/src/type/engine/template_literal/decode.ts
@@ -50,7 +50,7 @@ type TFromLiteralPush<Variants extends string[], Value extends TLiteralValue, Re
   : Result
 
 function FromLiteralPush<Variants extends string[], Value extends TLiteralValue>(variants: [...Variants], value: Value, result: string[] = []): TFromLiteralPush<Variants, Value> {
-  return Guard.TakeLeft(variants, (left, right) =>
+  return Guard.ShiftLeft(variants, (left, right) =>
     FromLiteralPush(right, value, [...result, `${left}${value}`]),
     () => result) as never
 }
@@ -68,7 +68,7 @@ type TFromUnion<Variants extends string[], Types extends TSchema[], Result exten
   ? TFromUnion<Variants, Right, [...Result, ...TFromType<Variants, Left>]>
   : Result
 function FromUnion<Variants extends string[], Types extends TSchema[]>(variants: [...Variants], types: [...Types], result: string[] = []): TFromUnion<Variants, Types> {
-  return Guard.TakeLeft(types, (left, right) =>
+  return Guard.ShiftLeft(types, (left, right) =>
     FromUnion(variants, right, [...result, ...FromType(variants, left)]),
     () => result
   ) as never
@@ -110,7 +110,7 @@ type TDecodeFromSpan<Variants extends string[], Types extends TSchema[]> =
   ? TDecodeFromSpan<TFromType<Variants, Left>, Right>
   : Variants
 function DecodeFromSpan<Variants extends string[], Types extends TSchema[]>(variants: [...Variants], types: [...Types]): TDecodeFromSpan<Variants, Types> {
-  return Guard.TakeLeft(types, (left, right) =>
+  return Guard.ShiftLeft(types, (left, right) =>
     DecodeFromSpan(FromType(variants, left) as string[], right),
     () => variants) as never
 }

--- a/src/type/engine/template_literal/encode.ts
+++ b/src/type/engine/template_literal/encode.ts
@@ -188,7 +188,7 @@ type TEncodeUnion<Types extends TSchema[], Right extends TSchema[], Pattern exte
 function EncodeUnion<Types extends TSchema[], Right extends TSchema[], Pattern extends string>
   (types: [...Types], right: Right, pattern: Pattern, result: string[] = []): 
     TEncodeUnion<Types, Right, Pattern> {
-  return Guard.TakeLeft(types, (head, tail) => 
+  return Guard.ShiftLeft(types, (head, tail) => 
     EncodeUnion(tail, right, pattern, [...result, EncodeType(head, [], '')]),
     () => EncodeTypes(right, `${pattern}(${JoinString(result)})`)) as never
 }
@@ -235,7 +235,7 @@ type TEncodeTypes<Types extends TSchema[], Pattern extends string> = (
 )
 function EncodeTypes<Types extends TSchema[], Pattern extends string>
   (types: [...Types], pattern: Pattern): TEncodeTypes<Types, Pattern> {
-  return Guard.TakeLeft(types, (left, right) => 
+  return Guard.ShiftLeft(types, (left, right) => 
     EncodeType(left, right, pattern),
     () => pattern) as never
 }

--- a/src/type/engine/template_literal/is_finite.ts
+++ b/src/type/engine/template_literal/is_finite.ts
@@ -51,7 +51,7 @@ type TFromTypesReduce<Types extends TSchema[]> = (
   : true
 )
 function FromTypesReduce<Types extends TSchema[]>(types: [...Types]): TFromTypesReduce<Types> {
-  return Guard.TakeLeft(types, (left, right) =>
+  return Guard.ShiftLeft(types, (left, right) =>
     FromType(left)
       ? FromTypesReduce(right)
       : false,

--- a/src/type/extends/extends_left.ts
+++ b/src/type/extends/extends_left.ts
@@ -46,6 +46,7 @@ import { type TExtendsNull, ExtendsNull } from './null.ts'
 import { type TExtendsNumber, ExtendsNumber } from './number.ts'
 import { type TExtendsObject, ExtendsObject } from './object.ts'
 import { type TExtendsPromise, ExtendsPromise } from './promise.ts'
+import { type TExtendsRecord, ExtendsRecord } from './record.ts'
 import { type TExtendsString, ExtendsString } from './string.ts'
 import { type TExtendsSymbol, ExtendsSymbol } from './symbol.ts'
 import { type TExtendsTemplateLiteral, ExtendsTemplateLiteral } from './template_literal.ts'
@@ -76,6 +77,7 @@ import { type TNull, IsNull } from '../types/null.ts'
 import { type TNumber, IsNumber } from '../types/number.ts'
 import { type TObject, IsObject } from '../types/object.ts'
 import { type TPromise, IsPromise } from '../types/promise.ts'
+import { type TRecord, IsRecord, RecordPattern, RecordValue } from '../types/record.ts'
 import { type TSchema } from '../types/schema.ts'
 import { type TString, IsString } from '../types/string.ts'
 import { type TSymbol, IsSymbol } from '../types/symbol.ts'
@@ -111,6 +113,7 @@ export type TExtendsLeft<Inferred extends TProperties, Left extends TSchema, Rig
   Left extends TNumber ? TExtendsNumber<Inferred, Left, Right> :
   Left extends TObject<infer Properties extends TProperties> ? TExtendsObject<Inferred, Properties, Right> :
   Left extends TPromise<infer Type extends TSchema> ? TExtendsPromise<Inferred, Type, Right> :
+  Left extends TRecord<infer Pattern extends string, infer Value extends TSchema> ? TExtendsRecord<Inferred, Pattern, Value, Right> :
   Left extends TString ? TExtendsString<Inferred, Left, Right> :
   Left extends TSymbol ? TExtendsSymbol<Inferred, Left, Right> :
   Left extends TTemplateLiteral<infer Pattern extends string> ? TExtendsTemplateLiteral<Inferred, Pattern, Right> :
@@ -143,6 +146,7 @@ export function ExtendsLeft<Inferred extends TProperties, Left extends TSchema, 
     IsNumber(left) ? ExtendsNumber(inferred, left, right) :
     IsObject(left) ? ExtendsObject(inferred, left.properties, right) :
     IsPromise(left) ? ExtendsPromise(inferred, left.item, right) :
+    IsRecord(left) ? ExtendsRecord(inferred, RecordPattern(left), RecordValue(left), right) :
     IsString(left) ? ExtendsString(inferred, left, right) :
     IsSymbol(left) ? ExtendsSymbol(inferred, left, right) :
     IsTemplateLiteral(left) ? ExtendsTemplateLiteral(inferred, left.pattern, right) :

--- a/src/type/extends/extends_right.ts
+++ b/src/type/extends/extends_right.ts
@@ -131,7 +131,7 @@ type TExtendsRightIntersect<Inferred extends TProperties, Left extends TSchema, 
 function ExtendsRightIntersect<Inferred extends TProperties, Left extends TSchema, Right extends TSchema[]>
   (inferred: Inferred, left: Left, right: Right): 
     TExtendsRightIntersect<Inferred, Left, Right> {
-  return Guard.TakeLeft(right, (head, tail) => 
+  return Guard.ShiftLeft(right, (head, tail) => 
     Result.Match(ExtendsLeft(inferred, left, head),
       inferred => ExtendsRightIntersect(inferred, left, tail),
       () => Result.ExtendsFalse()),
@@ -162,7 +162,7 @@ type TExtendsRightUnion<Inferred extends TProperties, Left extends TSchema, Righ
 function ExtendsRightUnion<Inferred extends TProperties, Left extends TSchema, Right extends TSchema[]>
   (inferred: Inferred, left: Left, right: Right):
   TExtendsRightUnion<Inferred, Left, Right> {
-  return Guard.TakeLeft(right, (head, tail) =>
+  return Guard.ShiftLeft(right, (head, tail) =>
     Result.Match(ExtendsLeft(inferred, left, head),
       inferred => Result.ExtendsTrue(inferred),
       () => ExtendsRightUnion(inferred, left, tail)),

--- a/src/type/extends/inference.ts
+++ b/src/type/extends/inference.ts
@@ -146,7 +146,7 @@ type TryInferResults<Rest extends TSchema[], Right extends TSchema, Result exten
     : Result
 )
 function TryInferResults<Rest extends TSchema[], Right extends TSchema>(rest: [...Rest], right: Right, result: TSchema[] = []): TryInferResults<Rest, Right> {
-  return Guard.TakeLeft(rest, (head, tail) =>
+  return Guard.ShiftLeft(rest, (head, tail) =>
     Result.Match(ExtendsLeft({}, head, right),
       () => TryInferResults(tail, right, [...result, head]),
       () => undefined),

--- a/src/type/extends/object.ts
+++ b/src/type/extends/object.ts
@@ -39,6 +39,9 @@ import { type TOptional, IsOptional } from '../types/_optional.ts'
 import { type TInfer, IsInfer } from '../types/infer.ts'
 import { type TNever, IsNever } from '../types/never.ts'
 import { type TObject, IsObject, Object } from '../types/object.ts'
+import { type TRecord, IsRecord, RecordPattern, RecordValue } from '../types/record.ts'
+import { type TUnion, Union, IsUnion } from '../types/union.ts'
+
 import { type TExtendsLeft, ExtendsLeft } from './extends_left.ts'
 import { type TExtendsRight, ExtendsRight } from './extends_right.ts'
 import { type TUnionToTuple } from '../engine/helpers/union.ts'
@@ -51,8 +54,8 @@ import * as Result from './result.ts'
 type TExtendsPropertyOptional<Inferred extends TProperties, Left extends TSchema, Right extends TSchema> = (
   Left extends TOptional<Left>
   ? Right extends TOptional<Right>
-  ? Result.TExtendsTrue<Inferred>
-  : Result.TExtendsFalse
+    ? Result.TExtendsTrue<Inferred>
+    : Result.TExtendsFalse
   : Result.TExtendsTrue<Inferred>
 )
 function ExtendsPropertyOptional<Inferred extends TProperties, Left extends TSchema, Right extends TSchema>
@@ -248,23 +251,90 @@ function ExtendsObjectToObject<Inferred extends TProperties, Left extends TPrope
     TExtendsObjectToObject<Inferred, Left, Right> {
   return ExtendsProperties(inferred, left, right) as never
 }
+
 // ----------------------------------------------------------------------------
-// ExtendsObjectToObject
+// ObjectToRecord
 //
-// todo: Tuples can be inferred as Object. We can Transform Tuple to Object
-// to perform this check.
+// It should be possible to unify this logic, specifically the property
+// level extends checks and inferred merge logic. To be honest, this
+// entire module needs to be cleaned up. Consider computing a forward
+// "Entries" data structure that can be uniformly compared for both
+// Object and Record comparisons. This also has some cross over with
+// Indexed and KeyOf operators which could also benefit from unified
+// 'Entry' enumeration. (review)
+//
+// ----------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------
+// RecordMergeInferred
+// ----------------------------------------------------------------------------
+type TRecordMergeInferred<Left extends TProperties, Right extends TProperties,
+  Result extends TProperties = {
+    [Key in keyof Right]: Key extends keyof Left
+      ? Left[Key] extends TUnion<infer Types extends TSchema[]>
+        ? TUnion<[...Types, Right[Key]]>
+        : TUnion<[Left[Key], Right[Key]]>
+      : Right[Key]
+}> = Result
+function RecordMergeInferred<Left extends TProperties, Right extends TProperties>
+  (left: Left, right: Right): TRecordMergeInferred<Left, Right> {
+  return Guard.Keys(right).reduce<TProperties>((result, key) => {
+    return {
+      ...result, [key]: Guard.HasPropertyKey(left, key)
+        ? IsUnion(result[key])
+          // @ts-ignore 5.0.4 cannot see `.anyOf`
+          ? Union([...result[key].anyOf, right[key]])
+          : Union([left[key], right[key]])
+        : right[key]
+    }
+  }, left) as never
+}
+// ----------------------------------------------------------------------------
+// ExtendsRecordComparer
+// ----------------------------------------------------------------------------
+type TExtendsRecordComparer<Properties extends TProperties, Keys extends (keyof Properties)[], Type extends TSchema, Result extends TProperties> = (
+  Keys extends [infer Left extends (keyof Properties), ...infer Right extends (keyof Properties)[]]
+    ? TExtendsLeft<{}, Properties[Left], Type> extends Result.TExtendsTrueLike<infer Inferred extends TProperties>
+      ? TExtendsRecordComparer<Properties, Right, Type, TRecordMergeInferred<Result, Inferred>> 
+      : Result.TExtendsFalse
+    : Result.TExtendsTrue<Result>
+)
+function ExtendsRecordComparer<Properties extends TProperties, Keys extends (keyof Properties)[], Type extends TSchema, Result extends TProperties>
+ (properties: Properties, keys: Keys, type: Type, result: Result): TExtendsRecordComparer<Properties, Keys, Type, Result> {
+  return Guard.ShiftLeft(keys, (left, right) => 
+    Result.Match(ExtendsLeft({}, properties[left], type), inferred => 
+      ExtendsRecordComparer(properties, right, type, RecordMergeInferred(result, inferred)),
+      () => Result.ExtendsFalse()),
+    () => Result.ExtendsTrue(result)) as never
+}
+// ----------------------------------------------------------------------------
+// ExtendsObjectToRecord
+// ----------------------------------------------------------------------------
+type TExtendsObjectToRecord<Inferred extends TProperties, Properties extends TProperties, _Pattern extends string, Value extends TSchema,
+  Keys extends (keyof Properties)[] = TUnionToTuple<keyof Properties>,
+  Result extends  Result.TResult = TExtendsRecordComparer<Properties, Keys, Value, Inferred>
+> = Result
+function ExtendsObjectToRecord<Inferred extends TProperties, Properties extends TProperties, Pattern extends string, Value extends TSchema>
+  (inferred: Inferred, properties: Properties, _pattern: Pattern, value: Value):
+    TExtendsObjectToRecord<Inferred, Properties, Pattern, Value> {
+  const keys = Guard.Keys(properties)
+  const result = ExtendsRecordComparer(properties, keys, value, inferred)
+  return result as never
+}
+// ----------------------------------------------------------------------------
+// ExtendsObject
 // ----------------------------------------------------------------------------
 export type TExtendsObject<Inferred extends TProperties, Left extends TProperties, Right extends TSchema> = (
-  Right extends TObject<infer Properties extends TProperties>
-  ? TExtendsObjectToObject<Inferred, Left, Properties>
-  : TExtendsRight<Inferred, TObject<Left>, Right>
+  Right extends TRecord<infer Pattern extends string, infer Value extends TSchema> ? TExtendsObjectToRecord<Inferred, Left, Pattern, Value> : 
+  Right extends TObject<infer Properties extends TProperties> ? TExtendsObjectToObject<Inferred, Left, Properties> : 
+  TExtendsRight<Inferred, TObject<Left>, Right>
 )
 export function ExtendsObject<Inferred extends TProperties, Left extends TProperties, Right extends TSchema>
   (inferred: Inferred, left: Left, right: Right): 
     TExtendsObject<Inferred, Left, Right> {
   return (
-    IsObject(right)
-      ? ExtendsObjectToObject(inferred, left, right.properties)
-      : ExtendsRight(inferred, Object(left), right)
+    IsRecord(right) ? ExtendsObjectToRecord(inferred, left, RecordPattern(right), RecordValue(right)) : 
+    IsObject(right) ? ExtendsObjectToObject(inferred, left, right.properties) : 
+    ExtendsRight(inferred, Object(left), right)
   ) as never
 }

--- a/src/type/extends/parameters.ts
+++ b/src/type/extends/parameters.ts
@@ -81,7 +81,7 @@ type TParameterRight<Inferred extends TProperties, Left extends TSchema, LeftRes
 function ParameterRight<Inferred extends TProperties, Left extends TSchema, LeftRest extends TSchema[], RightRest extends TSchema[]>
   (inferred: Inferred, left: Left, leftRest: LeftRest, rightRest: RightRest):
   TParameterRight<Inferred, Left, LeftRest, RightRest> {
-  return Guard.TakeLeft(rightRest, (head, tail) =>
+  return Guard.ShiftLeft(rightRest, (head, tail) =>
     ParameterCompare(inferred, left, leftRest, head, tail),
     () => IsOptional(left)                // 'right-did-not-have-enough-elements'
       ? Result.ExtendsTrue(inferred)      // 'ok: left was optional'
@@ -98,7 +98,7 @@ type TParameterLeft<Inferred extends TProperties, LeftRest extends TSchema[], Ri
 function ParametersLeft<Inferred extends TProperties, Left extends TSchema[], Right extends TSchema[]>
   (inferred: Inferred, left: Left, rightRest: Right): 
     TParameterLeft<Inferred, Left, Right> {
-  return Guard.TakeLeft(left, (head, tail) => 
+  return Guard.ShiftLeft(left, (head, tail) => 
     ParameterRight(inferred, head, tail, rightRest),
     () => Result.ExtendsTrue(inferred)) as never // 'ok: no-more-elements-in-left'
 }

--- a/src/type/extends/record.ts
+++ b/src/type/extends/record.ts
@@ -1,0 +1,85 @@
+/*--------------------------------------------------------------------------
+
+TypeBox
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2026 Haydn Paterson 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
+// deno-fmt-ignore-file
+
+import { Guard } from '../../guard/index.ts'
+import { type TSchema } from '../types/schema.ts'
+import { type TProperties } from '../types/properties.ts'
+import { type TAny, IsAny } from '../types/any.ts'
+import { type TUnknown, IsUnknown } from '../types/unknown.ts'
+import { type TObject, IsObject } from '../types/object.ts'
+import { type TRecordPatternToType,  type TRecord, IsRecord, RecordPatternToType, RecordPattern, RecordValue } from '../types/record.ts'
+import { type TExtendsLeft, ExtendsLeft } from './extends_left.ts'
+import * as Result from './result.ts'
+
+// ------------------------------------------------------------------
+// FromObject
+// ------------------------------------------------------------------
+export type TFromObject<Inferred extends TProperties, Properties extends TProperties> = 
+  keyof Properties extends never
+    ? Result.TExtendsTrue<Inferred>
+    : Result.TExtendsFalse
+function FromObject<Inferred extends TProperties, Properties extends TProperties>
+  (inferred: Inferred, properties: Properties): TFromObject<Inferred, Properties> {
+  return (Guard.IsEqual(Guard.Keys(properties).length, 0)
+    ? Result.ExtendsTrue(inferred)
+    : Result.ExtendsFalse()) as never
+}
+// ------------------------------------------------------------------
+// FromRecord
+// ------------------------------------------------------------------
+type TFromRecord<Inferred extends TProperties, _LeftKey extends TSchema, LeftValue extends TSchema, _RightKey extends TSchema, RightValue extends TSchema> = (
+  TExtendsLeft<Inferred, LeftValue, RightValue>
+)
+function FromRecord<Inferred extends TProperties, LeftKey extends TSchema, LeftValue extends TSchema, RightKey extends TSchema, RightValue extends TSchema>
+  (inferred: Inferred, _leftKey: LeftKey, leftValue: LeftValue, _rightKey: RightKey, rightValue: RightValue): 
+    TFromRecord<Inferred, LeftKey, LeftValue, RightKey, RightValue> {
+  return ExtendsLeft(inferred, leftValue, rightValue) as never
+}
+// ------------------------------------------------------------------
+// Extends
+// ------------------------------------------------------------------
+export type TExtendsRecord<Inferred extends TProperties, LeftPattern extends string, LeftValue extends TSchema, Right extends TSchema> = (
+  Right extends TRecord<infer Pattern extends string, infer Value extends TSchema> ? TFromRecord<Inferred, TRecordPatternToType<LeftPattern>, LeftValue, TRecordPatternToType<Pattern>, Value> :
+  Right extends TObject<infer Properties extends TProperties> ? TFromObject<Inferred, Properties> :
+  Right extends TAny ? Result.TExtendsTrue<Inferred> :
+  Right extends TUnknown ? Result.TExtendsTrue<Inferred> :
+  Result.TExtendsFalse
+)
+export function ExtendsRecord<Inferred extends TProperties, Pattern extends string, Value extends TSchema, Right extends TSchema>
+  (inferred: Inferred, leftPattern: Pattern, leftValue: Value, right: Right): 
+    TExtendsRecord<Inferred, Pattern, Value, Right> {
+  return (
+    IsRecord(right) ? FromRecord(inferred, RecordPatternToType(leftPattern), leftValue, RecordPatternToType(RecordPattern(right)), RecordValue(right)) :
+    IsObject(right) ? FromObject(inferred, right.properties) :
+    IsAny(right) ? Result.ExtendsTrue(inferred) :
+    IsUnknown(right) ? Result.ExtendsTrue(inferred) :
+    Result.ExtendsFalse()
+  ) as never
+}

--- a/src/type/extends/tuple.ts
+++ b/src/type/extends/tuple.ts
@@ -151,7 +151,7 @@ function ElementsLeft<Inferred extends TProperties, Reversed extends boolean, Le
     // Rest Inferrable Right Means we delegate to TInferTupleResult to Generate a Result
     IsInferable(inferable)
       ? InferTupleResult(inferred, inferable['name'], ApplyReverse(leftRest, reversed), inferable['type'])
-      : Guard.TakeLeft(leftRest, (head, tail) => 
+      : Guard.ShiftLeft(leftRest, (head, tail) => 
         ElementsCompare(inferred, reversed, head, tail, right, rightRest),
         () => Result.ExtendsFalse())
   ) as never
@@ -182,7 +182,7 @@ type TElementsRight<Inferred extends TProperties, Reversed extends boolean, Left
 function ElementsRight<Inferred extends TProperties, Reversed extends boolean, LeftRest extends TSchema[], RightRest extends TSchema[]>
   (inferred: Inferred, reversed: Reversed, leftRest: [...LeftRest], rightRest: [...RightRest]):
   TElementsRight<Inferred, Reversed, LeftRest, RightRest> {
-  return Guard.TakeLeft(rightRest, (head, tail) =>
+  return Guard.ShiftLeft(rightRest, (head, tail) =>
     ElementsLeft(inferred, reversed, leftRest, head, tail),
     () => Guard.IsEqual(leftRest.length, 0)
       ? Result.ExtendsTrue(inferred)     // 'Ok: right-empty-and-left-empty'
@@ -234,7 +234,7 @@ function ExtendsTupleToArray<Inferred extends TProperties, Left extends TSchema[
   return (
     IsInferable(inferrable)
       ? InferUnionResult(inferred, inferrable['name'], left, inferrable['type'])
-      : Guard.TakeLeft(left, (head, tail) => 
+      : Guard.ShiftLeft(left, (head, tail) => 
         Result.Match(ExtendsLeft(inferred, head, right), inferred => 
           ExtendsTupleToArray(inferred, tail, right),
           () => Result.ExtendsFalse()),

--- a/src/type/extends/union.ts
+++ b/src/type/extends/union.ts
@@ -57,7 +57,7 @@ type TExtendsUnionSome<Inferred extends TProperties, Type extends TSchema, Union
 function ExtendsUnionSome<Inferred extends TProperties, Type extends TSchema, UnionTypes extends TSchema[]>
   (inferred: Inferred, type: Type, unionTypes: [...UnionTypes]): 
     TExtendsUnionSome<Inferred, Type, UnionTypes> {
-  return Guard.TakeLeft(unionTypes, (head, tail) => 
+  return Guard.ShiftLeft(unionTypes, (head, tail) => 
     Result.Match(ExtendsLeft(inferred, type, head), inferred => 
       Result.ExtendsTrue(inferred),
       () => ExtendsUnionSome(inferred, type, tail)),
@@ -74,7 +74,7 @@ type TExtendsUnionLeft<Inferred extends TProperties, Left extends TSchema[], Rig
   : Result.TExtendsTrue<Inferred>
 )
 function ExtendsUnionLeft<Inferred extends TProperties, Left extends TSchema[], Right extends TSchema[]>(inferred: Inferred, left: [...Left], right: [...Right]): TExtendsUnionLeft<Inferred, Left, Right> {
-  return Guard.TakeLeft(left, (head, tail) => 
+  return Guard.ShiftLeft(left, (head, tail) => 
     Result.Match(ExtendsUnionSome(inferred, head, right), inferred => 
       ExtendsUnionLeft(inferred, tail, right),
       () => Result.ExtendsFalse()),

--- a/src/type/script/token/internal/guard.ts
+++ b/src/type/script/token/internal/guard.ts
@@ -28,7 +28,7 @@ THE SOFTWARE.
 
 // deno-coverage-ignore-start - parsebox tested
 
-export { IsArray, IsEqual, IsString, TakeLeft } from '../../../../guard/guard.ts'
+export { IsArray, IsEqual, IsString, ShiftLeft } from '../../../../guard/guard.ts'
 
 // ------------------------------------------------------------------
 // Internal Guards to ensure Token is portable.

--- a/src/type/script/token/internal/take.ts
+++ b/src/type/script/token/internal/take.ts
@@ -63,7 +63,7 @@ export function Take<Variants extends string[], Input extends string>(variants: 
   // ----------------------------------------------------------------
   // Symmetric
   // ----------------------------------------------------------------
-  // return Guard.TakeLeft(variants, (valueLeft, valueRight) => 
+  // return Guard.ShiftLeft(variants, (valueLeft, valueRight) => 
   //   Match(TakeVariant(valueLeft, input), (take, rest) => 
   //     [take, rest],
   //     () => Take(valueRight, input)),

--- a/src/type/script/token/until.ts
+++ b/src/type/script/token/until.ts
@@ -30,7 +30,7 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import { Match } from './internal/match.ts'
-import { IsEqual, TakeLeft } from './internal/guard.ts'
+import { IsEqual, ShiftLeft } from './internal/guard.ts'
 
 // ------------------------------------------------------------------
 // TakeOne
@@ -55,7 +55,7 @@ type TIsInputMatchSentinal<End extends string[], Input extends string> = (
     : false
 )
 function IsInputMatchSentinal<End extends string[], Input extends string>(end: [...End], input: Input): TIsInputMatchSentinal<End, Input> {
-  return TakeLeft(end, (left, right) => 
+  return ShiftLeft(end, (left, right) => 
     input.startsWith(left)
       ? true
       : IsInputMatchSentinal(right, input),

--- a/src/type/types/record.ts
+++ b/src/type/types/record.ts
@@ -104,22 +104,10 @@ export function RecordFromPattern<Pattern extends string, Value extends TSchema>
   return CreateRecord(key, value)
 }
 // -------------------------------------------------------------------
-// RecordPattern
+// RecordPatternToType
 // -------------------------------------------------------------------
-/** Returns the raw string pattern used for the Record key  */
-export type TRecordPattern<Type extends TRecord,
-  Result extends string = Extract<keyof Type['patternProperties'], string>
-> = Result
-/** Returns the raw string pattern used for the Record key  */
-export function RecordPattern<Type extends TRecord>(type: Type): TRecordPattern<Type> {
-  return Guard.Keys(type.patternProperties)[0] as never
-}
-// -------------------------------------------------------------------
-// RecordKey
-// -------------------------------------------------------------------
-/** Returns the Record key as a TypeBox type  */
-export type TRecordKey<Type extends TRecord,
-  Pattern extends string = TRecordPattern<Type>,
+/** Transforms a Record Pattern to a Type */
+export type TRecordPatternToType<Pattern extends string,
   Result extends TSchema = (
     Pattern extends typeof StringKey ? TString :
     Pattern extends typeof IntegerKey ? TInteger :
@@ -127,9 +115,8 @@ export type TRecordKey<Type extends TRecord,
     TTemplateLiteralDecodeUnsafe<Pattern>
   )
 > = Result
-/** Returns the Record key as a TypeBox type  */
-export function RecordKey<Type extends TRecord>(type: Type): TRecordKey<Type> {
-  const pattern = RecordPattern(type)
+/** Transforms a Record Pattern to a Type */
+export function RecordPatternToType<Pattern extends string>(pattern: Pattern): TRecordPatternToType<Pattern> {
   const result = (
     Guard.IsEqual(pattern, StringKey) ? String() :
     Guard.IsEqual(pattern, IntegerKey) ? Integer() :
@@ -139,11 +126,38 @@ export function RecordKey<Type extends TRecord>(type: Type): TRecordKey<Type> {
   return result as never
 }
 // -------------------------------------------------------------------
+// RecordPattern
+// -------------------------------------------------------------------
+/** Extracts the Pattern from a Record type */
+export type TRecordPattern<Type extends TRecord,
+  Result extends string = Extract<keyof Type['patternProperties'], string>
+> = Result
+/** Extracts the Pattern from a Record type */
+export function RecordPattern<Type extends TRecord>(type: Type): TRecordPattern<Type> {
+  return Guard.Keys(type.patternProperties)[0] as never
+}
+// -------------------------------------------------------------------
+// RecordKey
+// -------------------------------------------------------------------
+/** Extracts the Key from a Record type */
+export type TRecordKey<Type extends TRecord,
+  Pattern extends string = TRecordPattern<Type>,
+  Result extends TSchema = TRecordPatternToType<Pattern>
+> = Result
+/** Extracts the Key from a Record type */
+export function RecordKey<Type extends TRecord>(type: Type): TRecordKey<Type> {
+  const pattern = RecordPattern(type)
+  const result = RecordPatternToType(pattern)
+  return result as never
+}
+// -------------------------------------------------------------------
 // RecordValue
 // -------------------------------------------------------------------
+/** Extracts the Value from a Record type */
 export type TRecordValue<Type extends TRecord,
   Result extends TSchema = Type['patternProperties'][TRecordPattern<Type>]
 > = Result
+/** Extracts the Value from a Record type */
 export function RecordValue<Type extends TRecord>(type: Type): TRecordValue<Type> {
   return type.patternProperties[RecordPattern(type)] as never
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.2.10'
+const Version = '1.2.11'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/guard/guard.ts
+++ b/test/typebox/runtime/guard/guard.ts
@@ -326,23 +326,23 @@ Test('Should IsClassInstance 15', () => {
 })
 
 // ------------------------------------------------------------------
-// Guard.TakeLeft
+// Guard.ShiftLeft
 // ------------------------------------------------------------------
-Test('Should TakeLeft 1', () => {
-  const result: any = Guard.TakeLeft([], (left, right) => ({ left, right }), () => 'empty')
+Test('Should ShiftLeft 1', () => {
+  const result: any = Guard.ShiftLeft([], (left, right) => ({ left, right }), () => 'empty')
   Assert.IsEqual(result, 'empty')
 })
-Test('Should TakeLeft 2', () => {
+Test('Should ShiftLeft 2', () => {
   const result: string | {
     left: number
     right: number[]
-  } = Guard.TakeLeft([1, 2, 3], (left, right) => ({ left, right }), () => 'empty')
+  } = Guard.ShiftLeft([1, 2, 3], (left, right) => ({ left, right }), () => 'empty')
   Assert.IsEqual(result, { left: 1, right: [2, 3] })
 })
-Test('Should TakeLeft 3', () => {
+Test('Should ShiftLeft 3', () => {
   const result: string | {
     left: number
     right: number[]
-  } = Guard.TakeLeft([42], (left, right) => ({ left, right }), () => 'empty')
+  } = Guard.ShiftLeft([42], (left, right) => ({ left, right }), () => 'empty')
   Assert.IsEqual(result, { left: 42, right: [] })
 })

--- a/test/typebox/runtime/type/extends/cyclic.ts
+++ b/test/typebox/runtime/type/extends/cyclic.ts
@@ -117,8 +117,8 @@ Test('Should CyclicExtends 10', () => {
   Assert.IsExtends<string, any>(true)
   const A = Type.Record(Type.String(), Type.Ref('A'))
   const L = Type.Cyclic({ A }, 'A')
-  const R: ExtendsResult.TExtendsFalse = Extends({}, L, Type.Unknown())
-  Assert.IsTrue(ExtendsResult.IsExtendsFalse(R))
+  const R: ExtendsResult.TExtendsTrue = Extends({}, L, Type.Unknown())
+  Assert.IsTrue(ExtendsResult.IsExtendsTrue(R))
 })
 Test('Should CyclicExtends 11', () => {
   Assert.IsExtends<string, any>(true)

--- a/test/typebox/runtime/type/extends/object.ts
+++ b/test/typebox/runtime/type/extends/object.ts
@@ -1,6 +1,5 @@
 import Type, { Extends, ExtendsResult } from 'typebox'
 import { Assert } from 'test'
-import { stringify } from 'node:querystring'
 
 const Test = Assert.Context('Extends.Object')
 
@@ -131,4 +130,59 @@ Test('Should Extends 20', () => {
   Assert.IsTrue(ExtendsResult.IsExtendsTrue(R))
   Assert.IsTrue(Type.IsUnknown(R.inferred.A))
   Assert.IsTrue(Type.IsNumber(R.inferred.B))
+})
+// ------------------------------------------------------------------
+// ExtendsRecord
+// ------------------------------------------------------------------
+Test('Should Extends 21', () => {
+  const L = Type.Object({ x: Type.Literal(1), y: Type.Literal(2) })
+  const R = Type.Record(Type.String(), Type.Number())
+  const T: Type.ExtendsResult.TExtendsTrue<{}> = Extends({}, L, R)
+  Assert.IsTrue(ExtendsResult.IsExtendsTrue(T))
+})
+Test('Should Extends 22', () => {
+  const L = Type.Object({ x: Type.Literal(1), y: Type.Literal(2) })
+  const R = Type.Record(Type.String(), Type.String())
+  const T: Type.ExtendsResult.TExtendsFalse = Extends({}, L, R)
+  Assert.IsTrue(ExtendsResult.IsExtendsFalse(T))
+})
+Test('Should Extends 23', () => {
+  const L = Type.Object({ x: Type.Literal(1), y: Type.Literal(2) })
+  const R = Type.Record(Type.String(), Type.Infer('X'))
+  const T: Type.ExtendsResult.TExtendsTrue<{
+    X: Type.TUnion<[Type.TLiteral<1>, Type.TLiteral<2>]>
+  }> = Extends({}, L, R)
+  Assert.IsTrue(ExtendsResult.IsExtendsTrue(T))
+  Assert.IsTrue(Type.IsUnion(T.inferred.X))
+  Assert.IsEqual(T.inferred.X.anyOf[0].const, 1)
+  Assert.IsEqual(T.inferred.X.anyOf[1].const, 2)
+})
+Test('Should Extends 24', () => {
+  const L = Type.Object({ x: Type.Literal(1), y: Type.Literal(2) })
+  const R = Type.Record(Type.String(), Type.Infer('X', Type.Number()))
+  const T: Type.ExtendsResult.TExtendsTrue<{
+    X: Type.TUnion<[Type.TLiteral<1>, Type.TLiteral<2>]>
+  }> = Extends({}, L, R)
+  Assert.IsTrue(ExtendsResult.IsExtendsTrue(T))
+  Assert.IsTrue(Type.IsUnion(T.inferred.X))
+  Assert.IsEqual(T.inferred.X.anyOf[0].const, 1)
+  Assert.IsEqual(T.inferred.X.anyOf[1].const, 2)
+})
+Test('Should Extends 25', () => {
+  const L = Type.Object({ x: Type.Literal(1), y: Type.Literal(2), z: Type.Literal(3) })
+  const R = Type.Record(Type.String(), Type.Infer('X', Type.Number()))
+  const T: Type.ExtendsResult.TExtendsTrue<{
+    X: Type.TUnion<[Type.TLiteral<1>, Type.TLiteral<2>, Type.TLiteral<3>]>
+  }> = Extends({}, L, R)
+  Assert.IsTrue(ExtendsResult.IsExtendsTrue(T))
+  Assert.IsTrue(Type.IsUnion(T.inferred.X))
+  Assert.IsEqual(T.inferred.X.anyOf[0].const, 1)
+  Assert.IsEqual(T.inferred.X.anyOf[1].const, 2)
+  Assert.IsEqual(T.inferred.X.anyOf[2].const, 3)
+})
+Test('Should Extends 26', () => {
+  const L = Type.Object({ x: Type.Literal(1), y: Type.Literal(2) })
+  const R = Type.Record(Type.String(), Type.Infer('X', Type.String()))
+  const T: Type.ExtendsResult.TExtendsFalse = Extends({}, L, R)
+  Assert.IsTrue(ExtendsResult.IsExtendsFalse(T))
 })

--- a/test/typebox/runtime/type/extends/record.ts
+++ b/test/typebox/runtime/type/extends/record.ts
@@ -1,0 +1,72 @@
+import Type, { Extends, ExtendsResult } from 'typebox'
+import { Assert } from 'test'
+
+const Test = Assert.Context('Extends.Record')
+
+// ------------------------------------------------------------------
+// Invariant
+// ------------------------------------------------------------------
+Test('Should Extends 1', () => {
+  Assert.IsExtends<Record<string, number>, null>(false)
+  const T: ExtendsResult.TExtendsFalse = Extends({}, Type.Record(Type.String(), Type.Number()), Type.Null())
+  Assert.IsTrue(ExtendsResult.IsExtendsFalse(T))
+})
+// ------------------------------------------------------------------
+// Coverage
+// ------------------------------------------------------------------
+Test('Should Extends 2', () => {
+  Assert.IsExtends<Record<string, number>, any>(true)
+  const T: Type.ExtendsResult.TExtendsTrue<{}> = Extends({}, Type.Record(Type.String(), Type.Number()), Type.Any())
+  Assert.IsTrue(ExtendsResult.IsExtendsTrue(T))
+})
+Test('Should Extends 3', () => {
+  Assert.IsExtends<Record<string, number>, unknown>(true)
+  const T: Type.ExtendsResult.TExtendsTrue<{}> = Extends({}, Type.Record(Type.String(), Type.Number()), Type.Unknown())
+  Assert.IsTrue(ExtendsResult.IsExtendsTrue(T))
+})
+Test('Should Extends 4', () => {
+  Assert.IsExtends<Record<string, number>, never>(false)
+  const T: Type.ExtendsResult.TExtendsFalse = Extends({}, Type.Record(Type.String(), Type.Number()), Type.Never())
+  Assert.IsTrue(ExtendsResult.IsExtendsFalse(T))
+})
+// ------------------------------------------------------------------
+// RecordToRecord
+// ------------------------------------------------------------------
+Test('Should Extends 5', () => {
+  Assert.IsExtends<Record<string, string>, Record<string, string>>(true)
+  const L = Type.Record(Type.String(), Type.String())
+  const R = Type.Record(Type.String(), Type.String())
+  const T: ExtendsResult.TExtendsTrue = Extends({}, L, R)
+  Assert.IsTrue(ExtendsResult.IsExtendsTrue(T))
+})
+Test('Should Extends 6', () => {
+  Assert.IsExtends<Record<string, string>, Record<string, number>>(false)
+  const L = Type.Record(Type.String(), Type.String())
+  const R = Type.Record(Type.String(), Type.Number())
+  const T: ExtendsResult.TExtendsFalse = Extends({}, L, R)
+  Assert.IsTrue(ExtendsResult.IsExtendsFalse(T))
+})
+Test('Should Extends 7', () => {
+  Assert.IsExtends<Record<number, string>, Record<string, string>>(true)
+  const L = Type.Record(Type.Number(), Type.String())
+  const R = Type.Record(Type.String(), Type.String())
+  const T: ExtendsResult.TExtendsTrue = Extends({}, L, R)
+  Assert.IsTrue(ExtendsResult.IsExtendsTrue(T))
+})
+// ------------------------------------------------------------------
+// RecordToObject
+// ------------------------------------------------------------------
+Test('Should Extends 8', () => {
+  Assert.IsExtends<Record<string, string>, {}>(true)
+  const L = Type.Record(Type.Number(), Type.String())
+  const R = Type.Object({})
+  const T: ExtendsResult.TExtendsTrue = Extends({}, L, R)
+  Assert.IsTrue(ExtendsResult.IsExtendsTrue(T))
+})
+Test('Should Extends 9', () => {
+  Assert.IsExtends<Record<string, string>, { x: 1 }>(false)
+  const L = Type.Record(Type.Number(), Type.String())
+  const R = Type.Object({ x: Type.Literal(1) })
+  const T: ExtendsResult.TExtendsFalse = Extends({}, L, R)
+  Assert.IsTrue(ExtendsResult.IsExtendsFalse(T))
+})

--- a/test/typebox/runtime/type/script/conditional.ts
+++ b/test/typebox/runtime/type/script/conditional.ts
@@ -8,7 +8,6 @@ Test('Should Conditional 1', () => {
   Assert.IsTrue(Type.IsLiteral(T))
   Assert.IsEqual(T.const, true)
 })
-
 Test('Should Conditional 2', () => {
   const T: Type.TString = Type.Script('string extends infer S ? S : false')
   Assert.IsTrue(Type.IsString(T))
@@ -48,4 +47,14 @@ Test('Should Conditional 5', () => {
   Assert.IsEqual(T.items[0].const, 3)
   Assert.IsEqual(T.items[1].const, 2)
   Assert.IsEqual(T.items[2].const, 1)
+})
+// ------------------------------------------------------------------
+// Record Inference
+// ------------------------------------------------------------------
+Test('Should Conditional 6', () => {
+  const T: Type.TUnion<[Type.TLiteral<1>, Type.TLiteral<2>, Type.TLiteral<3>]> = Type.Script('{ x: 1, y: 2, z: 3 } extends Record<string, infer K> ? K : never')
+  Assert.IsTrue(Type.IsUnion(T))
+  Assert.IsEqual(T.anyOf[0].const, 1)
+  Assert.IsEqual(T.anyOf[1].const, 2)
+  Assert.IsEqual(T.anyOf[2].const, 3)
 })

--- a/test/typebox/runtime/value/shared/union_priority_sort.ts
+++ b/test/typebox/runtime/value/shared/union_priority_sort.ts
@@ -164,7 +164,13 @@ Test('Should UnionPrioritySort 24', () => {
   const A = Type.Object({ a: Type.String() })
   const B = Type.Record(Type.String(), Type.Any())
   const R = UnionPrioritySort([B, A])
-  Assert.IsEqual(R, [B, A]) // Review on Extends Check for Record
+  Assert.IsEqual(R, [A, B])
+})
+Test('Should UnionPrioritySort 24.1', () => {
+  const A = Type.Object({ a: Type.String() })
+  const B = Type.Record(Type.String(), Type.Any())
+  const R = UnionPrioritySort([A, B])
+  Assert.IsEqual(R, [A, B])
 })
 // ------------------------------------------------------------------
 // Reverse


### PR DESCRIPTION
This PR adds support for Record Extend and Infer.

```typescript
const { T } = Type.Script(`
  type T = { x: 1, y: 2, z: 3 } extends Record<string, infer Value> 
    ? Value 
    : never
`)

// where T is:

const T: Type.TUnion<[
  Type.TLiteral<1>, 
  Type.TLiteral<2>, 
  Type.TLiteral<3>
]>
```

## Additional

- `Guard.TakeLeft` has been renamed to `Guard.ShiftLeft` inline with ParseBox definition
- Update Axiom Example