### PR TITLE
Version 1.3.4

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -4,6 +4,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.3.4](https://github.com/sinclairzx81/typebox/pull/1644)
+  - Use SchemaRef + Href Registry for Improved Compiler Performance
 - [Revision 1.3.3](https://github.com/sinclairzx81/typebox/pull/1642)
   - IsMultipleOf Accepts Negative Fractional Multiples
 - [Revision 1.3.2](https://github.com/sinclairzx81/typebox/pull/1640)

--- a/design/website/docs/script/1_syntax.md
+++ b/design/website/docs/script/1_syntax.md
@@ -1,12 +1,11 @@
 # Script.Syntax
 
-TypeBox is designed to be a programmable DSL for the JSON Schema specification. It uses JSON Schema as an intermediate representation for TypeScript types (tentatively named Type IR), and evaluates it using the type semantics of the TypeScript language.
+TypeBox is designed to be a programmable TypeScript based DSL for the JSON Schema specification. It uses JSON Schema as an intermediate representation (IR) for TypeScript types, and evaluates the IR using the semantics of the TypeScript language.
 
-The TypeBox Script function is the DSL interface. It accepts TypeScript type-level expressions and resolves them to their TypeBox equivalents. It supports interfaces, type aliases, conditional types, mapped types, indexed access, generics, and union distribution. The Script function returns parsed TypeBox types that can be inferred with `Static<T>`
 
 ## Types
 
-Script has support for most TypeScript types and structural constructs. Each type will map into its corresponding TypeBox representation, which can be serialized as JSON Schema or compiled into a validator.
+Script has support for most TypeScript types and syntactic constructs. Each type will map into its corresponding TypeBox IR representation.
 
 ```typescript
 // ------------------------------------------------------------------

--- a/design/website/docs/script/overview.md
+++ b/design/website/docs/script/overview.md
@@ -4,24 +4,22 @@ TypeScript Syntax Engine For JSON Schema
 
 ## Overview
 
-TypeBox includes a syntax engine that can transform TypeScript declarations into JSON Schema. The engine is a full syntactic frontend to Type.* and supports many advanced type-level constructs such as Conditional, Mapped, Indexed, Infer, Generics, Distributed types and more. This feature is implemented symmetrically at runtime and statically via TypeScript Template Literal types. 
-
-Syntax highlighting is available via the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=sinclairzx81.typebox-script)
+TypeBox includes a micro TypeScript scripting engine that can parse TypeScript definitions into JSON Schema. The engine is implemented at runtime as well as statically inside TypeScript's type system, and supports many programmable constructs such as conditional, mapped, indexed, generic, and distributed types, and more.
 
 ### Example
 
-The following uses Script to parse TypeScript declarations into JSON Schema.
+Syntax highlighting is available via the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=sinclairzx81.typebox-script)
 
 ```typescript
 // Module
 const Math = Type.Script(`
   type Vector2 = { x: number, y: number }
-  type Vector3 = Evaluate<Vector2 & { z: number }>
-  type Vector4 = Evaluate<Vector3 & { w: number }>
+  type Vector3 = { x: number, y: number, z: number }
+  type Vector4 = { x: number, y: number, z: number, w: number }
 `)
 
 // Dependent Module
-const { Mesh } = Type.Script({ ...Math }, `  
+const { Mesh } = Type.Script(Math, `  
   type Vertex = {
     position: Vector4,
     normal: Vector3,

--- a/docs/docs/script/1_syntax.html
+++ b/docs/docs/script/1_syntax.html
@@ -1,8 +1,7 @@
 <h1>Script.Syntax</h1>
-<p>TypeBox is designed to be a programmable DSL for the JSON Schema specification. It uses JSON Schema as an intermediate representation for TypeScript types (tentatively named Type IR), and evaluates it using the type semantics of the TypeScript language.</p>
-<p>The TypeBox Script function is the DSL interface. It accepts TypeScript type-level expressions and resolves them to their TypeBox equivalents. It supports interfaces, type aliases, conditional types, mapped types, indexed access, generics, and union distribution. The Script function returns parsed TypeBox types that can be inferred with <code>Static&lt;T&gt;</code></p>
+<p>TypeBox is designed to be a programmable TypeScript based DSL for the JSON Schema specification. It uses JSON Schema as an intermediate representation (IR) for TypeScript types, and evaluates the IR using the semantics of the TypeScript language.</p>
 <h2>Types</h2>
-<p>Script has support for most TypeScript types and structural constructs. Each type will map into its corresponding TypeBox representation, which can be serialized as JSON Schema or compiled into a validator.</p>
+<p>Script has support for most TypeScript types and syntactic constructs. Each type will map into its corresponding TypeBox IR representation.</p>
 <pre><code class="language-typescript">// ------------------------------------------------------------------
 // Literal
 // ------------------------------------------------------------------

--- a/docs/docs/script/overview.html
+++ b/docs/docs/script/overview.html
@@ -1,19 +1,18 @@
 <h1>Script</h1>
 <p>TypeScript Syntax Engine For JSON Schema</p>
 <h2>Overview</h2>
-<p>TypeBox includes a syntax engine that can transform TypeScript declarations into JSON Schema. The engine is a full syntactic frontend to Type.* and supports many advanced type-level constructs such as Conditional, Mapped, Indexed, Infer, Generics, Distributed types and more. This feature is implemented symmetrically at runtime and statically via TypeScript Template Literal types. </p>
-<p>Syntax highlighting is available via the <a href="https://marketplace.visualstudio.com/items?itemName=sinclairzx81.typebox-script">Visual Studio Marketplace</a></p>
+<p>TypeBox includes a micro TypeScript scripting engine that can parse TypeScript definitions into JSON Schema. The engine is implemented at runtime as well as statically inside TypeScript&#39;s type system, and supports many programmable constructs such as conditional, mapped, indexed, generic, and distributed types, and more.</p>
 <h3>Example</h3>
-<p>The following uses Script to parse TypeScript declarations into JSON Schema.</p>
+<p>Syntax highlighting is available via the <a href="https://marketplace.visualstudio.com/items?itemName=sinclairzx81.typebox-script">Visual Studio Marketplace</a></p>
 <pre><code class="language-typescript">// Module
 const Math = Type.Script(`
   type Vector2 = { x: number, y: number }
-  type Vector3 = Evaluate&lt;Vector2 &amp; { z: number }&gt;
-  type Vector4 = Evaluate&lt;Vector3 &amp; { w: number }&gt;
+  type Vector3 = { x: number, y: number, z: number }
+  type Vector4 = { x: number, y: number, z: number, w: number }
 `)
 
 // Dependent Module
-const { Mesh } = Type.Script({ ...Math }, `  
+const { Mesh } = Type.Script(Math, `  
   type Vertex = {
     position: Vector4,
     normal: Vector3,

--- a/example/mcp/index.ts
+++ b/example/mcp/index.ts
@@ -26,6 +26,4 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-export * from './discriminated_union.ts'
-export * from './dynamic.ts'
-export * from './reverse_static.ts'
+export * from './type.ts'

--- a/example/mcp/readme.md
+++ b/example/mcp/readme.md
@@ -1,0 +1,50 @@
+# Mcp: ProtocolType
+
+This example demonstrates how to compile and infer the Mcp Protocol specification directly from JSON Schema. The example uses no code generation, all inference is derived via TypeBox's JSON Schema compiler infrastructure.
+
+## Usage
+
+The following compiles the CallToolRequest protocol definition and parses a value.
+
+```typescript
+import { ProtocolValidator, type ProtocolType } from './mcp/index.ts'
+
+// ------------------------------------------------------------------
+// Type
+// ------------------------------------------------------------------
+type CallToolRequest = ProtocolType<'CallToolRequest'>
+
+// ------------------------------------------------------------------
+// Validator
+// ------------------------------------------------------------------
+const CallToolRequestValidator = ProtocolValidator('CallToolRequest')
+
+// ------------------------------------------------------------------
+// Parse
+// ------------------------------------------------------------------
+const callToolRequest = CallToolRequestValidator.Parse({ 
+  id: '...',
+  jsonrpc: '2.0',
+  method: 'tools/call',
+  params: {
+    _meta: {
+      'io.modelcontextprotocol/clientCapabilities': {},
+      'io.modelcontextprotocol/clientInfo': { name: '...', version: '...' },
+      'io.modelcontextprotocol/protocolVersion': '1',
+    },
+    name: 'add',
+    arguments: {
+      x: 1,
+      y: 2
+    }
+  }
+})
+
+// ------------------------------------------------------------------
+// TypeSafe
+// ------------------------------------------------------------------
+callToolRequest.id                // 'id'
+callToolRequest.jsonrpc           // '2.0'
+callToolRequest.method            // 'tools/call'
+callToolRequest.params            // { ... }
+```

--- a/example/mcp/spec.ts
+++ b/example/mcp/spec.ts
@@ -1,0 +1,3940 @@
+// -------------------------------------------------------------------------------------------------
+//
+// spec: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/draft/schema.json
+//
+// Paste Specification Updates Here
+//
+// -------------------------------------------------------------------------------------------------
+export default {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "Annotations": {
+      "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+      "properties": {
+        "audience": {
+          "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+          "items": {
+            "$ref": "#/$defs/Role"
+          },
+          "type": "array"
+        },
+        "lastModified": {
+          "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
+          "type": "string"
+        },
+        "priority": {
+          "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "AudioContent": {
+      "description": "Audio provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "data": {
+          "description": "The base64-encoded audio data.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of the audio. Different providers may support different audio types.",
+          "type": "string"
+        },
+        "type": {
+          "const": "audio",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "mimeType",
+        "type"
+      ],
+      "type": "object"
+    },
+    "BaseMetadata": {
+      "description": "Base interface for metadata with name (identifier) and title (display name) properties.",
+      "properties": {
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "BlobResourceContents": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "blob": {
+          "description": "A base64-encoded string representing the binary data of the item.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "blob",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "BooleanSchema": {
+      "properties": {
+        "default": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "boolean",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "CacheableResult": {
+      "description": "A result that supports a time-to-live (TTL) hint for client-side caching.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "CallToolRequest": {
+      "description": "Used by the client to invoke a tool provided by the server.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "tools/call",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CallToolRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CallToolRequestParams": {
+      "description": "Parameters for a `tools/call` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "arguments": {
+          "additionalProperties": {},
+          "description": "Arguments to use for the tool call.",
+          "type": "object"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "name": {
+          "description": "The name of the tool.",
+          "type": "string"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "name"
+      ],
+      "type": "object"
+    },
+    "CallToolResult": {
+      "description": "The result returned by the server for a {@link CallToolRequesttools/call} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "content": {
+          "description": "A list of content objects that represent the unstructured result of the tool call.",
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "type": "array"
+        },
+        "isError": {
+          "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+          "type": "boolean"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "structuredContent": {
+          "description": "An optional JSON value that represents the structured result of the tool call.\n\nThis can be any JSON value (object, array, string, number, boolean, or null)\nthat conforms to the tool's outputSchema if one is defined."
+        }
+      },
+      "required": [
+        "content",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "CallToolResultResponse": {
+      "description": "A successful response from the server for a {@link CallToolRequesttools/call} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/CallToolResult"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "CancelledNotification": {
+      "description": "This notification is sent by the client to indicate that it is cancelling a request it previously issued.\n\nOn stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/cancelled",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CancelledNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CancelledNotificationParams": {
+      "description": "Parameters for a `notifications/cancelled` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "reason": {
+          "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+          "type": "string"
+        },
+        "requestId": {
+          "$ref": "#/$defs/RequestId",
+          "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request the client previously issued."
+        }
+      },
+      "required": [
+        "requestId"
+      ],
+      "type": "object"
+    },
+    "ClientCapabilities": {
+      "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+      "properties": {
+        "elicitation": {
+          "description": "Present if the client supports elicitation from the server.",
+          "properties": {
+            "form": {
+              "$ref": "#/$defs/JSONObject"
+            },
+            "url": {
+              "$ref": "#/$defs/JSONObject"
+            }
+          },
+          "type": "object"
+        },
+        "experimental": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Experimental, non-standard capabilities that the client supports.",
+          "type": "object"
+        },
+        "extensions": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Optional MCP extensions that the client supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/oauth-client-credentials\"), and values are\nper-extension settings objects. An empty object indicates support with no settings.\n\nKeys MUST follow the {@link MetaObject`_meta` key naming rules}, with a\nmandatory prefix.",
+          "type": "object"
+        },
+        "roots": {
+          "description": "Present if the client supports listing roots.",
+          "properties": {},
+          "type": "object"
+        },
+        "sampling": {
+          "description": "Present if the client supports sampling from an LLM.",
+          "properties": {
+            "context": {
+              "$ref": "#/$defs/JSONObject",
+              "description": "Whether the client supports context inclusion via `includeContext` parameter.\nIf not declared, servers SHOULD only use `includeContext: \"none\"` (or omit it)."
+            },
+            "tools": {
+              "$ref": "#/$defs/JSONObject",
+              "description": "Whether the client supports tool use via `tools` and `toolChoice` parameters."
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ClientNotification": {
+      "description": "This notification is sent by the client to indicate that it is cancelling a request it previously issued.\n\nOn stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/cancelled",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CancelledNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ClientRequest": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DiscoverRequest"
+        },
+        {
+          "$ref": "#/$defs/ListResourcesRequest"
+        },
+        {
+          "$ref": "#/$defs/ListResourceTemplatesRequest"
+        },
+        {
+          "$ref": "#/$defs/ReadResourceRequest"
+        },
+        {
+          "$ref": "#/$defs/SubscriptionsListenRequest"
+        },
+        {
+          "$ref": "#/$defs/ListPromptsRequest"
+        },
+        {
+          "$ref": "#/$defs/GetPromptRequest"
+        },
+        {
+          "$ref": "#/$defs/ListToolsRequest"
+        },
+        {
+          "$ref": "#/$defs/CallToolRequest"
+        },
+        {
+          "$ref": "#/$defs/CompleteRequest"
+        }
+      ]
+    },
+    "ClientResult": {
+      "$ref": "#/$defs/Result",
+      "description": "Common result fields."
+    },
+    "CompleteRequest": {
+      "description": "A request from the client to the server, to ask for completion options.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "completion/complete",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CompleteRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CompleteRequestParams": {
+      "description": "Parameters for a `completion/complete` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "argument": {
+          "description": "The argument's information",
+          "properties": {
+            "name": {
+              "description": "The name of the argument",
+              "type": "string"
+            },
+            "value": {
+              "description": "The value of the argument to use for completion matching.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "value"
+          ],
+          "type": "object"
+        },
+        "context": {
+          "description": "Additional, optional context for completions",
+          "properties": {
+            "arguments": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Previously-resolved variables in a URI template or prompt.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptReference"
+            },
+            {
+              "$ref": "#/$defs/ResourceTemplateReference"
+            }
+          ]
+        }
+      },
+      "required": [
+        "_meta",
+        "argument",
+        "ref"
+      ],
+      "type": "object"
+    },
+    "CompleteResult": {
+      "description": "The result returned by the server for a {@link CompleteRequestcompletion/complete} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "completion": {
+          "properties": {
+            "hasMore": {
+              "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
+              "type": "boolean"
+            },
+            "total": {
+              "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
+              "type": "integer"
+            },
+            "values": {
+              "description": "An array of completion values. Must not exceed 100 items.",
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 100,
+              "type": "array"
+            }
+          },
+          "required": [
+            "values"
+          ],
+          "type": "object"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "completion",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "CompleteResultResponse": {
+      "description": "A successful response from the server for a {@link CompleteRequestcompletion/complete} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/CompleteResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ContentBlock": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TextContent"
+        },
+        {
+          "$ref": "#/$defs/ImageContent"
+        },
+        {
+          "$ref": "#/$defs/AudioContent"
+        },
+        {
+          "$ref": "#/$defs/ResourceLink"
+        },
+        {
+          "$ref": "#/$defs/EmbeddedResource"
+        }
+      ]
+    },
+    "CreateMessageRequest": {
+      "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+      "properties": {
+        "method": {
+          "const": "sampling/createMessage",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CreateMessageRequestParams"
+        }
+      },
+      "required": [
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CreateMessageRequestParams": {
+      "description": "Parameters for a `sampling/createMessage` request.",
+      "properties": {
+        "includeContext": {
+          "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is `\"none\"`. The values `\"thisServer\"` and `\"allServers\"` are deprecated (SEP-2596): servers SHOULD\nomit this field or use `\"none\"`, and SHOULD only use the deprecated values if the client declares\n{@link ClientCapabilities.sampling.context}.",
+          "enum": [
+            "allServers",
+            "none",
+            "thisServer"
+          ],
+          "type": "string"
+        },
+        "maxTokens": {
+          "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
+          "type": "integer"
+        },
+        "messages": {
+          "items": {
+            "$ref": "#/$defs/SamplingMessage"
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific."
+        },
+        "modelPreferences": {
+          "$ref": "#/$defs/ModelPreferences",
+          "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+        },
+        "stopSequences": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "systemPrompt": {
+          "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+          "type": "string"
+        },
+        "temperature": {
+          "type": "number"
+        },
+        "toolChoice": {
+          "$ref": "#/$defs/ToolChoice",
+          "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.\nDefault is `{ mode: \"auto\" }`."
+        },
+        "tools": {
+          "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.",
+          "items": {
+            "$ref": "#/$defs/Tool"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "maxTokens",
+        "messages"
+      ],
+      "type": "object"
+    },
+    "CreateMessageResult": {
+      "description": "The result returned by the client for a {@link CreateMessageRequestsampling/createMessage} request.\nThe client should inform the user before returning the sampled message, to allow them\nto inspect the response (human in the loop) and decide whether to allow the server to see it.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "content": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextContent"
+            },
+            {
+              "$ref": "#/$defs/ImageContent"
+            },
+            {
+              "$ref": "#/$defs/AudioContent"
+            },
+            {
+              "$ref": "#/$defs/ToolUseContent"
+            },
+            {
+              "$ref": "#/$defs/ToolResultContent"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/SamplingMessageContentBlock"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "model": {
+          "description": "The name of the model that generated the message.",
+          "type": "string"
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        },
+        "stopReason": {
+          "description": "The reason why sampling stopped, if known.\n\nStandard values:\n- `\"endTurn\"`: Natural end of the assistant's turn\n- `\"stopSequence\"`: A stop sequence was encountered\n- `\"maxTokens\"`: Maximum token limit was reached\n- `\"toolUse\"`: The model wants to use one or more tools\n\nThis field is an open string to allow for provider-specific stop reasons.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "model",
+        "role"
+      ],
+      "type": "object"
+    },
+    "Cursor": {
+      "description": "An opaque token used to represent a cursor for pagination.",
+      "type": "string"
+    },
+    "DiscoverRequest": {
+      "description": "A request from the client asking the server to advertise its supported\nprotocol versions, capabilities, and other metadata. Servers **MUST**\nimplement `server/discover`. Clients **MAY** call it but are not required\nto — version negotiation can also happen inline via per-request `_meta`.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "server/discover",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/RequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "DiscoverResult": {
+      "description": "The result returned by the server for a {@link DiscoverRequestserver/discover} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/ServerCapabilities",
+          "description": "The capabilities of the server."
+        },
+        "instructions": {
+          "description": "Natural-language guidance describing the server and its features.\n\nThis can be used by clients to improve an LLM's understanding of\navailable tools (e.g., by including it in a system prompt). It should\nfocus on information that helps the model use the server effectively\nand should not duplicate information already in tool descriptions.",
+          "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "serverInfo": {
+          "$ref": "#/$defs/Implementation",
+          "description": "Information about the server software implementation."
+        },
+        "supportedVersions": {
+          "description": "MCP Protocol Versions this server supports. The client should choose a\nversion from this list for use in subsequent requests.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "capabilities",
+        "resultType",
+        "serverInfo",
+        "supportedVersions",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "DiscoverResultResponse": {
+      "description": "A successful response from the server for a {@link DiscoverRequestserver/discover} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/DiscoverResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ElicitRequest": {
+      "description": "A request from the server to elicit additional information from the user via the client.",
+      "properties": {
+        "method": {
+          "const": "elicitation/create",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ElicitRequestParams"
+        }
+      },
+      "required": [
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ElicitRequestFormParams": {
+      "description": "The parameters for a request to elicit non-sensitive information from the user via a form in the client.",
+      "properties": {
+        "message": {
+          "description": "The message to present to the user describing what information is being requested.",
+          "type": "string"
+        },
+        "mode": {
+          "const": "form",
+          "description": "The elicitation mode.",
+          "type": "string"
+        },
+        "requestedSchema": {
+          "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "properties": {
+              "additionalProperties": {
+                "$ref": "#/$defs/PrimitiveSchemaDefinition"
+              },
+              "type": "object"
+            },
+            "required": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "object",
+              "type": "string"
+            }
+          },
+          "required": [
+            "properties",
+            "type"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "message",
+        "requestedSchema"
+      ],
+      "type": "object"
+    },
+    "ElicitRequestParams": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ElicitRequestFormParams"
+        },
+        {
+          "$ref": "#/$defs/ElicitRequestURLParams"
+        }
+      ],
+      "description": "The parameters for a request to elicit additional information from the user via the client."
+    },
+    "ElicitRequestURLParams": {
+      "description": "The parameters for a request to elicit information from the user via a URL in the client.",
+      "properties": {
+        "message": {
+          "description": "The message to present to the user explaining why the interaction is needed.",
+          "type": "string"
+        },
+        "mode": {
+          "const": "url",
+          "description": "The elicitation mode.",
+          "type": "string"
+        },
+        "url": {
+          "description": "The URL that the user should navigate to.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "mode",
+        "url"
+      ],
+      "type": "object"
+    },
+    "ElicitResult": {
+      "description": "The result returned by the client for an {@link ElicitRequestelicitation/create} request.",
+      "properties": {
+        "action": {
+          "description": "The user action in response to the elicitation.\n- `\"accept\"`: User submitted the form/confirmed the action\n- `\"decline\"`: User explicitly declined the action\n- `\"cancel\"`: User dismissed without making an explicit choice",
+          "enum": [
+            "accept",
+            "cancel",
+            "decline"
+          ],
+          "type": "string"
+        },
+        "content": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": [
+                  "string",
+                  "integer",
+                  "boolean"
+                ]
+              }
+            ]
+          },
+          "description": "The submitted form data, only present when action is `\"accept\"` and mode was `\"form\"`.\nContains values matching the requested schema.\nOmitted for out-of-band mode responses.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "type": "object"
+    },
+    "EmbeddedResource": {
+      "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "resource": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextResourceContents"
+            },
+            {
+              "$ref": "#/$defs/BlobResourceContents"
+            }
+          ]
+        },
+        "type": {
+          "const": "resource",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resource",
+        "type"
+      ],
+      "type": "object"
+    },
+    "EmptyResult": {
+      "$ref": "#/$defs/Result",
+      "description": "Common result fields."
+    },
+    "EnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/LegacyTitledEnumSchema"
+        }
+      ]
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "GetPromptRequest": {
+      "description": "Used by the client to get a prompt provided by the server.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "prompts/get",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/GetPromptRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "GetPromptRequestParams": {
+      "description": "Parameters for a `prompts/get` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "arguments": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arguments to use for templating the prompt.",
+          "type": "object"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "name": {
+          "description": "The name of the prompt or prompt template.",
+          "type": "string"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "name"
+      ],
+      "type": "object"
+    },
+    "GetPromptResult": {
+      "description": "The result returned by the server for a {@link GetPromptRequestprompts/get} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "description": {
+          "description": "An optional description for the prompt.",
+          "type": "string"
+        },
+        "messages": {
+          "items": {
+            "$ref": "#/$defs/PromptMessage"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "messages",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "GetPromptResultResponse": {
+      "description": "A successful response from the server for a {@link GetPromptRequestprompts/get} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/GetPromptResult"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "HeaderMismatchError": {
+      "description": "Returned when a server rejects a request because the values in the HTTP\nheaders do not match the corresponding values in the request body, or\nbecause required headers are missing or malformed. For HTTP, the response\nstatus code MUST be `400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32020,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "code"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "Icon": {
+      "description": "An optionally-sized icon that can be displayed in a user interface.",
+      "properties": {
+        "mimeType": {
+          "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
+          "type": "string"
+        },
+        "sizes": {
+          "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD take steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
+          "format": "uri",
+          "type": "string"
+        },
+        "theme": {
+          "description": "Optional specifier for the theme this icon is designed for. `\"light\"` indicates\nthe icon is designed to be used with a light background, and `\"dark\"` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
+          "enum": [
+            "dark",
+            "light"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ],
+      "type": "object"
+    },
+    "Icons": {
+      "description": "Base interface to add `icons` property.",
+      "properties": {
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ImageContent": {
+      "description": "An image provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "data": {
+          "description": "The base64-encoded image data.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of the image. Different providers may support different image types.",
+          "type": "string"
+        },
+        "type": {
+          "const": "image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "mimeType",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Implementation": {
+      "description": "Describes the MCP implementation.",
+      "properties": {
+        "description": {
+          "description": "An optional human-readable description of what this implementation does.\n\nThis can be used by clients or servers to provide context about their purpose\nand capabilities. For example, a server might describe the types of resources\nor tools it provides, while a client might describe its intended use case.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version of this implementation.",
+          "type": "string"
+        },
+        "websiteUrl": {
+          "description": "An optional URL of the website for this implementation.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ],
+      "type": "object"
+    },
+    "InputRequest": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CreateMessageRequest"
+        },
+        {
+          "$ref": "#/$defs/ListRootsRequest"
+        },
+        {
+          "$ref": "#/$defs/ElicitRequest"
+        }
+      ]
+    },
+    "InputRequests": {
+      "additionalProperties": {
+        "$ref": "#/$defs/InputRequest"
+      },
+      "description": "A map of server-initiated requests that the client must fulfill.\nKeys are server-assigned identifiers; values are the request objects.",
+      "type": "object"
+    },
+    "InputRequiredResult": {
+      "description": "An InputRequiredResult sent by the server to indicate that additional input is needed\nbefore the request can be completed.\n\nAt least one of `inputRequests` or `requestState` MUST be present.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "inputRequests": {
+          "$ref": "#/$defs/InputRequests"
+        },
+        "requestState": {
+          "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "InputResponse": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CreateMessageResult"
+        },
+        {
+          "$ref": "#/$defs/ListRootsResult"
+        },
+        {
+          "$ref": "#/$defs/ElicitResult"
+        }
+      ]
+    },
+    "InputResponseRequestParams": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "type": "object"
+    },
+    "InputResponses": {
+      "additionalProperties": {
+        "$ref": "#/$defs/InputResponse"
+      },
+      "description": "A map of client responses to server-initiated requests.\nKeys correspond to the keys in the {@link InputRequests} map;\nvalues are the client's result for each request.",
+      "type": "object"
+    },
+    "InternalError": {
+      "description": "A JSON-RPC error indicating that an internal error occurred on the receiver. This error is returned when the receiver encounters an unexpected condition that prevents it from fulfilling the request.",
+      "properties": {
+        "code": {
+          "const": -32603,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "InvalidParamsError": {
+      "description": "A JSON-RPC error indicating that the method parameters are invalid or malformed.\n\nIn MCP, this error is returned in various contexts when request parameters fail validation:\n\n- **Tools**: Unknown tool name or invalid tool arguments\n- **Prompts**: Unknown prompt name or missing required arguments\n- **Pagination**: Invalid or expired cursor values\n- **Logging**: Invalid log level\n- **Elicitation**: Server requests an elicitation mode not declared in client capabilities\n- **Sampling**: Missing tool result or tool results mixed with other content",
+      "properties": {
+        "code": {
+          "const": -32602,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "InvalidRequestError": {
+      "description": "A JSON-RPC error indicating that the request is not a valid request object. This error is returned when the message structure does not conform to the JSON-RPC 2.0 specification requirements for a request (e.g., missing required fields like `jsonrpc` or `method`, or using invalid types for these fields).",
+      "properties": {
+        "code": {
+          "const": -32600,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "JSONArray": {
+      "items": {
+        "$ref": "#/$defs/JSONValue"
+      },
+      "type": "array"
+    },
+    "JSONObject": {
+      "additionalProperties": {
+        "$ref": "#/$defs/JSONValue"
+      },
+      "type": "object"
+    },
+    "JSONRPCErrorResponse": {
+      "description": "A response to a request that indicates an error occurred.",
+      "properties": {
+        "error": {
+          "$ref": "#/$defs/Error"
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "JSONRPCMessage": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONRPCRequest"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCNotification"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCResultResponse"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCErrorResponse"
+        }
+      ],
+      "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
+    },
+    "JSONRPCNotification": {
+      "description": "A notification which does not expect a response.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "JSONRPCRequest": {
+      "description": "A request that expects a response.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "JSONRPCResponse": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONRPCResultResponse"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCErrorResponse"
+        }
+      ],
+      "description": "A response to a request, containing either the result or error."
+    },
+    "JSONRPCResultResponse": {
+      "description": "A successful (non-error) response to a request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/Result"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "JSONValue": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONObject"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/JSONValue"
+          },
+          "type": "array"
+        },
+        {
+          "type": [
+            "string",
+            "integer",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    "LegacyTitledEnumSchema": {
+      "description": "Use {@link TitledSingleSelectEnumSchema} instead.\nThis interface will be removed in a future version.",
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enum": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enumNames": {
+          "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "enum",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ListPromptsRequest": {
+      "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "prompts/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListPromptsResult": {
+      "description": "The result returned by the server for a {@link ListPromptsRequestprompts/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "prompts": {
+          "items": {
+            "$ref": "#/$defs/Prompt"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "prompts",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListPromptsResultResponse": {
+      "description": "A successful response from the server for a {@link ListPromptsRequestprompts/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListPromptsResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ListResourceTemplatesRequest": {
+      "description": "Sent from the client to request a list of resource templates the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "resources/templates/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListResourceTemplatesResult": {
+      "description": "The result returned by the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resourceTemplates": {
+          "items": {
+            "$ref": "#/$defs/ResourceTemplate"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resourceTemplates",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListResourceTemplatesResultResponse": {
+      "description": "A successful response from the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListResourceTemplatesResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ListResourcesRequest": {
+      "description": "Sent from the client to request a list of resources the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "resources/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListResourcesResult": {
+      "description": "The result returned by the server for a {@link ListResourcesRequestresources/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resources": {
+          "items": {
+            "$ref": "#/$defs/Resource"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resources",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListResourcesResultResponse": {
+      "description": "A successful response from the server for a {@link ListResourcesRequestresources/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListResourcesResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ListRootsRequest": {
+      "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+      "properties": {
+        "method": {
+          "const": "roots/list",
+          "type": "string"
+        },
+        "params": {
+          "properties": {
+            "_meta": {
+              "$ref": "#/$defs/MetaObject"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "ListRootsResult": {
+      "description": "The result returned by the client for a {@link ListRootsRequestroots/list} request.\nThis result contains an array of {@link Root} objects, each representing a root directory\nor file that the server can operate on.",
+      "properties": {
+        "roots": {
+          "items": {
+            "$ref": "#/$defs/Root"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "roots"
+      ],
+      "type": "object"
+    },
+    "ListToolsRequest": {
+      "description": "Sent from the client to request a list of tools the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "tools/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListToolsResult": {
+      "description": "The result returned by the server for a {@link ListToolsRequesttools/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "tools": {
+          "items": {
+            "$ref": "#/$defs/Tool"
+          },
+          "type": "array"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resultType",
+        "tools",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListToolsResultResponse": {
+      "description": "A successful response from the server for a {@link ListToolsRequesttools/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListToolsResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "LoggingLevel": {
+      "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
+      "enum": [
+        "alert",
+        "critical",
+        "debug",
+        "emergency",
+        "error",
+        "info",
+        "notice",
+        "warning"
+      ],
+      "type": "string"
+    },
+    "LoggingMessageNotification": {
+      "description": "JSONRPCNotification of a log message passed from server to client. The client opts in by setting `\"io.modelcontextprotocol/logLevel\"` in a request's `_meta`.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/message",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/LoggingMessageNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "LoggingMessageNotificationParams": {
+      "description": "Parameters for a `notifications/message` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "data": {
+          "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+        },
+        "level": {
+          "$ref": "#/$defs/LoggingLevel",
+          "description": "The severity of this log message."
+        },
+        "logger": {
+          "description": "An optional name of the logger issuing this message.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "level"
+      ],
+      "type": "object"
+    },
+    "MetaObject": {
+      "description": "Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.\n\nCertain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.\n\nValid keys have two segments:\n\n**Prefix:**\n- Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).\n- Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).\n- Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).\n- Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.\n\n**Name:**\n- Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).\n- Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).",
+      "type": "object"
+    },
+    "MethodNotFoundError": {
+      "description": "A JSON-RPC error indicating that the requested method does not exist or is not available.\n\nIn MCP, a server returns this error when a client invokes a method the server does not implement — either a genuinely unknown method, or one gated behind a server capability the server did not advertise (e.g., calling `prompts/list` when the `prompts` capability was not advertised).\n\nA request that requires a client capability the client did not declare is signalled instead by {@link MissingRequiredClientCapabilityError} (`-32021`).",
+      "properties": {
+        "code": {
+          "const": -32601,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "MissingRequiredClientCapabilityError": {
+      "description": "Returned when processing a request requires a capability the client did not\ndeclare in `clientCapabilities`. For HTTP, the response status code MUST be\n`400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32021,
+                  "type": "integer"
+                },
+                "data": {
+                  "properties": {
+                    "requiredCapabilities": {
+                      "$ref": "#/$defs/ClientCapabilities",
+                      "description": "The capabilities the server requires from the client to process this request."
+                    }
+                  },
+                  "required": [
+                    "requiredCapabilities"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "code",
+                "data"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "ModelHint": {
+      "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+      "properties": {
+        "name": {
+          "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ModelPreferences": {
+      "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+      "properties": {
+        "costPriority": {
+          "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "hints": {
+          "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+          "items": {
+            "$ref": "#/$defs/ModelHint"
+          },
+          "type": "array"
+        },
+        "intelligencePriority": {
+          "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "speedPriority": {
+          "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "MultiSelectEnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        }
+      ]
+    },
+    "Notification": {
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "NotificationMetaObject": {
+      "description": "Extends {@link MetaObject} with additional notification-specific fields. All key naming rules from `MetaObject` apply.",
+      "properties": {
+        "io.modelcontextprotocol/subscriptionId": {
+          "$ref": "#/$defs/RequestId",
+          "description": "Identifies the subscription stream a notification was delivered on. The\nserver MUST include this key on every notification delivered via a\n{@link SubscriptionsListenRequestsubscriptions/listen} stream, so the\nclient can correlate the notification with the originating subscription.\nThe key is absent on notifications not delivered via a subscription\nstream (e.g. progress notifications for an in-flight request), which is\nwhy it is optional here.\n\nThe value is the JSON-RPC ID of the `subscriptions/listen` request that\nopened the stream."
+        }
+      },
+      "type": "object"
+    },
+    "NotificationParams": {
+      "description": "Common params for any notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        }
+      },
+      "type": "object"
+    },
+    "NumberSchema": {
+      "properties": {
+        "default": {
+          "type": "number"
+        },
+        "description": {
+          "type": "string"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "integer",
+            "number"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "PaginatedRequest": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "PaginatedRequestParams": {
+      "description": "Common params for paginated requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "cursor": {
+          "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "type": "object"
+    },
+    "PaginatedResult": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "ParseError": {
+      "description": "A JSON-RPC error indicating that invalid JSON was received by the server. This error is returned when the server cannot parse the JSON text of a message.",
+      "properties": {
+        "code": {
+          "const": -32700,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "PrimitiveSchemaDefinition": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/StringSchema"
+        },
+        {
+          "$ref": "#/$defs/NumberSchema"
+        },
+        {
+          "$ref": "#/$defs/BooleanSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/LegacyTitledEnumSchema"
+        }
+      ],
+      "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays."
+    },
+    "ProgressNotification": {
+      "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/progress",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ProgressNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ProgressNotificationParams": {
+      "description": "Parameters for a {@link ProgressNotificationnotifications/progress} notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "message": {
+          "description": "An optional message describing the current progress.",
+          "type": "string"
+        },
+        "progress": {
+          "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+          "type": "number"
+        },
+        "progressToken": {
+          "$ref": "#/$defs/ProgressToken",
+          "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+        },
+        "total": {
+          "description": "Total number of items to process (or total progress required), if known.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "progress",
+        "progressToken"
+      ],
+      "type": "object"
+    },
+    "ProgressToken": {
+      "description": "A progress token, used to associate progress notifications with the original request.",
+      "type": [
+        "string",
+        "integer"
+      ]
+    },
+    "Prompt": {
+      "description": "A prompt or prompt template that the server offers.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "arguments": {
+          "description": "A list of arguments to use for templating the prompt.",
+          "items": {
+            "$ref": "#/$defs/PromptArgument"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "An optional description of what this prompt provides",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "PromptArgument": {
+      "description": "Describes an argument that a prompt can accept.",
+      "properties": {
+        "description": {
+          "description": "A human-readable description of the argument.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "required": {
+          "description": "Whether this argument must be provided.",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "PromptListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `promptsListChanged` filter field.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/prompts/list_changed",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/NotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "PromptMessage": {
+      "description": "Describes a message returned as part of a prompt.\n\nThis is similar to {@link SamplingMessage}, but also supports the embedding of\nresources from the MCP server.",
+      "properties": {
+        "content": {
+          "$ref": "#/$defs/ContentBlock"
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        }
+      },
+      "required": [
+        "content",
+        "role"
+      ],
+      "type": "object"
+    },
+    "PromptReference": {
+      "description": "Identifies a prompt.",
+      "properties": {
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "type": {
+          "const": "ref/prompt",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ReadResourceRequest": {
+      "description": "Sent from the client to the server, to read a specific resource URI.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "resources/read",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ReadResourceRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ReadResourceRequestParams": {
+      "description": "Parameters for a `resources/read` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "requestState": {
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ReadResourceResult": {
+      "description": "The result returned by the server for a {@link ReadResourceRequestresources/read} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "contents": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TextResourceContents"
+              },
+              {
+                "$ref": "#/$defs/BlobResourceContents"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "contents",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ReadResourceResultResponse": {
+      "description": "A successful response from the server for a {@link ReadResourceRequestresources/read} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/ReadResourceResult"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "Request": {
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "RequestId": {
+      "description": "A uniquely identifying ID for a request in JSON-RPC.",
+      "type": [
+        "string",
+        "integer"
+      ]
+    },
+    "RequestMetaObject": {
+      "description": "Extends {@link MetaObject} with additional request-specific fields. All key naming rules from `MetaObject` apply.",
+      "properties": {
+        "io.modelcontextprotocol/clientCapabilities": {
+          "$ref": "#/$defs/ClientCapabilities",
+          "description": "The client's capabilities for this specific request. Required.\n\nCapabilities are declared per-request rather than once at initialization;\nan empty object means the client supports no optional capabilities.\nServers MUST NOT infer capabilities from prior requests."
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "$ref": "#/$defs/Implementation",
+          "description": "Identifies the client software making the request. Required.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional."
+        },
+        "io.modelcontextprotocol/logLevel": {
+          "$ref": "#/$defs/LoggingLevel",
+          "description": "The desired log level for this request. Optional.\n\nIf absent, the server MUST NOT send any {@link LoggingMessageNotificationnotifications/message}\nnotifications for this request. The client opts in to log messages by\nexplicitly setting a level. Replaces the former `logging/setLevel` RPC."
+        },
+        "io.modelcontextprotocol/protocolVersion": {
+          "description": "The MCP Protocol Version being used for this request. Required.\n\nFor the HTTP transport, this value MUST match the `MCP-Protocol-Version`\nheader; otherwise the server MUST return a `400 Bad Request`. If the\nserver does not support the requested version, it MUST return an\n{@link UnsupportedProtocolVersionError}.",
+          "type": "string"
+        },
+        "progressToken": {
+          "$ref": "#/$defs/ProgressToken",
+          "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by {@link ProgressNotificationnotifications/progress}). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+        }
+      },
+      "required": [
+        "io.modelcontextprotocol/clientCapabilities",
+        "io.modelcontextprotocol/clientInfo",
+        "io.modelcontextprotocol/protocolVersion"
+      ],
+      "type": "object"
+    },
+    "RequestParams": {
+      "description": "Common params for any request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "type": "object"
+    },
+    "Resource": {
+      "description": "A known resource that the server is capable of reading.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceContents": {
+      "description": "The contents of a specific resource or sub-resource.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceLink": {
+      "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of {@link ListResourcesRequestresources/list} requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "type": {
+          "const": "resource_link",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `resourcesListChanged` filter field.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/resources/list_changed",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/NotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "ResourceRequestParams": {
+      "description": "Common params for resource-related requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "uri": {
+          "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceTemplate": {
+      "description": "A template description for resources available on the server.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "uriTemplate": {
+          "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
+          "format": "uri-template",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "uriTemplate"
+      ],
+      "type": "object"
+    },
+    "ResourceTemplateReference": {
+      "description": "A reference to a resource or resource template definition.",
+      "properties": {
+        "type": {
+          "const": "ref/resource",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI or URI template of the resource.",
+          "format": "uri-template",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceUpdatedNotification": {
+      "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This is only sent for resources the client opted in to via the `resourceSubscriptions` field of a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/resources/updated",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ResourceUpdatedNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ResourceUpdatedNotificationParams": {
+      "description": "Parameters for a `notifications/resources/updated` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "uri": {
+          "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "Result": {
+      "additionalProperties": {},
+      "description": "Common result fields.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "ResultType": {
+      "description": "Indicates the type of a {@link Result} object, allowing the client to\ndetermine how to parse the response.\n\ncomplete - the request completed successfully and the result contains the final content.\ninput_required - the request requires additional input and the result contains an {@link InputRequiredResult} object with instructions for the client to provide additional input before retrying the original request.",
+      "type": "string"
+    },
+    "Role": {
+      "description": "The sender or recipient of messages and data in a conversation.",
+      "enum": [
+        "assistant",
+        "user"
+      ],
+      "type": "string"
+    },
+    "Root": {
+      "description": "Represents a root directory or file that the server can operate on.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "name": {
+          "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI identifying the root. This *must* start with `file://` for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "SamplingMessage": {
+      "description": "Describes a message issued to or received from an LLM API.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "content": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextContent"
+            },
+            {
+              "$ref": "#/$defs/ImageContent"
+            },
+            {
+              "$ref": "#/$defs/AudioContent"
+            },
+            {
+              "$ref": "#/$defs/ToolUseContent"
+            },
+            {
+              "$ref": "#/$defs/ToolResultContent"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/SamplingMessageContentBlock"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        }
+      },
+      "required": [
+        "content",
+        "role"
+      ],
+      "type": "object"
+    },
+    "SamplingMessageContentBlock": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TextContent"
+        },
+        {
+          "$ref": "#/$defs/ImageContent"
+        },
+        {
+          "$ref": "#/$defs/AudioContent"
+        },
+        {
+          "$ref": "#/$defs/ToolUseContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultContent"
+        }
+      ]
+    },
+    "ServerCapabilities": {
+      "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+      "properties": {
+        "completions": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Present if the server supports argument autocompletion suggestions."
+        },
+        "experimental": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Experimental, non-standard capabilities that the server supports.",
+          "type": "object"
+        },
+        "extensions": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Optional MCP extensions that the server supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/tasks\"), and values are per-extension settings\nobjects. An empty object indicates support with no settings.\n\nKeys MUST follow the {@link MetaObject`_meta` key naming rules}, with a\nmandatory prefix.",
+          "type": "object"
+        },
+        "logging": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Present if the server supports sending log messages to the client."
+        },
+        "prompts": {
+          "description": "Present if the server offers any prompt templates.",
+          "properties": {
+            "listChanged": {
+              "description": "Whether this server supports notifications for changes to the prompt list.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "resources": {
+          "description": "Present if the server offers any resources to read.",
+          "properties": {
+            "listChanged": {
+              "description": "Whether this server supports notifications for changes to the resource list.",
+              "type": "boolean"
+            },
+            "subscribe": {
+              "description": "Whether this server supports subscribing to resource updates.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "tools": {
+          "description": "Present if the server offers any tools to call.",
+          "properties": {
+            "listChanged": {
+              "description": "Whether this server supports notifications for changes to the tool list.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ServerNotification": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CancelledNotification"
+        },
+        {
+          "$ref": "#/$defs/ProgressNotification"
+        },
+        {
+          "$ref": "#/$defs/ResourceListChangedNotification"
+        },
+        {
+          "$ref": "#/$defs/SubscriptionsAcknowledgedNotification"
+        },
+        {
+          "$ref": "#/$defs/ResourceUpdatedNotification"
+        },
+        {
+          "$ref": "#/$defs/PromptListChangedNotification"
+        },
+        {
+          "$ref": "#/$defs/ToolListChangedNotification"
+        },
+        {
+          "$ref": "#/$defs/LoggingMessageNotification"
+        }
+      ]
+    },
+    "ServerResult": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Result"
+        },
+        {
+          "$ref": "#/$defs/InputRequiredResult"
+        },
+        {
+          "$ref": "#/$defs/DiscoverResult"
+        },
+        {
+          "$ref": "#/$defs/ListResourcesResult"
+        },
+        {
+          "$ref": "#/$defs/ListResourceTemplatesResult"
+        },
+        {
+          "$ref": "#/$defs/ReadResourceResult"
+        },
+        {
+          "$ref": "#/$defs/SubscriptionsListenResult"
+        },
+        {
+          "$ref": "#/$defs/ListPromptsResult"
+        },
+        {
+          "$ref": "#/$defs/GetPromptResult"
+        },
+        {
+          "$ref": "#/$defs/ListToolsResult"
+        },
+        {
+          "$ref": "#/$defs/CallToolResult"
+        },
+        {
+          "$ref": "#/$defs/CompleteResult"
+        }
+      ]
+    },
+    "SingleSelectEnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        }
+      ]
+    },
+    "StringSchema": {
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "enum": [
+            "date",
+            "date-time",
+            "email",
+            "uri"
+          ],
+          "type": "string"
+        },
+        "maxLength": {
+          "type": "integer"
+        },
+        "minLength": {
+          "type": "integer"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "SubscriptionFilter": {
+      "description": "The set of notification types a client may opt in to on a\n{@link SubscriptionsListenRequestsubscriptions/listen} request.\n\nEach notification type is **opt-in**; the server **MUST NOT** send\nnotification types the client has not explicitly requested here.",
+      "properties": {
+        "promptsListChanged": {
+          "description": "If true, receive {@link PromptListChangedNotificationnotifications/prompts/list_changed}.",
+          "type": "boolean"
+        },
+        "resourceSubscriptions": {
+          "description": "Subscribe to {@link ResourceUpdatedNotificationnotifications/resources/updated} for these resource URIs.\nReplaces the former `resources/subscribe` RPC.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resourcesListChanged": {
+          "description": "If true, receive {@link ResourceListChangedNotificationnotifications/resources/list_changed}.",
+          "type": "boolean"
+        },
+        "toolsListChanged": {
+          "description": "If true, receive {@link ToolListChangedNotificationnotifications/tools/list_changed}.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "SubscriptionsAcknowledgedNotification": {
+      "description": "Sent by the server as the first message on a\n{@link SubscriptionsListenRequestsubscriptions/listen} stream to acknowledge\nthat the subscription has been established and to report which notification\ntypes it agreed to honor.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/subscriptions/acknowledged",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SubscriptionsAcknowledgedNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsAcknowledgedNotificationParams": {
+      "description": "Parameters for a {@link SubscriptionsAcknowledgedNotificationnotifications/subscriptions/acknowledged} notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "notifications": {
+          "$ref": "#/$defs/SubscriptionFilter",
+          "description": "The subset of requested notification types the server agreed to honor.\nOnly includes notification types the server actually supports; if the\nclient requested an unsupported type (e.g., `promptsListChanged` when\nthe server has no prompts), it is omitted from this set."
+        }
+      },
+      "required": [
+        "notifications"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenRequest": {
+      "description": "Sent from the client to open a long-lived channel for receiving notifications\noutside the context of a specific request. Replaces the previous HTTP GET\nendpoint and ensures consistent behavior between HTTP and STDIO.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "subscriptions/listen",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SubscriptionsListenRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenRequestParams": {
+      "description": "Parameters for a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "notifications": {
+          "$ref": "#/$defs/SubscriptionFilter",
+          "description": "The notifications the client opts in to on this stream. The server\n**MUST NOT** send notification types the client has not explicitly\nrequested."
+        }
+      },
+      "required": [
+        "_meta",
+        "notifications"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenResult": {
+      "description": "The response to a {@link SubscriptionsListenRequestsubscriptions/listen}\nrequest, signalling that the subscription has ended gracefully (for example,\nduring server shutdown). Because the listen stream is long-lived, this result\nis sent only when the server tears the subscription down; an abrupt transport\nclose carries no response. The result body is otherwise empty.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/SubscriptionsListenResultMeta"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenResultMeta": {
+      "description": "Extends {@link MetaObject} with the subscription-stream identifier carried by a\n{@link SubscriptionsListenResult}. All key naming rules from `MetaObject` apply.",
+      "properties": {
+        "io.modelcontextprotocol/subscriptionId": {
+          "$ref": "#/$defs/RequestId",
+          "description": "Identifies the subscription stream this response closes, so the client can\ncorrelate it with the originating subscription — mirroring the same key on\nthe stream's notifications. The value is the JSON-RPC ID of the\n`subscriptions/listen` request that opened the stream (and equals this\nresponse's `id`)."
+        }
+      },
+      "required": [
+        "io.modelcontextprotocol/subscriptionId"
+      ],
+      "type": "object"
+    },
+    "TextContent": {
+      "description": "Text provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "text": {
+          "description": "The text content of the message.",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "type"
+      ],
+      "type": "object"
+    },
+    "TextResourceContents": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "text": {
+          "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "TitledMultiSelectEnumSchema": {
+      "description": "Schema for multiple-selection enumeration with display titles for each option.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Schema for array items with enum options and display labels.",
+          "properties": {
+            "anyOf": {
+              "description": "Array of enum options with values and display labels.",
+              "items": {
+                "properties": {
+                  "const": {
+                    "description": "The constant enum value.",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "Display title for this option.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "const",
+                  "title"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "anyOf"
+          ],
+          "type": "object"
+        },
+        "maxItems": {
+          "description": "Maximum number of items to select.",
+          "type": "integer"
+        },
+        "minItems": {
+          "description": "Minimum number of items to select.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "required": [
+        "items",
+        "type"
+      ],
+      "type": "object"
+    },
+    "TitledSingleSelectEnumSchema": {
+      "description": "Schema for single-selection enumeration with display titles for each option.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "oneOf": {
+          "description": "Array of enum options with values and display labels.",
+          "items": {
+            "properties": {
+              "const": {
+                "description": "The enum value.",
+                "type": "string"
+              },
+              "title": {
+                "description": "Display label for this option.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "const",
+              "title"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "oneOf",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Tool": {
+      "description": "Definition for a tool the client can call.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/ToolAnnotations",
+          "description": "Optional additional tool information.\n\nDisplay name precedence order is: `title`, `annotations.title`, then `name`."
+        },
+        "description": {
+          "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "inputSchema": {
+          "additionalProperties": {},
+          "description": "A JSON Schema object defining the expected parameters for the tool.\n\nTool arguments are always JSON objects, so `type: \"object\"` is required at the root.\nBeyond that, any JSON Schema 2020-12 keyword may appear alongside `type` — including\ncomposition keywords (`oneOf`, `anyOf`, `allOf`, `not`), conditional keywords\n(`if`/`then`/`else`), reference keywords (`$ref`, `$defs`, `$anchor`), and any other\nstandard validation or annotation keywords.\n\nProperty schemas may carry an `x-mcp-header` annotation to mirror the\nargument value into an HTTP header on the Streamable HTTP transport. See\nthe Streamable HTTP transport specification for the validity and\nextraction rules.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "type": {
+              "const": "object",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "outputSchema": {
+          "additionalProperties": {},
+          "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a {@link CallToolResult}. This can be any valid JSON Schema 2020-12.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "inputSchema",
+        "name"
+      ],
+      "type": "object"
+    },
+    "ToolAnnotations": {
+      "description": "Additional properties describing a {@link Tool} to clients.\n\nNOTE: all properties in `ToolAnnotations` are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on `ToolAnnotations`\nreceived from untrusted servers.",
+      "properties": {
+        "destructiveHint": {
+          "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
+          "type": "boolean"
+        },
+        "idempotentHint": {
+          "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+          "type": "boolean"
+        },
+        "openWorldHint": {
+          "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
+          "type": "boolean"
+        },
+        "readOnlyHint": {
+          "description": "If true, the tool does not modify its environment.\n\nDefault: false",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "A human-readable title for the tool.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ToolChoice": {
+      "description": "Controls tool selection behavior for sampling requests.",
+      "properties": {
+        "mode": {
+          "description": "Controls the tool use ability of the model:\n- `\"auto\"`: Model decides whether to use tools (default)\n- `\"required\"`: Model MUST use at least one tool before completing\n- `\"none\"`: Model MUST NOT use any tools",
+          "enum": [
+            "auto",
+            "none",
+            "required"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ToolListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `toolsListChanged` filter field.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/tools/list_changed",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/NotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "ToolResultContent": {
+      "description": "The result of a tool use, provided by the user back to the assistant.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject",
+          "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations."
+        },
+        "content": {
+          "description": "The unstructured result content of the tool use.\n\nThis has the same format as {@link CallToolResult.content} and can include text, images,\naudio, resource links, and embedded resources.",
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "type": "array"
+        },
+        "isError": {
+          "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
+          "type": "boolean"
+        },
+        "structuredContent": {
+          "description": "An optional structured result value.\n\nThis can be any JSON value (object, array, string, number, boolean, or null).\nIf the tool defined an {@link Tool.outputSchema}, this SHOULD conform to that schema."
+        },
+        "toolUseId": {
+          "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous {@link ToolUseContent}.",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_result",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "toolUseId",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ToolUseContent": {
+      "description": "A request from the assistant to call a tool.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject",
+          "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations."
+        },
+        "id": {
+          "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
+          "type": "string"
+        },
+        "input": {
+          "additionalProperties": {},
+          "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
+          "type": "object"
+        },
+        "name": {
+          "description": "The name of the tool to call.",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_use",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "input",
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "UnsupportedProtocolVersionError": {
+      "description": "Returned when the request's protocol version is unknown to the server or\nunsupported (e.g., a known experimental or draft version the server has\nchosen not to implement). For HTTP, the response status code MUST be\n`400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32022,
+                  "type": "integer"
+                },
+                "data": {
+                  "properties": {
+                    "requested": {
+                      "description": "The protocol version that was requested by the client.",
+                      "type": "string"
+                    },
+                    "supported": {
+                      "description": "Protocol versions the server supports. The client should choose a\nmutually supported version from this list and retry.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "requested",
+                    "supported"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "code",
+                "data"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "UntitledMultiSelectEnumSchema": {
+      "description": "Schema for multiple-selection enumeration without display titles for options.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Schema for the array items.",
+          "properties": {
+            "enum": {
+              "description": "Array of enum values to choose from.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "string",
+              "type": "string"
+            }
+          },
+          "required": [
+            "enum",
+            "type"
+          ],
+          "type": "object"
+        },
+        "maxItems": {
+          "description": "Maximum number of items to select.",
+          "type": "integer"
+        },
+        "minItems": {
+          "description": "Minimum number of items to select.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "required": [
+        "items",
+        "type"
+      ],
+      "type": "object"
+    },
+    "UntitledSingleSelectEnumSchema": {
+      "description": "Schema for single-selection enumeration without display titles for options.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "enum": {
+          "description": "Array of enum values to choose from.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "enum",
+        "type"
+      ],
+      "type": "object"
+    }
+  }
+} as const

--- a/example/mcp/type.ts
+++ b/example/mcp/type.ts
@@ -1,0 +1,69 @@
+/*--------------------------------------------------------------------------
+
+TypeBox
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2026 Haydn Paterson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
+import { type TLocalizedValidationError } from 'typebox/error'
+import Schema from 'typebox/schema'
+import Spec from './spec.ts'
+
+// ------------------------------------------------------------------
+// DefinitionName
+// ------------------------------------------------------------------
+type DefinitionName = Extract<keyof (typeof Spec['$defs']), string>
+
+// ------------------------------------------------------------------
+// Validator
+// ------------------------------------------------------------------
+export class Validator<Type extends unknown = unknown> {
+  readonly #validator: Schema.Validator
+  constructor(schema: Schema.XSchema) {
+    this.#validator = Schema.Compile(schema)
+  }
+  public Check(value: unknown): value is Type {
+    return this.#validator.Check(value)
+  }
+  public Parse(value: unknown): Type {
+    return this.#validator.Parse(value) as Type
+  }
+  public Errors(value: unknown): TLocalizedValidationError[] {
+    return this.#validator.Errors(value)[1]
+  }
+}
+// ------------------------------------------------------------------
+// ProtocolType
+// ------------------------------------------------------------------
+export type ProtocolType<Key extends DefinitionName> = Schema.XStatic<typeof Spec & { $ref: `#/$defs/${Key}` }>
+
+// ------------------------------------------------------------------
+// ProtocolValidator
+// ------------------------------------------------------------------
+export function ProtocolValidator<Name extends DefinitionName> (name: Name): Validator<ProtocolType<Name>> {
+  return new Validator({ ...Spec, $ref: `#/$defs/${name}` })
+}
+
+
+

--- a/readme.md
+++ b/readme.md
@@ -111,27 +111,24 @@ type User = Type.Static<typeof User>              // type User = {
 
 ## Script
 
-[Documentation](https://sinclairzx81.github.io/typebox/#/docs/script/overview) | [Example 1](https://www.typescriptlang.org/play/?target=99&module=7#code/JYWwDg9gTgLgBAFQJ5gKZwGZQiOByGFVAIwgA88AoSgehrgFonmXW32POv3b7k0AdAGUAxlGBgYACjwC5eAJS9G3VWvXdqdOADkAhiFQBnMHpGpKIiADsj8ALJ6YACzgBeREWFiJ0gAaUcHCEaHAAaqgiMNAATO5wAN5wZABccNYAriDEqFAANHBIaZnZuXAAvoHBROGR0VAAzPEAogBuegA2GU6oADwRUbFwAGSJcABexVk5UBUAfFUh6AP1ACwt7V09-XXQTaNJAO5TpbPlC35KygAiqGjWACao1vD6hiZmFla28En2xq5yvF+KhvOJJFIknIBI4XBUCn4gosahFYKgyPEElUgpAjMAYMAbGkVtBVnlseloCBOsTdo1yUEghlWrTBlAYlVKkElnAAOKoHCoGBQJCYimtXIE8xGWlosgAbQAugzGcBHsBpScZkrOcjQrDcsBOmLGXADMRgM8YKy1iqgg9gBgMBkjKgbaS7XATJEMh09FB3VBVrruTV-kZXB4saaAOYCwzCop8+NCkWe6kwQ00uAG8SdXWXLT0ABKGReoHQxdQGA6dUJ1ko4ecAjA2DQsEtRgEccFiZbbclnYEEo70oE+NQIC7rYg7YJxhbEDxBJs-dng4XZEbALXc6HPYTIt3G67I6lC4nU+PHYX1ipnWv867W6bj-3Kb7M73C7PGovmavL8TwEZk303bcIzArsMyzDooIEB0nRdUEgJvZ8IObVCnwEGC8zgrCh3NS0Xngl8dwIhdcKNfCBzQgRvREX1-VIos4CEGAnA1OAAElrAwXJnnMShnWsKJ6zgKBnieKApHeZw0hBYQOKlXolggDAcwBOYFESKo5O7D8j1-aV5QABkVRdl3rAQtyCfSD1TJBh0HEzzIEO8oGpODbLgezDKc4zjDMizQJ8-SqIfRDnVdGy9J3CK4KIq1Yrs+Kejw+i0EYv0oFi8ogA) | [Example 2](https://www.typescriptlang.org/play/?target=99&module=7#code/JYWwDg9gTgLgBAFQJ5gKZwGZQiOByGFVAIwgA88AoSgehrgFonmXW32POv3b7k0AdACpejbuImTu1OnAByAQxCoAzmAUBjVJQB2S1eq1wAsgpgALOAG9KcOKjKRYcDRB0r4ANVQaY0AExwALyIRAIA8sQAVj4wABRWcGQAXKGCcgCuIMSoUHEAlAA0cEip-KgCmdm5BXAAvvm29o7Q8K7uXrHQAMzBaRUAogBuCgA2GWaoceUCAJI6MLkqsXEA2t6+AcUzkTG+CXAAXmVhVTl5+fX5ALr5jXYOTm1uHnAbflAALH0zw2MTi2mYXmiygy326y6UG62zCuxWiQA7id0llzrUGrdGnUZPQACKoNA6AAmqAW8n0ak02nar28sAcPzh0QRTUgKmAMGAblSpgsAne0E+hSaOmgIDGvLM5gFUJhTQyQyl-MFUH8lAalFp8AA4qgcKgYFAkEzBPD9jY7ENclytCoURUAIJQKAKJBxemLMhFJrAEnAO0OgTO13umZnGp3DWNbUmSZQYBjU0Vc3xS1wJTEYBkmDKmWq4VNYnADAYDLLPOyzZfEV2NQ+DKjBRQSsF6Nal7wYyqSwhHYsi1NADm+uURtKcD1BvHtbgEtBidGytyi-bogAShkFqB0OvUBhRrFuTpKN2VDKwNg0LBsyoBCPp8aBJeINeuaoBNab3aBJzUCA7xfN9b2fCAOS5NxnyvG0QLIU8eyg18YI-B8xyfIDkLvL9bQ-P8AMQ4CPzFKAJVGAjMIEOCzwvaCbxQ0dDXQ2j3ywmCfzwwDmJAxVyLou8qIQjC+IEecVzGXiWIEYtS3LCohMkgTzwkkDRITcT5JAzNswWZSP0UmikOE1TF10u96w0Rtm1MyjcTgABlGAzADOB5gwXIyS0Sgyx0XxjzgKAyVJPJlHPIMHKcjQAB5CDQCAMBMHsAD5LnTEKZVQxikE-NjVFWAAGa5QPA48bLsNL7wY8dsu-XKCoEYjSNKucEIyqrsIDWrCp4uCyoQ4zxOkstlia8r+rIrScxGvr4xM8zLKgGy6iAA) | [Challenge](test/typescript/readme.md)
+[Documentation](https://sinclairzx81.github.io/typebox/#/docs/script/overview) | [Example 1](https://www.typescriptlang.org/play/?target=99&module=7#code/JYWwDg9gTgLgBAFQJ5gKZwGZQiOByGFVAIwgA88AoSgehrgFkIATAVwBtVKBjCAOwDO8BgEMYACzgBeREQB0AZW5RgYGAAoABpThxCaOADVU3GNABM0uAG84ZAFxw+rEMVRQANHCSPnr93AAvjp6REYmZlAAzFa2Dk4ubp7evonuXgBeqf5QQSH66Mam0AAssXbZSV4+CTmZlelwAO4NucGaAJTUdHAAIqhofMyofMIsHFy8gvC2DKgCkoFWyGiKyqoaohJemrr5YcawqGSxIbqQAsAwwPyORZElHmdO0CAi7HcR0FFPurqsADdPsUoOYQsFdAU4ABxVA4VAwKBIU5-OAA9zXbjzT5HMgAbQAur8-sAhsAsQJWoTwfsDFt3MB3ii-iJXMARjBgQ9ibpmMAMBhWAJUFzSjy4AI0NwOCIoKKoCUaZCwnMFszdABzOEgBFIxyw+GIpDit4wBnvRz0lTvGmdbr0ABKrFGoHQDtQGE4phufEoqvEcjA2DQsHZAjkWsNSMDwYxYbk6NDFLkV1QIHDQYgIeu80DEEu134MazcdzZD98wDmez8cjOqNxZrucTmNzqfTjdL4b4r3endDZYrC37OfDdd1SBH8Zb5LbZo71a7ckBU8H-tX4dN5vYG7kfIFQtQu-L68XA83Ym3u9ZxHZo2PQ6rsfPci31p3Z9HcklJhlUAftD0AoMBiOScAAJJ8Bg7gjFilCCnw3r8HAUAjMMUDqDqCyOCsR7AaB3AADwFBAGCMJWAB8HQ2CEWEBuODYzhSeIAAwEnmBY+nI5a6HREbahOCZxsxbFyD2UBvDuPFwHxDHRkx8ysexK7SXxb6Mju+6CsK3G0ZWr6Xu+cg3neMC6bx+nqX2P7Suwsq6YEQA) | [Example 2](https://www.typescriptlang.org/play/?target=99&module=7#code/JYWwDg9gTgLgBAFQJ5gKZwGZQiOByGFVAIwgA88AoSgehrgFkIATAVwBtVKA7AQxFQBnMLwDG6BrxgALOAG9KcOKjKRYcURG6D4ANVSiY0AExwAvIiIA6APLEAVgZgAKOXDIAuS2isA5ViDEqFDOAJQANHBIXsg+-oHBYXAAvqGKyqrQ8Jraek7QAMzm3qi2Dk6u7jHW8UEhEVHVcQF1YZEAXk2ltYmhKWlKKmrZWjpw+obQACzFsaV2joaVniV+Lb2R0as99R1dawm7cADu+ztJqZTJ1HRwACKoaNzMqNzwTGyclDlj+rAqs2sCwqCiUkEEwBgwC0XkkMisEyMUCm4XS3GgIF47FhUmkCPyUAKqKUrAAbjj4YiTFc0j94ABxVA4VAwKBIQE+YFLUFwUnBKHiQT7ACCUCgvCQzj+MBUEXSwGewEFIrFEuccwOrVCaUudMYUmCwCxHPm5W56X4xGArxgFLxVORxLgzGAGAwrEEqDt+MmjvSwgMHF4UG9DqmNO+o3eQlkFg1XJcPIA5kyBKytozmemnZiZVAjdj9XmCxHaPQAEqsN6gdDl1AYTiGaHcSgMGNWMDYNCwa2CKwprNsjtd-m9qx8nuCqyQ1AgPudiDdqFCDsQCFQrTDxejldkVvthdLscDtNDw87vsTgUrmdzrdHlfoqCY9j3i9WPdtwR4889lcnlkzxHP9L1HKdb3nYDlz7Mk3xAj992-ODoKsXNDSxZCxxdN0PVKX8UM-A8oLHND8ww-Cx0ta03kw3dEJ-YiV1IgtaL7ANRCDKBWIQss4AAZRgKQlTgABJbgMGCV5xEod1uCbLQ4CgV4XhCARv32AShNEAAeQg0AgDBGBjAA+PoeTUvEAPTccwKEABtAAGABdVd12bBClAs-tU0ApAbMneznKsJ8Xw8uAvKsocryVQKXNgvdPPbZiMOw91PTCrzktfKibQypKDTI192M4hDkiAA) | [Challenge](test/typescript/readme.md)
 
-TypeBox includes a syntax engine that can transform TypeScript declarations into JSON Schema. The engine is a full syntactic frontend to Type.* and supports many advanced type-level constructs such as Conditional, Mapped, Indexed, Infer, Generics, Distributed types and more. This feature is implemented symmetrically at runtime and statically via TypeScript Template Literal types. 
-
-Syntax highlighting is available via the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=sinclairzx81.typebox-script)
-
+TypeBox includes a micro TypeScript scripting engine that can parse TypeScript definitions into JSON Schema. The engine is implemented at runtime as well as statically inside TypeScript's type system, and supports many programmable constructs such as conditional, mapped, indexed, generic, and distributed types, and more.
 
 ### Example
 
-The following uses Script to parse TypeScript declarations into JSON Schema. 
+Syntax highlighting is available via the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=sinclairzx81.typebox-script)
 
 ```typescript
 // Module
 const Math = Type.Script(`
   type Vector2 = { x: number, y: number }
-  type Vector3 = Evaluate<Vector2 & { z: number }>
-  type Vector4 = Evaluate<Vector3 & { w: number }>
+  type Vector3 = { x: number, y: number, z: number }
+  type Vector4 = { x: number, y: number, z: number, w: number }
 `)
 
 // Dependent Module
-const { Mesh } = Type.Script({ ...Math }, `  
+const { Mesh } = Type.Script(Math, `  
   type Vertex = {
     position: Vector4,
     normal: Vector3,

--- a/readme.md
+++ b/readme.md
@@ -298,29 +298,29 @@ The following table shows compile performance for various JSON Schema structures
 ┌──────────────────────┬─────────────┬─────────────┐
 │ Compile              │ TB1X        │ AJV8        │
 ├──────────────────────┼─────────────┼─────────────┤
-│ Boolean              │ 29.2K ops/s │  7.1K ops/s │
-│ Number               │ 34.5K ops/s │  7.6K ops/s │
-│ String               │ 48.9K ops/s │  8.7K ops/s │
-│ Null                 │ 39.6K ops/s │  7.6K ops/s │
-│ Literal_String       │ 46.8K ops/s │  6.8K ops/s │
-│ Literal_Number       │ 48.3K ops/s │  7.4K ops/s │
-│ Literal_Boolean      │ 48.8K ops/s │  7.3K ops/s │
-│ Pattern              │ 32.5K ops/s │  6.1K ops/s │
-│ Object_Open          │  6.6K ops/s │  1.4K ops/s │
-│ Object_Close         │  7.6K ops/s │    1K ops/s │
-│ Object_Vector3       │ 20.8K ops/s │  2.8K ops/s │
-│ Object_Basis3        │  7.5K ops/s │    1K ops/s │
-│ Intersect_And        │   23K ops/s │  3.9K ops/s │
-│ Intersect_Structural │  8.7K ops/s │  1.2K ops/s │
-│ Union_Or             │ 17.9K ops/s │  3.4K ops/s │
-│ Union_Structural     │ 11.3K ops/s │  2.1K ops/s │
-│ Tuple_Values         │  9.6K ops/s │  2.1K ops/s │
-│ Tuple_Objects        │  2.1K ops/s │   350 ops/s │
-│ Array_Numbers_4      │ 33.6K ops/s │  4.2K ops/s │
-│ Array_Numbers_8      │   39K ops/s │  3.7K ops/s │
-│ Array_Numbers_16     │ 29.6K ops/s │  3.8K ops/s │
-│ Array_Objects_Open   │  7.7K ops/s │   833 ops/s │
-│ Array_Objects_Close  │  7.6K ops/s │   860 ops/s │
+│ Boolean              │ 39.7K ops/s │  6.8K ops/s │
+│ Number               │ 86.2K ops/s │  7.5K ops/s │
+│ String               │ 82.6K ops/s │  8.2K ops/s │
+│ Null                 │   62K ops/s │  7.3K ops/s │
+│ Literal_String       │ 72.1K ops/s │  5.7K ops/s │
+│ Literal_Number       │ 72.7K ops/s │  6.9K ops/s │
+│ Literal_Boolean      │ 80.9K ops/s │    7K ops/s │
+│ Pattern              │ 38.7K ops/s │  5.7K ops/s │
+│ Object_Open          │ 16.3K ops/s │  1.3K ops/s │
+│ Object_Close         │ 15.7K ops/s │   952 ops/s │
+│ Object_Vector3       │ 40.2K ops/s │  3.2K ops/s │
+│ Object_Basis3        │ 16.1K ops/s │   834 ops/s │
+│ Intersect_And        │ 45.7K ops/s │  3.5K ops/s │
+│ Intersect_Structural │   21K ops/s │  1.6K ops/s │
+│ Union_Or             │ 45.1K ops/s │  3.4K ops/s │
+│ Union_Structural     │ 27.6K ops/s │    2K ops/s │
+│ Tuple_Values         │ 14.7K ops/s │    2K ops/s │
+│ Tuple_Objects        │  3.7K ops/s │   380 ops/s │
+│ Array_Numbers_4      │ 73.6K ops/s │  4.3K ops/s │
+│ Array_Numbers_8      │ 50.9K ops/s │  3.8K ops/s │
+│ Array_Numbers_16     │   85K ops/s │  3.9K ops/s │
+│ Array_Objects_Open   │ 18.9K ops/s │   789 ops/s │
+│ Array_Objects_Close  │ 17.9K ops/s │   909 ops/s │
 └──────────────────────┴─────────────┴─────────────┘
 ```
 

--- a/src/guard/guard.ts
+++ b/src/guard/guard.ts
@@ -26,6 +26,8 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
+// deno-fmt-ignore-file
+
 import * as String from './string.ts'
 
 // --------------------------------------------------------------------------
@@ -222,9 +224,11 @@ function DeepEqualArray(left: unknown[], right: unknown): boolean {
   return IsArray(right) && IsEqual(left.length, right.length) &&
     left.every((_, index) => IsDeepEqual(left[index], right[index]))
 }
-/** Tests values for deep equality */
+/** Returns true if left and right values are structurally equal */
 export function IsDeepEqual(left: unknown, right: unknown): boolean {
   return (
-    IsArray(left) ? DeepEqualArray(left, right) : IsObject(left) ? DeepEqualObject(left, right) : IsEqual(left, right)
+    IsArray(left) ? DeepEqualArray(left, right) : 
+    IsObject(left) ? DeepEqualObject(left, right) : 
+    IsEqual(left, right)
   )
 }

--- a/src/schema/engine/_functions.ts
+++ b/src/schema/engine/_functions.ts
@@ -35,45 +35,69 @@ import { BuildContext } from './_context.ts'
 import { EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchema } from './schema.ts'
 
-const functions: Map<string, string> = new Map()
+// ------------------------------------------------------------------
+// State
+// ------------------------------------------------------------------
+type Href = string & { kind: 'Href' }
+type Name = string & { kind: 'Name' }
 
+const index = [0]
+const names = new Map<Schema.XSchema, Map<Href, Name>>
+const funcs = new Map<Name, string> ()
+
+// ------------------------------------------------------------------
+// CreateName
+// ------------------------------------------------------------------
+function NextName(): Name {
+  return Hashing.Hash(index[0]++) as Name
+}
+function CreateName(schema: Schema.XSchema, href: Href): Name {
+  if(!names.has(schema)) names.set(schema, new Map<Href, Name>())
+  const hrefs = names.get(schema)!
+  if(hrefs.has(href)) return hrefs.get(href)!
+  const name = NextName()
+  hrefs.set(href, name)
+  return name
+}
 // ------------------------------------------------------------------
 // CreateCallExpression
 // ------------------------------------------------------------------
-function CreateCallExpression(context: BuildContext, _schema: Schema.XSchema, hash: string, value: string): string {
+function CreateCallExpression(context: BuildContext, _schema: Schema.XSchema, name: string, value: string): string {
   return context.UseUnevaluated()
-    ? E.Call(`check_${hash}`, ['context', value])
-    : E.Call(`check_${hash}`, [value])
+    ? E.Call(`check_${name}`, ['context', value])
+    : E.Call(`check_${name}`, [value])
 }
 // ------------------------------------------------------------------
 // CreateFunctionExpression
 // ------------------------------------------------------------------
-function CreateFunctionExpression(stack: Stack, context: BuildContext, schema: Schema.XSchema, hash: string): string {
+function CreateFunctionExpression(stack: Stack, context: BuildContext, schema: Schema.XSchema, name: string): string {
   const expression = BuildSchema(stack, context, schema, 'value')
   return context.UseUnevaluated()
-    ? E.ConstDeclaration(`check_${hash}`, E.ArrowFunction(['context', 'value'], expression))
-    : E.ConstDeclaration(`check_${hash}`, E.ArrowFunction(['value'], expression))
+    ? E.ConstDeclaration(`check_${name}`, E.ArrowFunction(['context', 'value'], expression))
+    : E.ConstDeclaration(`check_${name}`, E.ArrowFunction(['value'], expression))
 }
 // ------------------------------------------------------------------
 // ResetFunctions
 // ------------------------------------------------------------------
 export function ResetFunctions(): void {
-  functions.clear()
+  index[0] = 0
+  names.clear()
+  funcs.clear()
 }
 // ------------------------------------------------------------------
 // GetFunctions
 // ------------------------------------------------------------------
 export function GetFunctions(): string[] {
-  return [...functions.values()]
+  return [...funcs.values()]
 }
 // ------------------------------------------------------------------
 // CreateFunction
 // ------------------------------------------------------------------
 export function CreateFunction(stack: Stack, context: BuildContext, schema: Schema.XSchema, value: string): string {
-  const hash = Schema.IsSchemaObject(schema) ? Hashing.Hash({ __baseURL: stack.BaseURL().href, ...schema }) : Hashing.Hash(schema)
-  const call = CreateCallExpression(context, schema, hash, value)
-  if (functions.has(hash)) return call
-  functions.set(hash, '')
-  functions.set(hash, CreateFunctionExpression(stack, context, schema, hash))
+  const name = CreateName(schema, stack.BaseURL().href as Href)
+  const call = CreateCallExpression(context, schema, name, value)
+  if (funcs.has(name)) return call
+  funcs.set(name, '')
+  funcs.set(name, CreateFunctionExpression(stack, context, schema, name))
   return call
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.3.3'
+const Version = '1.3.4'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typescript/readme.md
+++ b/test/typescript/readme.md
@@ -1,24 +1,8 @@
 # Type Challenges
 
-Various solutions to [Type Challenges](https://github.com/type-challenges/type-challenges) implemented with TypeBox
-
 ## Overview
 
-This test suite is used to stress test the TypeBox syntax engine
-
-```typescript
-const Input = Type.Script(`{
-  x: string
-  y: number
-  z: boolean
-}`)
-
-const Output = Type.Script({ Input }, `Input extends {
-  x: infer X,
-  y: infer Y,
-  z: infer Z
-} ? [X, Y, Z] : never`) // [string, number, boolean]
-```
+Solutions to [Type Challenges](https://github.com/type-challenges/type-challenges) implemented with TypeBox's scripting engine.
 
 ## Solutions
 


### PR DESCRIPTION
This PR makes optimizations to Compile by replacing schema hashing on codegen and using a SchemaRef + Href caching strategy instead. By avoiding repeated calls to hash large schematics, compilation performance improves dramatically, particularly for recursive schematics. 

Performance tests were run against the Mcp Protocol Specification (Included in this PR)

### Implementation

The implementation opts for a Map instead of a WeakMap, and will reset the Map on each Compile call to mitigate issues with latent schema mutation. Function names are produced via incrementing Ordinal index which is hashed and also reset on Compile. The Ordinal reset is used to ensure the same Schema will produce the same functions each Compile (used for JavaScript engine JIT | Eval caching)

The following is the updated resolution strategy (replacing Hash with Name)

```typescript
// ------------------------------------------------------------------
// State
// ------------------------------------------------------------------
type Href = string & { kind: 'Href' }
type Name = string & { kind: 'Name' }

const index = [0]
const names = new Map<Schema.XSchema, Map<Href, Name>>
const funcs = new Map<Name, string> ()
// ------------------------------------------------------------------
// CreateName
// ------------------------------------------------------------------
function NextName(): Name {
  return Hashing.Hash(index[0]++) as Name
}
function CreateName(schema: Schema.XSchema, href: Href): Name {
  if(!names.has(schema)) names.set(schema, new Map<Href, Name>())
  const hrefs = names.get(schema)!
  if(hrefs.has(href)) return hrefs.get(href)!
  const name = NextName()
  hrefs.set(href, name)
  return name
}
```

### Before

```python
┌──────────────────────┬─────────────┬─────────────┐
│ Compile              │ TB1X        │ AJV8        │
├──────────────────────┼─────────────┼─────────────┤
│ Object_Open          │  6.6K ops/s │  1.4K ops/s │
│ Object_Close         │  7.6K ops/s │    1K ops/s │
│ Object_Vector3       │ 20.8K ops/s │  2.8K ops/s │
│ Object_Basis3        │  7.5K ops/s │    1K ops/s │
│ Intersect_And        │   23K ops/s │  3.9K ops/s │
│ Intersect_Structural │  8.7K ops/s │  1.2K ops/s │
│ Union_Or             │ 17.9K ops/s │  3.4K ops/s │
│ Union_Structural     │ 11.3K ops/s │  2.1K ops/s │
│ Tuple_Values         │  9.6K ops/s │  2.1K ops/s │
│ Tuple_Objects        │  2.1K ops/s │   350 ops/s │
│ Array_Numbers_4      │ 33.6K ops/s │  4.2K ops/s │
│ Array_Numbers_8      │   39K ops/s │  3.7K ops/s │
│ Array_Numbers_16     │ 29.6K ops/s │  3.8K ops/s │
│ Array_Objects_Open   │  7.7K ops/s │   833 ops/s │
│ Array_Objects_Close  │  7.6K ops/s │   860 ops/s │
└──────────────────────┴─────────────┴─────────────┘
```

### After

```python
┌──────────────────────┬─────────────┬─────────────┐
│ Compile              │ TB1X        │ AJV8        │
├──────────────────────┼─────────────┼─────────────┤
│ Object_Open          │ 16.3K ops/s │  1.3K ops/s │
│ Object_Close         │ 15.7K ops/s │   952 ops/s │
│ Object_Vector3       │ 40.2K ops/s │  3.2K ops/s │
│ Object_Basis3        │ 16.1K ops/s │   834 ops/s │
│ Intersect_And        │ 45.7K ops/s │  3.5K ops/s │
│ Intersect_Structural │   21K ops/s │  1.6K ops/s │
│ Union_Or             │ 45.1K ops/s │  3.4K ops/s │
│ Union_Structural     │ 27.6K ops/s │    2K ops/s │
│ Tuple_Values         │ 14.7K ops/s │    2K ops/s │
│ Tuple_Objects        │  3.7K ops/s │   380 ops/s │
│ Array_Numbers_4      │ 73.6K ops/s │  4.3K ops/s │
│ Array_Numbers_8      │ 50.9K ops/s │  3.8K ops/s │
│ Array_Numbers_16     │   85K ops/s │  3.9K ops/s │
│ Array_Objects_Open   │ 18.9K ops/s │   789 ops/s │
│ Array_Objects_Close  │ 17.9K ops/s │   909 ops/s │
└──────────────────────┴─────────────┴─────────────┘
```