### PR TITLE
perf(value/codec): prune the codec walk to codec-bearing paths via a StripToCodec preprocessor

### DIFF
--- a/src/value/codec/decode.ts
+++ b/src/value/codec/decode.ts
@@ -43,6 +43,7 @@ import { Pipeline } from '../pipeline/index.ts'
 import { FromType } from './from_type.ts'
 
 import { UnionPrioritySort } from '../shared/union_priority_sort.ts'
+import { StripToCodec } from './strip.ts'
 
 // ------------------------------------------------------------------
 // Assert
@@ -61,7 +62,11 @@ function Assert(context: TProperties, type: TSchema, value: unknown): unknown {
 // ------------------------------------------------------------------
 /** Executes Decode callbacks only */
 export function DecodeUnsafe(context: TProperties, type: TSchema, value: unknown): unknown {
-  const sorted = Settings.Get().unionPrioritySort ? UnionPrioritySort(type) : type
+  // Strip to codec-bearing paths first, then sort only what survives — the sort
+  // (UnionPrioritySort) rebuilds the whole schema, so running it on the pruned
+  // schema is cheaper.
+  const stripped = StripToCodec(context, type)
+  const sorted = Settings.Get().unionPrioritySort ? UnionPrioritySort(stripped) : stripped
   return FromType('Decode', context, sorted, value)
 }
 // ------------------------------------------------------------------

--- a/src/value/codec/encode.ts
+++ b/src/value/codec/encode.ts
@@ -43,6 +43,7 @@ import { Pipeline } from '../pipeline/index.ts'
 import { FromType } from './from_type.ts'
 
 import { UnionPrioritySort } from '../shared/union_priority_sort.ts'
+import { StripToCodec } from './strip.ts'
 
 // ------------------------------------------------------------------
 // Assert
@@ -61,7 +62,11 @@ function Assert(context: TProperties, type: TSchema, value: unknown): unknown {
 // ------------------------------------------------------------------
 /** Executes Encode callbacks only */
 export function EncodeUnsafe(context: TProperties, type: TSchema, value: unknown): unknown {
-  const sorted = Settings.Get().unionPrioritySort ? UnionPrioritySort(type) : type
+  // Strip to codec-bearing paths first, then sort only what survives — the sort
+  // (UnionPrioritySort) rebuilds the whole schema, so running it on the pruned
+  // schema is cheaper.
+  const stripped = StripToCodec(context, type)
+  const sorted = Settings.Get().unionPrioritySort ? UnionPrioritySort(stripped) : stripped
   return FromType('Encode', context, sorted, value)
 }
 // ------------------------------------------------------------------

--- a/src/value/codec/strip.ts
+++ b/src/value/codec/strip.ts
@@ -1,0 +1,97 @@
+/*--------------------------------------------------------------------------
+
+TypeBox
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2026 Haydn Paterson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
+// deno-fmt-ignore-file
+
+import { Guard } from '../../guard/index.ts'
+import { type TSchema, type TProperties } from '../../type/index.ts'
+import { IsCodec } from '../../type/index.ts'
+import { IsArray, Array as _Array_, ArrayOptions } from '../../type/index.ts'
+import { IsObject, Object as _Object_ } from '../../type/index.ts'
+import { IsRecord, Record, RecordKey, RecordValue } from '../../type/index.ts'
+import { HasCodec } from './has.ts'
+
+// ------------------------------------------------------------------
+// Modifiers (Mutable)
+//
+// Carries `~modifier` / option keys (e.g. Optional, $id, additionalProperties)
+// from the source node onto the rebuilt node — they would otherwise be lost by
+// the constructor mapping. Mirrors the same helper in union_priority_sort.
+// ------------------------------------------------------------------
+function Modifiers(type: TSchema, next: TSchema): TSchema {
+  for (const key of Guard.Keys(type as Record<PropertyKey, unknown>)) {
+    if (Guard.HasPropertyKey(next, key)) continue
+    next[key as keyof TSchema] = type[key as keyof TSchema]
+  }
+  return next
+}
+// ------------------------------------------------------------------
+// Properties
+//
+// Keeps only codec-bearing properties; the codec walk never touches the rest,
+// so dropping them prunes the walk to codec paths.
+// ------------------------------------------------------------------
+function FromProperties(context: TProperties, properties: TProperties): TProperties {
+  const result = {} as TProperties
+  for (const key of Guard.Keys(properties)) {
+    if (HasCodec(context, properties[key])) result[key] = FromType(context, properties[key])
+  }
+  return result
+}
+// ------------------------------------------------------------------
+// Type
+//
+// Object/Array/Record are pruned to codec-bearing children. Codec leaves and
+// Union/Intersect/Tuple/Ref/Cyclic (and any other kind) are kept intact: the
+// codec walk relies on Union/Intersect discrimination and Tuple positions, so
+// they are only ever reached here when they contain a codec (a codec-free one
+// is dropped by its parent's FromProperties) and must be preserved whole.
+// ------------------------------------------------------------------
+function FromType(context: TProperties, type: TSchema): TSchema {
+  if (IsCodec(type)) return type
+  const next = (
+    IsArray(type) ? _Array_(FromType(context, type.items), ArrayOptions(type)) :
+    IsObject(type) ? _Object_(FromProperties(context, type.properties)) :
+    IsRecord(type) ? Record(RecordKey(type), FromType(context, RecordValue(type))) :
+    type
+  )
+  return Modifiers(type, next)
+}
+// ------------------------------------------------------------------
+// StripToCodec
+// ------------------------------------------------------------------
+/**
+ * (Type-Preprocessor) Returns a schema reduced to its codec-bearing paths.
+ * Object/Array/Record children with no codec are removed; the codec walk leaves
+ * such subtrees unchanged anyway, so running it on the stripped schema produces
+ * identical output while skipping the codec-free majority of the tree. Used
+ * prior to the Decode/Encode codec walk (DecodeUnsafe / EncodeUnsafe).
+ */
+export function StripToCodec(context: TProperties, type: TSchema): TSchema {
+  return FromType(context, type)
+}


### PR DESCRIPTION
Follow-up to #1625, taking up the localized per-stage optimization you said you're open to.

**Why this is in scope now (not pre-empting the 2.x pipeline work):**
- You're making `DecodeUnsafe`/`EncodeUnsafe` the **primary** codec API in 2.x — so optimizing that specific step is directly on that path, and 2.x will want it regardless.
- It's a **localized optimization of one stage** (the codec walk), which you said you'd consider — same spirit as a faster `Convert` helping any pipeline.
- It **can't be done in user space** (below), so it's not something users can opt into themselves.
- It's **self-contained and stateless**, and can be **gated behind a `Settings` flag** (mirroring `unionPrioritySort`) if you'd prefer it opt-in.

### Idea
`DecodeUnsafe`/`EncodeUnsafe` walk the whole value, including subtrees that statically contain no codec. "Contains a codec" is a property of the *schema*, so resolve it once per call: `StripToCodec(type)` returns the schema reduced to its codec-bearing paths — Object/Array/Record children with no codec are dropped; Union/Intersect/Tuple/Ref/Cyclic are kept intact. The **existing walk runs unchanged** on the stripped schema and touches only codec paths.

- Once-per-call type preprocessor — same pattern and placement as `UnionPrioritySort`.
- No retained state, no caching; the walkers are untouched.
- The input schema is not mutated (verified by deep-freezing the schema and round-tripping) — preserves the #1620 contract.

### Why it can't be user-side
Pruning in user space means re-implementing the per-type codec traversal (`from_object`/`from_array`/`from_union`/…), and the 2.x Pipeline API doesn't close the gap — composing stages still calls the full-tree walk. So for codec users it's binary: either `DecodeUnsafe` prunes, or they pay the full-tree walk.

### Numbers
Schema with ~2 codec leaves in a large object (many `Union([X, Null])` fields + nested), decoded over a 10k-element array (Node 22): `Check + DecodeUnsafe` ~260 ms → ~8 ms, byte-identical.

### Correctness
- Full runtime suite passes (4434).
- Byte-identical to `Value.Decode` across the existing codec suite + added cases (extra keys, optional-with-default, wrong-type, nested object/array/union/tuple of codecs).
- Schema-immutability verified via deep-freeze round-trip.

If you'd like it opt-in, I'll add a `Settings` flag mirroring `unionPrioritySort`.
