### PR TITLE
docs: fix typo occurance -> occurrence in Errors doc comments

### DIFF
--- a/src/value/errors/errors.ts
+++ b/src/value/errors/errors.ts
@@ -36,7 +36,7 @@ import { Errors as SchemaErrors,  } from '../../schema/index.ts'
 /** 
  * Performs an exhaustive Check on the specified value and reports any errors found.
  * If no errors are found, an empty array is returned. Unlike Check, this function
- * does not terminate at the first occurance of an error. For best performance, call 
+ * does not terminate at the first occurrence of an error. For best performance, call 
  * Check first and call Errors only if Check returns false.
  */
 export function Errors<Type extends TSchema>(type: Type, value: unknown): TLocalizedValidationError[]
@@ -44,7 +44,7 @@ export function Errors<Type extends TSchema>(type: Type, value: unknown): TLocal
 /** 
  * Performs an exhaustive Check on the specified value and reports any errors found.
  * If no errors are found, an empty array is returned. Unlike Check, this function
- * does not terminate at the first occurance of an error. For best performance, call 
+ * does not terminate at the first occurrence of an error. For best performance, call 
  * Check first and call Errors only if Check returns false.
  */
 export function Errors<Context extends TProperties, Type extends TSchema>(context: Context, type: Type, value: unknown): TLocalizedValidationError[]
@@ -52,7 +52,7 @@ export function Errors<Context extends TProperties, Type extends TSchema>(contex
 /** 
  * Performs an exhaustive Check on the specified value and reports any errors found.
  * If no errors are found, an empty array is returned. Unlike Check, this function
- * does not terminate at the first occurance of an error. For best performance, call 
+ * does not terminate at the first occurrence of an error. For best performance, call 
  * Check first and call Errors only if Check returns false.
  */
 export function Errors(...args: unknown[]): TLocalizedValidationError[] {


### PR DESCRIPTION
## Summary

Fix a typo in the `Errors` function doc comments: "occurance" -> "occurrence".

The word appears in the shared JSDoc block across all three `Errors` overloads in `src/value/errors/errors.ts` (3 occurrences, identical wording). Doc-comment only - no runtime, type, or API change.
