### PR TITLE
Record contains-matched indices so unevaluatedItems accepts them

### DIFF
--- a/src/schema/engine/contains.ts
+++ b/src/schema/engine/contains.ts
@@ -49,16 +49,35 @@ export function BuildContains(stack: Stack, context: BuildContext, schema: Schem
   if (!IsValid(schema)) return E.Constant(true)
   const item = Unique()
   const isLength = E.Not(E.IsEqual(E.Member(value, 'length'), E.Constant(0)))
-  const isSome = E.Call(E.Member(value, 'some'), [E.ArrowFunction([item], BuildSchema(stack, context, schema.contains, item))])
+  if (!context.UseUnevaluated()) {
+    const isSome = E.Call(E.Member(value, 'some'), [E.ArrowFunction([item], BuildSchema(stack, context, schema.contains, item))])
+    return E.And(isLength, isSome)
+  }
+  // When unevaluated tracking is active, record the index of every matching
+  // item so unevaluatedItems treats them as evaluated. reduce (not some) is
+  // used so the scan does not short-circuit before all indices are recorded.
+  const index = Unique()
+  const accumulator = Unique()
+  const isSome = E.Call(E.Member(value, 'reduce'), [
+    E.ArrowFunction([accumulator, item, index], E.Ternary(BuildSchema(stack, context, schema.contains, item), context.AddIndex(index), accumulator)),
+    E.Constant(false),
+  ])
   return E.And(isLength, isSome)
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
 export function CheckContains(stack: Stack, context: CheckContext, schema: Schema.XContains, value: unknown[]): boolean {
-  if (!IsValid(schema)) return true
-  return !G.IsEqual(value.length, 0) &&
-    value.some((item) => CheckSchema(stack, context, schema.contains, item))
+  // Record the index of every matching item (not just whether one exists) so
+  // that unevaluatedItems treats contains-matched items as evaluated.
+  let contains = false
+  for (let index = 0; index < value.length; index++) {
+    if (CheckSchema(stack, context, schema.contains, value[index])) {
+      context.AddIndex(index)
+      contains = true
+    }
+  }
+  return contains || !IsValid(schema)
 }
 // ------------------------------------------------------------------
 // Error

--- a/test/typebox/runtime/value/check/array.ts
+++ b/test/typebox/runtime/value/check/array.ts
@@ -96,6 +96,13 @@ Test('Should validate for contains', () => {
   Fail(T, [])
   Fail(T, [2])
 })
+Test('Should treat contains-matched items as evaluated for unevaluatedItems', () => {
+  const T = Type.Unsafe({ type: 'array', contains: Type.String(), unevaluatedItems: false })
+  Ok(T, ['foo'])
+  Ok(T, ['foo', 'bar'])
+  Fail(T, ['foo', 1])
+  Fail(T, [1])
+})
 Test('Should validate for minContains', () => {
   const T = Type.Array(Type.Number(), { contains: Type.Literal(1), minContains: 3 })
   Ok(T, [1, 1, 1, 2])


### PR DESCRIPTION
### Problem

Under JSON Schema draft 2020-12 §11.2, `unevaluatedItems` treats an item as
*evaluated* if it was matched by `prefixItems`, `items`, **or `contains`**.
TypeBox records evaluated indices for `prefixItems` and `items`
(`context.AddIndex(...)`), but `contains` used `value.some(...)` (interpreter)
and a compiled `.some(...)` and recorded nothing. So a `contains`-matched item
was treated as unevaluated, and a valid array was wrongly rejected — on both the
`Value.Check` and `Compile().Check` paths:

```ts
const S = { contains: { type: 'string' }, unevaluatedItems: false }
Value.Check(S, ['foo'])       // false — should be true
Compile(S).Check(['foo'])     // false — should be true
Value.Check({ prefixItems: [true], ...S }, [1, 'foo']) // false — should be true
```

`['foo']` has its only item matched by `contains`, so nothing is unevaluated and
`unevaluatedItems: false` is satisfied.

TypeBox already vendors this exact expectation in
`test/jsonschema/cases/v1/_unevaluatedItems.json` ("second item is evaluated by
contains" → `valid: true`), but that file is `_`-prefixed and excluded from the
active suite, so the behavior was never enforced. The official
JSON-Schema-Test-Suite `draft2020-12/unevaluatedItems.json` agrees.

### Fix

Record the index of every `contains`-matching item, in both `CheckContains` and
`BuildContains`. The compiled path uses `reduce` instead of `some` when
unevaluated tracking is active so the scan does not short-circuit before all
matching indices are recorded; when tracking is off it keeps the original
`.some(...)` fast-path. `minContains: 0` semantics are preserved (an
all-non-matching array with `minContains: 0` still validates).

### Test

Added a `Value.Check.Array` case (which exercises both the `Compile` and `Value`
paths via the shared `Ok`/`Fail` helper) asserting that a `contains`-matched item
counts as evaluated. Fails on `main`, passes with the fix; the full suite is
otherwise unchanged.
