### PR TITLE
Version 1.3.1 (Continued)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: 2.5.4
+          deno-version: 2.9.0
       # Build
       - name: Test Library
         run: deno task test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       # Deno
-      - uses: denoland/setup-deno@v2
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.5
+          deno-version: 2.9.0
 
       # Update
       - name: Update

--- a/src/format/_idna.ts
+++ b/src/format/_idna.ts
@@ -63,7 +63,8 @@ const RFC5892_DISALLOWED = new Set([
 // ------------------------------------------------------------------
 // A set of Virama (halant) code points used to validate CONTEXTJ
 // rules (RFC 5892 Appendix A.1). These characters allow a subsequent
-// Zero Width Joiner (U+200D) to be valid in a label.
+// Zero Width Non-Joiner (U+200C) or Zero Width Joiner (U+200D) to
+// be valid in a label.
 // ------------------------------------------------------------------
 const VIRAMA_CPS = new Set<number>([
   0x094d,
@@ -163,9 +164,15 @@ function IsUnicodeLabel(value: string): boolean {
       case 0x05f4:
         if (prev === undefined || !IsHebrew(prev)) return false
         break // Hebrew GERESH
-      case 0x200d:
+      case 0x200c: // ZWNJ - RFC 5892 Appendix A.1
+        // Note: Full validation requires a Unicode joining type table. We reject
+        // only when preceded by ASCII (U+0000-U+007F), which can never satisfy
+        // the Virama or cursive-joining rules.
+        if (prev === undefined || (prev < 0x0080 && !IsVirama(prev))) return false
+        break
+      case 0x200d: // ZWJ  - RFC 5892 Appendix A.2
         if (prev === undefined || !IsVirama(prev)) return false
-        break // ZWJ
+        break
       case 0x30fb: /* Checked at end via hasJapanese */
         break // KATAKANA MIDDLE DOT
     }

--- a/src/format/_idna.ts
+++ b/src/format/_idna.ts
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+import { Unreachable } from '../system/unreachable/unreachable.ts'
 import * as Puny from './_puny.ts'
 
 // ------------------------------------------------------------------
@@ -130,7 +131,10 @@ function IsVirama(cp: number): boolean {
 // IsUnicodeLabel
 // ------------------------------------------------------------------
 function IsUnicodeLabel(value: string): boolean {
-  if (value.length === 0) return false
+  // deno-coverage-ignore-start - guarded by puny code check
+  if (value.length === 0) return Unreachable() // false
+  // deno-coverage-ignore-stop
+
   // Use spread to handle surrogate pairs and provide O(1) neighbor access
   const cps = [...value].map((c) => c.codePointAt(0)!)
   const len = cps.length

--- a/src/format/_idna.ts
+++ b/src/format/_idna.ts
@@ -131,10 +131,7 @@ function IsVirama(cp: number): boolean {
 // IsUnicodeLabel
 // ------------------------------------------------------------------
 function IsUnicodeLabel(value: string): boolean {
-  // deno-coverage-ignore-start - guarded by puny code check
-  if (value.length === 0) return Unreachable() // false
-  // deno-coverage-ignore-stop
-
+  if (value.length === 0) return false
   // Use spread to handle surrogate pairs and provide O(1) neighbor access
   const cps = [...value].map((c) => c.codePointAt(0)!)
   const len = cps.length

--- a/src/format/_idna.ts
+++ b/src/format/_idna.ts
@@ -26,7 +26,6 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-import { Unreachable } from '../system/unreachable/unreachable.ts'
 import * as Puny from './_puny.ts'
 
 // ------------------------------------------------------------------

--- a/test/jsonschema/cases/draft2019-09/optional/format/idn-hostname.json
+++ b/test/jsonschema/cases/draft2019-09/optional/format/idn-hostname.json
@@ -333,6 +333,12 @@
         "valid": false
       },
       {
+        "description": "zero width non-joiner must pass at every occurrence",
+        "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
+        "data": "क्‌षx‌y",
+        "valid": false
+      },
+      {
         "description": "non-canonical Punycode that does not re-encode to itself is invalid",
         "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
         "data": "xn---9uc",

--- a/test/jsonschema/cases/draft2020-12/optional/format/idn-hostname.json
+++ b/test/jsonschema/cases/draft2020-12/optional/format/idn-hostname.json
@@ -333,6 +333,12 @@
         "valid": false
       },
       {
+        "description": "zero width non-joiner must pass at every occurrence",
+        "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
+        "data": "क्‌षx‌y",
+        "valid": false
+      },
+      {
         "description": "non-canonical Punycode that does not re-encode to itself is invalid",
         "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
         "data": "xn---9uc",

--- a/test/jsonschema/cases/draft7/optional/format/idn-hostname.json
+++ b/test/jsonschema/cases/draft7/optional/format/idn-hostname.json
@@ -327,6 +327,12 @@
         "valid": false
       },
       {
+        "description": "zero width non-joiner must pass at every occurrence",
+        "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
+        "data": "क्‌षx‌y",
+        "valid": false
+      },
+      {
         "description": "non-canonical Punycode that does not re-encode to itself is invalid",
         "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
         "data": "xn---9uc",

--- a/test/jsonschema/cases/v1/format/idn-hostname.json
+++ b/test/jsonschema/cases/v1/format/idn-hostname.json
@@ -333,6 +333,12 @@
         "valid": false
       },
       {
+        "description": "zero width non-joiner must pass at every occurrence",
+        "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
+        "data": "क्‌षx‌y",
+        "valid": false
+      },
+      {
         "description": "non-canonical Punycode that does not re-encode to itself is invalid",
         "comment": "https://www.rfc-editor.org/rfc/rfc5891#section-5.4 a label decoded from Punycode must be identical to the original A-label",
         "data": "xn---9uc",

--- a/test/typebox/runtime/system/memory.ts
+++ b/test/typebox/runtime/system/memory.ts
@@ -71,22 +71,24 @@ Test('Should Create 4', () => {
 // UnsafePropertyKey
 // ------------------------------------------------------------------
 Test('Should Create 5', () => {
-  const A = { '__proto__': 1, '~kind': 'test' }
+  const A = { '~kind': 'test', '__proto__': 1 }
   const B = Memory.Clone(A)
-  Assert.NotHasPropertyKey(B, '__proto__')
   Assert.HasPropertyKey(B, '~kind')
+  Assert.HasPropertyKey(B, '__proto__')
+  Assert.NotEqual(B['__proto__'], 1)
 })
 Test('Should Create 6', () => {
-  const A = { 'constructor': 1, '~kind': 'test' }
+  const A = { '~kind': 'test', 'constructor': 1 }
   const B = Memory.Clone(A)
-  Assert.NotHasPropertyKey(B, '__proto__')
   Assert.HasPropertyKey(B, '~kind')
+  Assert.HasPropertyKey(B, 'constructor')
+  Assert.NotEqual(B['constructor'], 1)
 })
 Test('Should Create 7', () => {
-  const A = { 'prototype': 1, '~kind': 'test' }
+  const A = { '~kind': 'test', 'prototype': 1 }
   const B = Memory.Clone(A)
-  Assert.NotHasPropertyKey(B, '__proto__')
   Assert.HasPropertyKey(B, '~kind')
+  Assert.NotHasPropertyKey(B, 'prototype')
 })
 // ------------------------------------------------------------------
 // TypedObject (Kind + Unsafe)


### PR DESCRIPTION
This PR implements additional updates related to Deno 2.9.0 `__proto__` behavior change. 

Previous versions of Deno would modify the `__proto__` to make it non-enumerable, however this was non-standard behavior. Deno 2.9.0 adheres to the JavaScript specification as the default, which means the TypeBox `__proto__` unit tests need to be updated inline with 2.9.0

Updates: 
- Memory Tests (Clone)
- Github Actions (Build | Publish use Deno 2.9.0)

## Additional

This PR includes additional updates for IDNA / ZWNJ checking inline with the following test suite updates.

https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/939