### PR TITLE
Version 1.2.16

### DIFF
--- a/changelog/1.2.0.md
+++ b/changelog/1.2.0.md
@@ -4,6 +4,8 @@
 
 ### Version Updates
 
+- [Revision 1.2.16](https://github.com/sinclairzx81/typebox/pull/1628)
+  - Handle Unreachable cases on DecodeUnsafe
 - [Revision 1.2.15](https://github.com/sinclairzx81/typebox/pull/1627)
   - Engine Level Union Priority Sorting 
 - [Revision 1.2.14](https://github.com/sinclairzx81/typebox/pull/1623)

--- a/src/value/codec/from_array.ts
+++ b/src/value/codec/from_array.ts
@@ -28,7 +28,6 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { Unreachable } from '../../system/unreachable/index.ts'
 import { Guard } from '../../guard/index.ts'
 import { type TArray, type TProperties } from '../../type/index.ts'
 import { FromType } from './from_type.ts'
@@ -38,9 +37,7 @@ import { Callback } from './callback.ts'
 // Decode
 // ------------------------------------------------------------------
 function Decode(direction: string, context: TProperties, type: TArray, value: unknown): unknown {
-  // deno-coverage-ignore-start - unreachable | checked
-  if(!Guard.IsArray(value)) return Unreachable()
-  // deno-coverage-ignore-stop
+  if(!Guard.IsArray(value)) return value
 
   for(let i = 0; i < value.length; i++) {
     value[i] = FromType(direction, context, type.items, value[i])

--- a/src/value/codec/from_object.ts
+++ b/src/value/codec/from_object.ts
@@ -28,7 +28,6 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { Unreachable } from '../../system/unreachable/index.ts'
 import { Guard } from '../../guard/index.ts'
 import { type TObject, type TProperties } from '../../type/index.ts'
 import { FromType } from './from_type.ts'
@@ -40,10 +39,8 @@ import { IsOptionalUndefined } from '../shared/optional_undefined.ts'
 // Decode
 // ------------------------------------------------------------------
 function Decode(direction: string, context: TProperties, type: TObject, value: unknown): unknown {
-  // deno-coverage-ignore-start - unreachable | checked
-  if (!Guard.IsObjectNotArray(value)) return Unreachable()
-  // deno-coverage-ignore-stop
-
+  if (!Guard.IsObjectNotArray(value)) return value
+  
   for (const key of Guard.Keys(type.properties)) {
     // Ignore for non-present or optional-undefined
     if(!Guard.HasPropertyKey(value, key) || IsOptionalUndefined(type.properties[key], key, value)) continue

--- a/src/value/codec/from_record.ts
+++ b/src/value/codec/from_record.ts
@@ -28,7 +28,6 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { Unreachable } from '../../system/unreachable/index.ts'
 import { Guard } from '../../guard/index.ts'
 import { RecordPattern, RecordValue, type TProperties, type TRecord } from '../../type/index.ts'
 import { FromType } from './from_type.ts'
@@ -39,15 +38,10 @@ import { Callback } from './callback.ts'
 // Decode
 // ------------------------------------------------------------------
 function Decode(direction: string, context: TProperties, type: TRecord, value: unknown): unknown {
-  // deno-coverage-ignore-start - unreachable | checked
-  if (!Guard.IsObjectNotArray(value)) return Unreachable()
-  // deno-coverage-ignore-stop
+  if (!Guard.IsObjectNotArray(value)) return value
   const regexp = new RegExp(RecordPattern(type))
   for (const key of Guard.Keys(value)) {
-
-    // deno-coverage-ignore-start - unreachable | checked
-    if (!regexp.test(key)) Unreachable()
-    // deno-coverage-ignore-stop
+    if (!regexp.test(key)) continue
 
     value[key] = FromType(direction, context, RecordValue(type), value[key])
   }

--- a/src/value/codec/from_tuple.ts
+++ b/src/value/codec/from_tuple.ts
@@ -28,7 +28,6 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { Unreachable } from '../../system/unreachable/index.ts'
 import { Guard } from '../../guard/index.ts'
 import { type TProperties, type TTuple } from '../../type/index.ts'
 import { FromType } from './from_type.ts'
@@ -38,10 +37,8 @@ import { Callback } from './callback.ts'
 // Decode
 // ------------------------------------------------------------------
 function Decode(direction: string, context: TProperties, type: TTuple, value: unknown): unknown {
-  // deno-coverage-ignore-start - unreachable | checked
-  if(!Guard.IsArray(value)) return Unreachable()
-  // deno-coverage-ignore-stop
-
+  if(!Guard.IsArray(value)) return value
+  
   for(let i = 0; i < Math.min(type.items.length, value.length); i++) {
     value[i] = FromType(direction, context, type.items[i], value[i])
   }

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.2.15'
+const Version = '1.2.16'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/value/codec/~decode-unsafe.ts
+++ b/test/typebox/runtime/value/codec/~decode-unsafe.ts
@@ -1,0 +1,36 @@
+import { DecodeUnsafe } from 'typebox/value'
+import { Type } from 'typebox'
+import { Assert } from 'test'
+
+const Test = Assert.Context('Value.Codec.DecodeUnsafe')
+
+// ------------------------------------------------------------------
+// Coverage
+// ------------------------------------------------------------------
+Test('Should DecodeUnsafe 1', () => {
+  const T = Type.Object({
+    x: Type.Optional(Type.Number())
+  })
+  const D = DecodeUnsafe({}, T, undefined)
+  Assert.IsEqual(D, undefined)
+})
+Test('Should DecodeUnsafe 2', () => {
+  const T = Type.Array(Type.String())
+  const D = DecodeUnsafe({}, T, undefined)
+  Assert.IsEqual(D, undefined)
+})
+Test('Should DecodeUnsafe 3', () => {
+  const T = Type.Tuple([Type.String()])
+  const D = DecodeUnsafe({}, T, undefined)
+  Assert.IsEqual(D, undefined)
+})
+Test('Should DecodeUnsafe 4', () => {
+  const T = Type.Record(Type.String(), Type.String())
+  const D = DecodeUnsafe({}, T, undefined)
+  Assert.IsEqual(D, undefined)
+})
+Test('Should DecodeUnsafe 5', () => {
+  const T = Type.Record(Type.Number(), Type.String())
+  const D = DecodeUnsafe({}, T, { x: 1 })
+  Assert.IsEqual(D, { x: 1 })
+})

--- a/test/typebox/runtime/value/codec/~decode-unsafe.ts
+++ b/test/typebox/runtime/value/codec/~decode-unsafe.ts
@@ -9,7 +9,7 @@ const Test = Assert.Context('Value.Codec.DecodeUnsafe')
 // ------------------------------------------------------------------
 Test('Should DecodeUnsafe 1', () => {
   const T = Type.Object({
-    x: Type.Optional(Type.Number())
+    x: Type.Number()
   })
   const D = DecodeUnsafe({}, T, undefined)
   Assert.IsEqual(D, undefined)


### PR DESCRIPTION
This PR adds coverage for UnsafeDecode `Unreachable` cases. Previously these cases were Unreachable when calling thorugh Decode(). This PR adds defacto value fall-through if the value is not a candidate for Decode.

The fall through cases apply to:

- FromArray - Fall through if not Array
- FromObject  - Fall through if not Object
- FromRecord - Fall through if not Object, Continue for Non-Matching Key
- FromTuple - Fall through if not Array


