### PR TITLE
perf(value): memoize UnionPrioritySort to avoid per-value JSON.stringify

### DIFF
--- a/src/value/shared/union_priority_sort.ts
+++ b/src/value/shared/union_priority_sort.ts
@@ -45,6 +45,20 @@ function DeterministicCompare(left: TSchema, right: TSchema): number {
   return JSON.stringify(left).localeCompare(JSON.stringify(right))
 }
 // ------------------------------------------------------------------
+// Sort
+// ------------------------------------------------------------------
+function Sort(types: TSchema[], order: number): TSchema[] {
+  return [...types].sort((left, right) => {
+    const result = Compare(left, right) as string
+    return (
+      Guard.IsEqual(result, 'disjoint') ? DeterministicCompare(left, right) :
+      Guard.IsEqual(result, 'right-inside') ? 1 :
+      Guard.IsEqual(result, 'left-inside') ? -1 :
+      DeterministicCompare(left, right)
+    ) * order
+  })
+}
+// ------------------------------------------------------------------
 // UnionPrioritySort
 //
 // Performs a deterministic sort on Union members. By default, this
@@ -53,17 +67,28 @@ function DeterministicCompare(left: TSchema, right: TSchema): number {
 // the order property to -1 which will reverse unions from broader
 // to more narrow.
 //
+// The sort order is a pure function of the (static) member schemas, so the
+// result is memoized per source array and order. This avoids re-running the
+// DeterministicCompare (JSON.stringify) comparator on every call, which is
+// significant when Codec Decode/Encode or Value.Clean process large arrays of
+// union-bearing values (the comparator otherwise serializes member schemas on
+// every value). A fresh array is returned on each call, so the source array is
+// never mutated (see #1620) and callers never observe a shared array.
+//
 // ------------------------------------------------------------------
+const memo = new WeakMap<TSchema[], Map<number, TSchema[]>>()
 
 /** Deterministically sorts schemas by structural relationship (narrow to broad) */
 export function UnionPrioritySort(types: TSchema[], order: number = 1): TSchema[] {
-  return [...types].sort((left, right) => {
-    const result = Compare(left, right) as string
-    return (
-      Guard.IsEqual(result, 'disjoint') ? DeterministicCompare(left, right) : 
-      Guard.IsEqual(result, 'right-inside') ? 1 : 
-      Guard.IsEqual(result, 'left-inside') ? -1 : 
-      DeterministicCompare(left, right)
-    ) * order
-  })
+  let byOrder = memo.get(types)
+  if (Guard.IsUndefined(byOrder)) {
+    byOrder = new Map<number, TSchema[]>()
+    memo.set(types, byOrder)
+  }
+  let sorted = byOrder.get(order)
+  if (Guard.IsUndefined(sorted)) {
+    sorted = Sort(types, order)
+    byOrder.set(order, sorted)
+  }
+  return [...sorted]
 }

--- a/test/typebox/runtime/value/shared/union_priority_sort.ts
+++ b/test/typebox/runtime/value/shared/union_priority_sort.ts
@@ -197,3 +197,20 @@ Test('Should UnionPrioritySort 26', () => {
   UnionPrioritySort(A) // Priority Sort (A)
   Assert.IsEqual(A, B) // Expect Equal
 })
+// ------------------------------------------------------------------
+// Memoized result is stable and returned as a fresh array per call
+// ------------------------------------------------------------------
+Test('Should UnionPrioritySort 27', () => {
+  const A = [Type.Number(), Type.Literal(1)]
+  const R1 = UnionPrioritySort(A)
+  const R2 = UnionPrioritySort(A)
+  Assert.IsEqual(R1, R2) // stable order across calls
+  Assert.IsTrue(R1 !== R2) // distinct array per call (callers never share)
+})
+Test('Should UnionPrioritySort 28', () => {
+  const A = [Type.Number(), Type.Literal(1)]
+  const R1 = UnionPrioritySort(A)
+  R1.push(Type.String()) // mutating a returned array must not affect later calls
+  const R2 = UnionPrioritySort(A)
+  Assert.IsEqual(R2, [Type.Literal(1), Type.Number()])
+})


### PR DESCRIPTION
Fixes #1624.

## Problem

`UnionPrioritySort` sorts a union's members on **every call**, and its comparator
(`DeterministicCompare`) calls `JSON.stringify` on each member *schema* whenever `Compare`
returns `disjoint`. `disjoint` ("neither member contains the other") is the normal case for
`Type.Union([X, Null])` and discriminated unions, so the `JSON.stringify` runs on essentially
every comparison.

The sort order is a pure function of the (static) member schemas, but it is recomputed per
value. During `Codec` `Decode`/`Encode` and `Value.Clean` over large arrays of union-bearing
values, this repeats identical serialization work on every element. It dominates `Value.Clean`
(and therefore `Value.Decode`/`Encode`/`Parse`, which run `Clean`) on union-heavy schemas.

A minimal demonstration: `Value.Clean` on a payload that is always `null` (so there is nothing
to clean) still gets slower as the union member schema grows wider — the only size-dependent
work left is the comparator's `JSON.stringify`.

## Fix

Memoize the sorted result per source array and `order` (a `WeakMap` keyed by the `anyOf`
array). A fresh array is returned on each call, so:

- the source array is never mutated (preserves the #1620 fix from 1.2.12), and
- callers never observe a shared array (mutating a returned array can't corrupt the memo).

The comparator (and its `JSON.stringify`) now runs once per union schema instead of once per
value. Output is unchanged — same order, same fresh-array contract.

> Note: this builds on the 1.2.12 non-mutation fix (#1620). That change stopped the mutation
> but kept the per-value sort/serialization; this addresses the remaining cost.

An alternative shape would be to precompute the order when the type is built/compiled; the
`WeakMap` memo was chosen as the smaller, localized change. Happy to switch if you prefer.

## Performance (typebox built from this branch's `src`, Node 22, count = 10,000)

On a schema that is an array of objects with many `Union([X, Null])` fields + two codec leaves:

| | before | after |
|---|---|---|
| `Value.Clean` | ~1,543 ms | ~291 ms |
| codec walk (`Value.DecodeUnsafe`) | ~1,535 ms | ~283 ms |
| `compiled.Decode` (full interpreted path) | ~4,008 ms | ~1,424 ms |

## Tests

- Full runtime suite passes: `4417 passed | 0 failed`.
- Existing `UnionPrioritySort` tests (incl. the #1620 non-mutation test) unchanged and passing.
- Added two tests: result is stable across calls and returned as a distinct array per call
  (mutating a returned array does not affect later calls).

## Assumption

Caching by `anyOf` identity assumes a union's member array is treated as immutable after
construction — consistent with the direction in #1620. If a schema's `anyOf` is mutated in
place after first use, the memo would be stale; that is already an unsupported pattern.
