### PR TITLE
Version 1.2.13

### DIFF
--- a/changelog/1.2.0.md
+++ b/changelog/1.2.0.md
@@ -3,6 +3,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.2.13](https://github.com/sinclairzx81/typebox/pull/1622)
+  - Optimize Codec Inference for Parse, Encode and Decode.
 - [Revision 1.2.12](https://github.com/sinclairzx81/typebox/pull/1621)
   - Ensure UnionPrioritySort Does Not Mutate Source Array
 - [Revision 1.2.11](https://github.com/sinclairzx81/typebox/pull/1619)

--- a/src/type/types/_codec.ts
+++ b/src/type/types/_codec.ts
@@ -26,12 +26,11 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-// deno-lint-ignore-file ban-types
 // deno-fmt-ignore-file
 
 import { Memory } from '../../system/index.ts'
 import { Guard } from '../../guard/index.ts'
-import { type StaticDirection, type StaticType } from './static.ts'
+import { type StaticDirection, type StaticDecode, type StaticType } from './static.ts'
 import { IsSchema, type TSchema } from './schema.ts'
 import { type TProperties } from './properties.ts'
 
@@ -39,27 +38,25 @@ import { type TProperties } from './properties.ts'
 // Static
 // ------------------------------------------------------------------
 export type StaticCodec<Stack extends string[], Direction extends StaticDirection, Context extends TProperties, This extends TProperties, Type extends TSchema, Decoded extends unknown> = (
-  Direction extends 'Decode' 
-    ? Decoded
-    : StaticType<Stack, Direction, Context, This, Omit<Type, '~codec'>> // prevent recurrent static
+  Direction extends 'Decode' ? Decoded : StaticType<Stack, Direction, Context, This, Omit<Type, '~codec'>> // prevent recurrent static
 )
 // ------------------------------------------------------------------
 // Type
 // ------------------------------------------------------------------
-export type TDecodeCallback<Type extends TSchema, Decoded = unknown> = (input: StaticType<[], 'Decode', {}, {}, Type>) => Decoded
-export type TEncodeCallback<Type extends TSchema, Decoded = unknown> = (input: Decoded) => StaticType<[], 'Decode', {}, {}, Type>
+export type TDecodeCallback<Encoded extends unknown, Decoded = unknown> = (input: Encoded) => Decoded
+export type TEncodeCallback<Encoded extends unknown, Decoded = unknown> = (input: Decoded) => Encoded
 export type TCodec<Type extends TSchema = TSchema, Decoded extends unknown = unknown> = Type & {
   '~codec': {
-    encode: TDecodeCallback<Type, Decoded>
-    decode: TEncodeCallback<Type, Decoded>
+    encode: TDecodeCallback<unknown, Decoded>
+    decode: TEncodeCallback<unknown, Decoded>
   }
 }
 // ------------------------------------------------------------------
 // Factory
 // ------------------------------------------------------------------
-export class EncodeBuilder<Type extends TSchema, Decoded extends unknown> {
+export class EncodeBuilder<Type extends TSchema, Encoded extends unknown, Decoded extends unknown> {
   constructor(private readonly type: Type, private readonly decode: globalThis.Function) {}
-  public Encode<Callback extends TEncodeCallback<Type, Decoded>>(callback: Callback): TCodec<Type, Decoded> {
+  public Encode(callback: TEncodeCallback<Encoded, Decoded>): TCodec<Type, Decoded> {
     const type = this.type
     const decode = IsCodec(type) ? (value: unknown) => this.decode(type['~codec'].decode(value)) : this.decode
     const encode = IsCodec(type) ? (value: unknown) => type['~codec'].encode(callback(value as never)) : callback
@@ -67,9 +64,9 @@ export class EncodeBuilder<Type extends TSchema, Decoded extends unknown> {
     return Memory.Update(this.type, { '~codec': codec }, {}) as never
   }
 }
-export class DecodeBuilder<Type extends TSchema> {
+export class DecodeBuilder<Type extends TSchema, Encoded extends unknown> {
   constructor(private readonly type: Type) {}
-  public Decode<Callback extends TDecodeCallback<Type>>(callback: Callback): EncodeBuilder<Type, ReturnType<Callback>> {
+  public Decode<Callback extends TDecodeCallback<Encoded, unknown>>(callback: Callback): EncodeBuilder<Type, Encoded, ReturnType<Callback>> {
     return new EncodeBuilder(this.type, callback)
   }
 }
@@ -77,23 +74,23 @@ export class DecodeBuilder<Type extends TSchema> {
 // Bidirectional
 // ------------------------------------------------------------------
 /** Creates a bi-directional Codec. Codec functions are called on Value.Decode and Value.Encode. */
-export function Codec<Type extends TSchema>(type: Type): DecodeBuilder<Type> {
+export function Codec<Type extends TSchema>(type: Type): DecodeBuilder<Type, StaticDecode<Type>> {
   return new DecodeBuilder(type)
 }
 // ------------------------------------------------------------------
 // Unidirectional
 // ------------------------------------------------------------------
 /** Createsa  uni-directional Codec with Decode only. The Decode function is called on Value.Decode */
-export function Decode<Type extends TSchema, Callback extends TDecodeCallback<Type>>(type: Type, callback: Callback): TCodec<Type, ReturnType<Callback>> {
-  return Codec(type).Decode(callback).Encode(() => {
+export function Decode<Type extends TSchema, Callback extends TDecodeCallback<StaticDecode<Type>, unknown>>(type: Type, callback: Callback): TCodec<Type, ReturnType<Callback>> {
+  return Codec(type).Decode(callback as never).Encode(() => {
     throw Error('Encode not implemented')
-  })
+  }) as never
 }
 /** Creates a uni-directional Codec with Encode only. The Encode function is called on Value.Encode */
-export function Encode<Type extends TSchema, Callback extends TEncodeCallback<Type, unknown>>(type: Type, callback: Callback): TCodec<Type, unknown> {
+export function Encode<Type extends TSchema>(type: Type, callback: TEncodeCallback<StaticDecode<Type>, unknown>): TCodec<Type, unknown> {
   return Codec(type).Decode(() => {
     throw Error('Decode not implemented')
-  }).Encode(callback) as never
+  }).Encode(callback as never) as never
 }
 // ------------------------------------------------------------------
 // Guard

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.2.12'
+const Version = '1.2.13'
 
 // ------------------------------------------------------------------
 // Build


### PR DESCRIPTION
This PR is a continuation of 1.2.12 which implements additional type level optimizations for Codecs (specific to the Codec builder functions). This work was done due to degraded Codec inference that's appears to have degraded over the past few revisions / compiler iterations. 

This PR attempts to address the issue by using forward caching techniques over the current `TCodec<TSchema, Decoded>` structure. No other functional changes we made.

### Notes

- Additional inference performance should be possible by forward caching the `Encoded` form via an additional generic argument on `TCodec<TSchema, Encoded, Decoded>`. This PR defers this in order to keep the current signature non-breaking ... as well as to defer complications around deriving types from recursive Codecs (which needs a deeper review)


Reference: https://github.com/sinclairzx81/typebox/issues/1620