### PR TITLE
Fix keyword guards for multi-type schemas

### DIFF
--- a/src/schema/engine/schema.ts
+++ b/src/schema/engine/schema.ts
@@ -79,9 +79,9 @@ import { BuildUnevaluatedProperties, CheckUnevaluatedProperties, ErrorUnevaluate
 import { BuildUniqueItems, CheckUniqueItems, ErrorUniqueItems } from './uniqueItems.ts'
 
 // ----------------------------------------------------------------
-// HasOnlyTypeName
+// HasTypeName
 // ----------------------------------------------------------------
-function HasOnlyTypeName(schema: Schema.XSchemaObject, typename: string): boolean {
+function HasTypeName(schema: Schema.XSchemaObject, typename: string): boolean {
   return Schema.IsType(schema) &&
     (G.IsArray(schema.type) && schema.type.length > 0 && schema.type.every(type => G.IsEqual(type, typename)) ||
       G.IsEqual(schema.type, typename))
@@ -90,7 +90,7 @@ function HasOnlyTypeName(schema: Schema.XSchemaObject, typename: string): boolea
 // HasObject
 // ----------------------------------------------------------------
 function HasObjectType(schema: Schema.XSchemaObject): boolean {
-  return HasOnlyTypeName(schema, 'object')
+  return HasTypeName(schema, 'object')
 }
 function HasObjectKeywords(schema: Schema.XSchemaObject): boolean {
   return Schema.IsSchemaObject(schema) && (
@@ -111,7 +111,7 @@ function HasObjectKeywords(schema: Schema.XSchemaObject): boolean {
 // HasArray
 // ----------------------------------------------------------------
 function HasArrayType(schema: Schema.XSchemaObject): boolean {
-  return HasOnlyTypeName(schema, 'array')
+  return HasTypeName(schema, 'array')
 }
 function HasArrayKeywords(schema: Schema.XSchemaObject): boolean {
   return Schema.IsSchemaObject(schema) && (
@@ -131,7 +131,7 @@ function HasArrayKeywords(schema: Schema.XSchemaObject): boolean {
 // HasString
 // ----------------------------------------------------------------
 function HasStringType(schema: Schema.XSchemaObject): boolean {
-  return HasOnlyTypeName(schema, 'string')
+  return HasTypeName(schema, 'string')
 }
 function HasStringKeywords(schema: Schema.XSchemaObject): boolean {
   return Schema.IsSchemaObject(schema) && (
@@ -145,7 +145,7 @@ function HasStringKeywords(schema: Schema.XSchemaObject): boolean {
 // HasNumber
 // ----------------------------------------------------------------
 function HasNumberType(schema: Schema.XSchemaObject): boolean {
-  return HasOnlyTypeName(schema, 'number') || HasOnlyTypeName(schema, 'bigint')
+  return HasTypeName(schema, 'number') || HasTypeName(schema, 'bigint')
 }
 function HasNumberKeywords(schema: Schema.XSchemaObject): boolean {
   return Schema.IsSchemaObject(schema) && (

--- a/src/schema/engine/schema.ts
+++ b/src/schema/engine/schema.ts
@@ -79,18 +79,18 @@ import { BuildUnevaluatedProperties, CheckUnevaluatedProperties, ErrorUnevaluate
 import { BuildUniqueItems, CheckUniqueItems, ErrorUniqueItems } from './uniqueItems.ts'
 
 // ----------------------------------------------------------------
-// HasTypeName
+// HasOnlyTypeName
 // ----------------------------------------------------------------
-function HasTypeName(schema: Schema.XSchemaObject, typename: string): boolean {
+function HasOnlyTypeName(schema: Schema.XSchemaObject, typename: string): boolean {
   return Schema.IsType(schema) &&
-    (G.IsArray(schema.type) && schema.type.includes(typename) ||
+    (G.IsArray(schema.type) && schema.type.every(type => G.IsEqual(type, typename)) ||
       G.IsEqual(schema.type, typename))
 }
 // ----------------------------------------------------------------
 // HasObject
 // ----------------------------------------------------------------
 function HasObjectType(schema: Schema.XSchemaObject): boolean {
-  return HasTypeName(schema, 'object')
+  return HasOnlyTypeName(schema, 'object')
 }
 function HasObjectKeywords(schema: Schema.XSchemaObject): boolean {
   return Schema.IsSchemaObject(schema) && (
@@ -111,7 +111,7 @@ function HasObjectKeywords(schema: Schema.XSchemaObject): boolean {
 // HasArray
 // ----------------------------------------------------------------
 function HasArrayType(schema: Schema.XSchemaObject): boolean {
-  return HasTypeName(schema, 'array')
+  return HasOnlyTypeName(schema, 'array')
 }
 function HasArrayKeywords(schema: Schema.XSchemaObject): boolean {
   return Schema.IsSchemaObject(schema) && (
@@ -131,7 +131,7 @@ function HasArrayKeywords(schema: Schema.XSchemaObject): boolean {
 // HasString
 // ----------------------------------------------------------------
 function HasStringType(schema: Schema.XSchemaObject): boolean {
-  return HasTypeName(schema, 'string')
+  return HasOnlyTypeName(schema, 'string')
 }
 function HasStringKeywords(schema: Schema.XSchemaObject): boolean {
   return Schema.IsSchemaObject(schema) && (
@@ -145,7 +145,7 @@ function HasStringKeywords(schema: Schema.XSchemaObject): boolean {
 // HasNumber
 // ----------------------------------------------------------------
 function HasNumberType(schema: Schema.XSchemaObject): boolean {
-  return HasTypeName(schema, 'number') || HasTypeName(schema, 'bigint')
+  return HasOnlyTypeName(schema, 'number') || HasOnlyTypeName(schema, 'bigint')
 }
 function HasNumberKeywords(schema: Schema.XSchemaObject): boolean {
   return Schema.IsSchemaObject(schema) && (

--- a/src/schema/engine/schema.ts
+++ b/src/schema/engine/schema.ts
@@ -83,7 +83,7 @@ import { BuildUniqueItems, CheckUniqueItems, ErrorUniqueItems } from './uniqueIt
 // ----------------------------------------------------------------
 function HasOnlyTypeName(schema: Schema.XSchemaObject, typename: string): boolean {
   return Schema.IsType(schema) &&
-    (G.IsArray(schema.type) && schema.type.every(type => G.IsEqual(type, typename)) ||
+    (G.IsArray(schema.type) && schema.type.length > 0 && schema.type.every(type => G.IsEqual(type, typename)) ||
       G.IsEqual(schema.type, typename))
 }
 // ----------------------------------------------------------------

--- a/test/typebox/runtime/schema/compile.ts
+++ b/test/typebox/runtime/schema/compile.ts
@@ -45,6 +45,12 @@ Test('Should Compile 4', () => {
   const validator = Schema.Compile({ type: 'string' })
   Assert.Throws(() => validator.Parse(1))
 })
+Test('Should Compile Type Array With Array Keywords', () => {
+  const validator = Schema.Compile({ type: ['array', 'null'], items: { type: 'string' } })
+  Assert.IsTrue(validator.Check(null))
+  Assert.IsTrue(validator.Check(['hello']))
+  Assert.IsFalse(validator.Check([1]))
+})
 // ------------------------------------------------------------------
 // With Context
 // ------------------------------------------------------------------

--- a/test/typebox/runtime/schema/compile.ts
+++ b/test/typebox/runtime/schema/compile.ts
@@ -45,11 +45,29 @@ Test('Should Compile 4', () => {
   const validator = Schema.Compile({ type: 'string' })
   Assert.Throws(() => validator.Parse(1))
 })
+Test('Should Compile Type Array With Object Keywords', () => {
+  const validator = Schema.Compile({ type: ['object', 'null'], properties: { value: { type: 'string' } } })
+  Assert.IsTrue(validator.Check(null))
+  Assert.IsTrue(validator.Check({ value: 'hello' }))
+  Assert.IsFalse(validator.Check({ value: 1 }))
+})
 Test('Should Compile Type Array With Array Keywords', () => {
   const validator = Schema.Compile({ type: ['array', 'null'], items: { type: 'string' } })
   Assert.IsTrue(validator.Check(null))
   Assert.IsTrue(validator.Check(['hello']))
   Assert.IsFalse(validator.Check([1]))
+})
+Test('Should Compile Type Array With String Keywords', () => {
+  const validator = Schema.Compile({ type: ['string', 'null'], minLength: 1 })
+  Assert.IsTrue(validator.Check(null))
+  Assert.IsTrue(validator.Check('hello'))
+  Assert.IsFalse(validator.Check(''))
+})
+Test('Should Compile Type Array With Number Keywords', () => {
+  const validator = Schema.Compile({ type: ['number', 'null'], minimum: 1 })
+  Assert.IsTrue(validator.Check(null))
+  Assert.IsTrue(validator.Check(1))
+  Assert.IsFalse(validator.Check(0))
 })
 // ------------------------------------------------------------------
 // With Context


### PR DESCRIPTION
Fixes #1653

## Summary

Guard type-specific keyword checks when a schema's `type` array contains values outside that keyword's instance type.

## Problem

For this valid JSON Schema:

```json
{
  "type": ["array", "null"],
  "items": { "type": "string" }
}
```

`Schema.Check(schema, null)` returns `true`, but `Schema.Compile(schema).Check(null)` throws:

```text
TypeError: Cannot read properties of null (reading 'every')
```

The compiler currently treats the presence of `"array"` anywhere in the type array as sufficient to emit unguarded array keyword checks. It therefore generates logic equivalent to:

```js
(Array.isArray(value) || value === null) && value.every(...)
```

JSON Schema type-specific keywords only apply to compatible instances, so `items` must not be evaluated for `null`.

## Implementation

Only elide a type-specific runtime guard when every declared type is that exact type. Multi-type schemas retain the existing runtime guard, while single-type schemas keep the current fast path.

The same helper is used for object, array, string, and numeric keyword groups, preventing equivalent failures for other mixed-type schemas.

## Validation

- `deno task test` — 35,137 passed
- `deno task lint` — passed
- `deno fmt --check src/schema/engine/schema.ts test/typebox/runtime/schema/compile.ts` — passed
- `deno task build` — passed, including package type checks


