### PR TITLE
Expose Metrics counters as accessors

### DIFF
--- a/src/system/memory/metrics.ts
+++ b/src/system/memory/metrics.ts
@@ -39,11 +39,48 @@ export interface TMetrics {
   update: number
 }
 
+// ------------------------------------------------------------------
+// Counters
+// ------------------------------------------------------------------
+// Metrics exposes these counters as accessors so they remain writable when
+// Metrics is frozen. Hosts that share one module graph between isolated
+// consumers deep-freeze it, and incrementing a frozen data property throws.
+let assign = 0
+let create = 0
+let clone = 0
+let discard = 0
+let update = 0
+
 /** TypeBox instantiation metrics */
 export const Metrics: TMetrics = {
-  assign: 0,
-  create: 0,
-  clone: 0,
-  discard: 0,
-  update: 0
+  get assign() {
+    return assign
+  },
+  set assign(value: number) {
+    assign = value
+  },
+  get create() {
+    return create
+  },
+  set create(value: number) {
+    create = value
+  },
+  get clone() {
+    return clone
+  },
+  set clone(value: number) {
+    clone = value
+  },
+  get discard() {
+    return discard
+  },
+  set discard(value: number) {
+    discard = value
+  },
+  get update() {
+    return update
+  },
+  set update(value: number) {
+    update = value
+  }
 }

--- a/test/typebox/runtime/system/memory.ts
+++ b/test/typebox/runtime/system/memory.ts
@@ -121,3 +121,22 @@ Test('Should Create 11', () => {
   Assert.PropertyIsEnumerable(B, '~unsafe')
   Settings.Reset()
 })
+// ------------------------------------------------------------------
+// Metrics
+// ------------------------------------------------------------------
+Test('Should Increment Metrics', () => {
+  const A = Memory.Metrics.create
+  Type.String()
+  Assert.IsEqual(Memory.Metrics.create, A + 1)
+})
+// ------------------------------------------------------------------
+// Metrics Should Increment When Frozen
+//
+// https://github.com/sinclairzx81/typebox/issues/1658
+// ------------------------------------------------------------------
+Test('Should Increment Metrics When Frozen', () => {
+  Object.freeze(Memory.Metrics)
+  const A = Memory.Metrics.create
+  Type.String()
+  Assert.IsEqual(Memory.Metrics.create, A + 1)
+})


### PR DESCRIPTION

Closes https://github.com/sinclairzx81/typebox/issues/1658

`Metrics` increments a counter for every `Assign`, `Create`, `Clone`, `Discard` and `Update` call. The counters are data properties, so the increment throws `TypeError` once `Metrics` is frozen — and since every `Type.*` constructor routes through at least one of those five, schema construction fails outright rather than merely losing its metrics. The issue has a self-contained reproduction.

This keeps the counters as module-scope variables and exposes them through accessors. A freeze cannot disable an accessor, so the increments keep working.

`TMetrics` is unchanged, and `Object.keys(Metrics)` and `{ ...Metrics }` produce identical output before and after, so the counters stay readable, enumerable and spreadable.

## Tests

Two tests in `test/typebox/runtime/system/memory.ts`: that the counters increment, and that they still increment after `Object.freeze(Memory.Metrics)`.

They assert the behaviour rather than the mechanism, so they do not pin the implementation to accessors specifically.

## Verification

- `deno task lint` — clean, 685 files
- `deno task test` — 35,188 passing, 0 failing
- `deno task build` — clean
- packed that build and ran the issue's reproduction against it: prints `Metrics frozen? true` and then does not throw, where `typebox@1.3.8` throws at `create.mjs:25`

## Note

Happy to drop this in favour of a `Settings` flag (`Settings.Set({ metrics: false })`) if you would rather metrics were opt-out than freeze-tolerant — the tradeoff is that a flag has to be set before the first schema is constructed, which a library depending on TypeBox cannot guarantee.

---
🤖 Drafted with [Claude Code](https://claude.com/claude-code)
