### PR TITLE
fix(guard): fast-path length checks miss variation selectors and combining marks

### DIFF
--- a/src/guard/string.ts
+++ b/src/guard/string.ts
@@ -105,7 +105,8 @@ function NextGraphemeClusterIndex(value: string, clusterStart: number): number {
 function IsGraphemeCodePoint(value: number): boolean {
   return (
     IsBetween(value, 0xD800, 0xDBFF) || // High surrogate
-    IsBetween(value, 0x0300, 0x036F) || // Combining diacritical marks
+    IsCombiningMark(value) || // Combining marks
+    IsVariationSelector(value) || // Variation selectors
     (value === 0x200D) // Zero-width joiner
   )
 }

--- a/test/typebox/runtime/guard/string.ts
+++ b/test/typebox/runtime/guard/string.ts
@@ -381,3 +381,24 @@ Test('Should FastPath 22', () => {
 Test('Should FastPath 23', () => {
   Assert.IsEqual(Guard.GraphemeCount('\uDC00'), 1)
 })
+// ------------------------------------------------------------------
+// Guard.FastPath - Variation Selectors and Combining Marks (non-surrogate base)
+// ------------------------------------------------------------------
+Test('Should FastPath 24', () => {
+  Assert.IsTrue(Guard.IsMaxLength('❤️', 1)) // ❤️ base + variation selector
+})
+Test('Should FastPath 25', () => {
+  Assert.IsFalse(Guard.IsMinLength('❤️', 2)) // ❤️ base + variation selector
+})
+Test('Should FastPath 26', () => {
+  Assert.IsTrue(Guard.IsMaxLength('☀️', 1)) // ☀️ base + variation selector
+})
+Test('Should FastPath 27', () => {
+  Assert.IsTrue(Guard.IsMaxLength('a᪰', 1)) // base + combining mark U+1AB0
+})
+Test('Should FastPath 28', () => {
+  Assert.IsTrue(Guard.IsMaxLength('a᷀', 1)) // base + combining mark U+1DC0
+})
+Test('Should FastPath 29', () => {
+  Assert.IsTrue(Guard.IsMaxLength('a︠', 1)) // base + combining mark U+FE20
+})


### PR DESCRIPTION
`IsMinLengthFast`/`IsMaxLengthFast` only fall back to the accurate grapheme counter when they encounter a high surrogate, a combining diacritical mark (U+0300–U+036F) or a ZWJ. The accurate `NextGraphemeClusterIndex` also folds variation selectors (U+FE00–U+FE0F) and the combining marks in U+1AB0–U+1AFF, U+1DC0–U+1DFF and U+FE20–U+FE2F into the preceding cluster, so a BMP base followed by one of those is over-counted by the fast path.

This makes `minLength`/`maxLength` disagree with `Guard.GraphemeCount` for the most common emoji-presentation sequences (two BMP code units, no surrogate to trigger the fallback):

```ts
Guard.GraphemeCount('❤️')                        // 1
Value.Check(Type.String({ maxLength: 1 }), '❤️') // false  (should be true)
Value.Check(Type.String({ minLength: 2 }), '❤️') // true   (should be false)
```

Reuse the existing `IsCombiningMark` / `IsVariationSelector` helpers so the fast-path fallback covers every code point the accurate counter treats as cluster-extending. Falling back more often is always safe — the accurate path is the source of truth. Adds regression tests.
