### PR TITLE
Version 1.2.12

### DIFF
--- a/changelog/1.2.0.md
+++ b/changelog/1.2.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.2.12](https://github.com/sinclairzx81/typebox/pull/1621)
+  - Ensure UnionPrioritySort Does Not Mutate Source Array
 - [Revision 1.2.11](https://github.com/sinclairzx81/typebox/pull/1619)
   - Implement Extends Inference Logic for Record Types
 - [Revision 1.2.10](https://github.com/sinclairzx81/typebox/pull/1618)

--- a/src/value/shared/union_priority_sort.ts
+++ b/src/value/shared/union_priority_sort.ts
@@ -57,7 +57,7 @@ function DeterministicCompare(left: TSchema, right: TSchema): number {
 
 /** Deterministically sorts schemas by structural relationship (narrow to broad) */
 export function UnionPrioritySort(types: TSchema[], order: number = 1): TSchema[] {
-  return types.sort((left, right) => {
+  return [...types].sort((left, right) => {
     const result = Compare(left, right) as string
     return (
       Guard.IsEqual(result, 'disjoint') ? DeterministicCompare(left, right) : 

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.2.11'
+const Version = '1.2.12'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/value/shared/union_priority_sort.ts
+++ b/test/typebox/runtime/value/shared/union_priority_sort.ts
@@ -183,3 +183,17 @@ Test('Should UnionPrioritySort 25', () => {
   const R = UnionPrioritySort([A, B, C, D], -1)
   Assert.IsEqual(R, [A, C, B, D])
 })
+// ------------------------------------------------------------------
+// UnionPrioritySort Should not Mutate Source Array
+//
+// https://github.com/sinclairzx81/typebox/issues/1620
+// ------------------------------------------------------------------
+Test('Should UnionPrioritySort 26', () => {
+  const A = [
+    Type.Object({ x: Type.Number() }),
+    Type.Object({ x: Type.Number(), y: Type.Number() })
+  ]
+  const B = [...A]
+  UnionPrioritySort(A) // Priority Sort (A)
+  Assert.IsEqual(A, B) // Expect Equal
+})


### PR DESCRIPTION
This PR applies for fix to ensure UnionPrioritySort does not mutate the source array.

Issue Reported Via: https://github.com/sinclairzx81/typebox/issues/1620