### PR TITLE
fix(guard): accept negative multiples of a fractional multipleOf

### DIFF
--- a/src/guard/guard.ts
+++ b/src/guard/guard.ts
@@ -116,7 +116,7 @@ export function IsMultipleOf(dividend: bigint | number, divisor: bigint | number
   if (!IsNumber(dividend)) return true
   if (IsInteger(dividend) && (1 / divisor) % 1 === 0) return true
   const mod = dividend % divisor
-  return Math.min(Math.abs(mod), Math.abs(mod - divisor)) < tolerance
+  return Math.min(Math.abs(mod), Math.abs(mod - divisor), Math.abs(mod + divisor)) < tolerance
 }
 // ------------------------------------------------------------------
 // IsClassInstance

--- a/test/typebox/runtime/value/check/number.ts
+++ b/test/typebox/runtime/value/check/number.ts
@@ -84,6 +84,15 @@ Test('Should validate multipleOf', () => {
   Ok(T, 2)
   Fail(T, 1)
 })
+Test('Should validate multipleOf (negative fractional)', () => {
+  const T = Type.Number({ multipleOf: 0.1 })
+  Ok(T, 9.9)
+  Ok(T, -9.9)
+  Ok(T, -0.3)
+  Ok(T, -0.7)
+  Ok(T, -2.3)
+  Fail(T, -0.15)
+})
 // ------------------------------------------------------------------
 // Constraints: BigInt
 // ------------------------------------------------------------------


### PR DESCRIPTION
`Value.Check` and the compiled `TypeCompiler` wrongly reject a negative number that is a valid multiple of a fractional `multipleOf`, while accepting its positive twin.

## Repro

```ts
Value.Check(Type.Number({ multipleOf: 0.1 }), 9.9)   // true  (correct)
Value.Check(Type.Number({ multipleOf: 0.1 }), -9.9)  // false (wrong)

const C = Compile(Type.Number({ multipleOf: 0.1 }))
C.Check(9.9)   // true  (correct)
C.Check(-9.9)  // false (wrong)
```

## Root cause

`IsMultipleOf` measures the floating-point remainder against only two candidates:

```ts
const mod = dividend % divisor
return Math.min(Math.abs(mod), Math.abs(mod - divisor)) < tolerance
```

In JavaScript `%` takes the sign of the dividend, so for a negative value whose true remainder is ~0, `mod` lands near `-divisor`. For example `-9.9 % 0.1 = -0.09999999999999981`, and the two tested candidates are `Math.abs(mod)` (~0.0999) and `Math.abs(mod - divisor)` (~0.1999), both above tolerance. The candidate that is actually near zero, `Math.abs(mod + divisor)` (~1.9e-16), was never measured, so the check reported "not a multiple". The result is sign-asymmetric: `9.9` passes, `-9.9` fails.

## Fix

Add the missing `-divisor` candidate so the remainder is compared against the nearest of `{0, +divisor, -divisor}`:

```ts
return Math.min(Math.abs(mod), Math.abs(mod - divisor), Math.abs(mod + divisor)) < tolerance
```

## Authority

Per JSON Schema, `multipleOf` is sign-irrelevant: an instance is valid iff `instance / multipleOf` is an integer, and `-9.9 / 0.1 = -99`. Both signs must validate.

This mirrors the existing positive-dividend fix (#755 for #754); the `+divisor` candidate handles positive values landing near `+divisor`, and this adds the symmetric `-divisor` candidate for negative values. Integer fast-path, zero, and non-fractional cases are unchanged.

## Tests

Added a case under `Value.Check.Number` covering `-9.9`, `-0.3`, `-0.7`, `-2.3` (accepted) and `-0.15` (rejected), exercising the `Value.Check`, `Compile().Check`, and `Value.Errors` paths. It fails on the current line and passes with the fix. Full suite: 35006 passed, 1 failed. The single failure is the pre-existing `System.Memory: Should Create 5` (`__proto__`) test, which also fails on a clean checkout and is unrelated to this change.
