### PR TITLE
Version 1.3.1

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -1,5 +1,14 @@
 # 1.3.0
 
+
+---
+
+### Version Updates
+- [Revision 1.3.1](https://github.com/sinclairzx81/typebox/pull/1638)
+  - Unsafe Keyword Uses Property Enumeration Rules on Clone
+
+
+
 ---
 
 <a name="Overview"></a>

--- a/src/system/memory/clone.ts
+++ b/src/system/memory/clone.ts
@@ -43,15 +43,18 @@ function FromClassInstance(value: Record<PropertyKey, unknown>): Record<Property
   return value // atomic
 }
 // ------------------------------------------------------------------
-// KindedObject
+// TypeObject
 //
 // Types have non-enumerable properties that MUST be preserved on Clone. 
 // The following is the optimal path for TypeBox types.
 // ------------------------------------------------------------------
-function IsKindedObject(value: Record<PropertyKey, unknown>): boolean {
-  return Guard.HasPropertyKey(value, '~kind')
+function IsTypeObject(value: Record<PropertyKey, unknown>): boolean {
+  return (
+    Guard.HasPropertyKey(value, '~kind') || 
+    Guard.HasPropertyKey(value, '~unsafe')
+  )
 }
-function FromKindedObject(value: Record<PropertyKey, unknown>): Record<PropertyKey, unknown> {
+function FromTypeObject(value: Record<PropertyKey, unknown>): Record<PropertyKey, unknown> {
   const result = {} as Record<PropertyKey, unknown>
   const descriptors = Object.getOwnPropertyDescriptors(value)
   for (const key of Object.keys(descriptors)) {
@@ -83,7 +86,7 @@ function FromPlainObject(value: Record<PropertyKey, unknown>): Record<PropertyKe
 function FromObject(value: Record<PropertyKey, unknown>): Record<PropertyKey, unknown> {
   return (
     Guard.IsClassInstance(value) ? FromClassInstance(value) :
-    IsKindedObject(value) ? FromKindedObject(value) :
+    IsTypeObject(value) ? FromTypeObject(value) :
     FromPlainObject(value)
   )
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -115,7 +115,7 @@ Task.run('metrics', () => Metrics())
 // ------------------------------------------------------------------
 // Native
 // ------------------------------------------------------------------
-Task.run('native', (target: string = `target/build`) => Task.tsgo('latest')
+Task.run('native', (target: string = `target/build`) => Task.tsgo('beta')
   .run('src/index.ts --target ESNext --module ESNext --strict --noEmit --ignoreConfig --allowImportingTsExtensions'))
 // ------------------------------------------------------------------
 // Range
@@ -128,5 +128,8 @@ Task.run('range', async () => {
   ])
   await Range.Modern([
     '6.0.2', '6.0.3', 'next', 'latest', 
+  ])
+  await Range.Modern([
+    '7.0.1-rc'
   ])
 })

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.3.0'
+const Version = '1.3.1'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/common/assert.ts
+++ b/test/common/assert.ts
@@ -30,6 +30,18 @@ export function NotHasPropertyKey<K extends PropertyKey>(value: unknown, key: K)
   if (typeof value === 'object' && value !== null && !(key in value)) return
   throw new Error(`Expected value not to have property '${key as string}'`)
 }
+/** Property Exists and IS Enumerable */
+export function PropertyIsEnumerable<K extends PropertyKey>(value: unknown, key: K): asserts value is Record<K, unknown> {
+  HasPropertyKey(value, key)
+  if (globalThis.Object.getOwnPropertyDescriptor(value, key)?.enumerable ?? false) return
+  throw new Error(`Expected property to be enumerable '${key as string}'`)
+}
+/** Property Exists and IS-NOT Enumerable */
+export function NotPropertyIsEnumerable<K extends PropertyKey>(value: unknown, key: K): asserts value is Record<K, unknown> {
+  HasPropertyKey(value, key)
+  if (!(globalThis.Object.getOwnPropertyDescriptor(value, key)?.enumerable ?? false)) return
+  throw new Error(`Expected property to not be enumerable '${key as string}'`)
+}
 // ------------------------------------------------------------------
 // Logic
 // ------------------------------------------------------------------

--- a/test/typebox/runtime/system/memory.ts
+++ b/test/typebox/runtime/system/memory.ts
@@ -1,5 +1,6 @@
 import { Memory, Settings } from 'typebox/system'
 import { Assert } from 'test'
+import Type from 'typebox'
 
 const Test = Assert.Context('System.Memory')
 
@@ -86,4 +87,31 @@ Test('Should Create 7', () => {
   const B = Memory.Clone(A)
   Assert.NotHasPropertyKey(B, '__proto__')
   Assert.HasPropertyKey(B, '~kind')
+})
+// ------------------------------------------------------------------
+// TypedObject (Kind + Unsafe)
+// ------------------------------------------------------------------
+Test('Should Create 8', () => {
+  const A = Type.String()
+  const B = Memory.Clone(A)
+  Assert.NotPropertyIsEnumerable(B, '~kind')
+})
+Test('Should Create 9', () => {
+  const A = Type.Unsafe({ type: 'Date' })
+  const B = Memory.Clone(A)
+  Assert.NotPropertyIsEnumerable(B, '~unsafe')
+})
+Test('Should Create 10', () => {
+  Settings.Set({ enumerableKind: true })
+  const A = Type.String()
+  const B = Memory.Clone(A)
+  Assert.PropertyIsEnumerable(B, '~kind')
+  Settings.Reset()
+})
+Test('Should Create 11', () => {
+  Settings.Set({ enumerableKind: true })
+  const A = Type.Unsafe({ type: 'Date' })
+  const B = Memory.Clone(A)
+  Assert.PropertyIsEnumerable(B, '~unsafe')
+  Settings.Reset()
 })


### PR DESCRIPTION
This PR updates System Clone to ensure the `~unsafe` property follows property enumerable rules. It also updates tasks to work around a regression in Deno 2.9.0 NPM resolution issue for TypeScript Native Preview

Fixes: https://github.com/sinclairzx81/typebox/issues/1637