### PR TITLE
Version 1.3.11

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -4,6 +4,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.3.11](https://github.com/sinclairzx81/typebox/pull/1664)
+  - Clone and Discard Memory Optimization
 - [Revision 1.3.10](https://github.com/sinclairzx81/typebox/pull/1662)
   - MaxInstantiationCount System Configuration
   - Ensure Enum and TemplateLiteral Types are Distributed as Generic Arguments

--- a/src/system/memory/clone.ts
+++ b/src/system/memory/clone.ts
@@ -43,18 +43,18 @@ function FromClassInstance(value: Record<PropertyKey, unknown>): Record<Property
   return value // atomic
 }
 // ------------------------------------------------------------------
-// TypeObject
+// SchemaObject
 //
-// Types have non-enumerable properties that MUST be preserved on Clone. 
-// The following is the optimal path for TypeBox types.
+// Schema objects have non-enumerable properties that MUST be preserved 
+// on Clone. The following is the optimal path these objects.
 // ------------------------------------------------------------------
-function IsTypeObject(value: Record<PropertyKey, unknown>): boolean {
+function IsSchemaObject(value: Record<PropertyKey, unknown>): boolean {
   return (
     Guard.HasPropertyKey(value, '~kind') || 
     Guard.HasPropertyKey(value, '~unsafe')
   )
 }
-function FromTypeObject(value: Record<PropertyKey, unknown>): Record<PropertyKey, unknown> {
+function FromSchemaObject(value: Record<PropertyKey, unknown>): Record<PropertyKey, unknown> {
   const result = {} as Record<PropertyKey, unknown>
   for (const key of Object.getOwnPropertyNames(value)) {
     if (Guard.IsUnsafePropertyKey(key)) continue // (ignore: prototype-pollution)
@@ -88,7 +88,7 @@ function FromPlainObject(value: Record<PropertyKey, unknown>): Record<PropertyKe
 function FromObject(value: Record<PropertyKey, unknown>): Record<PropertyKey, unknown> {
   return (
     Guard.IsClassInstance(value) ? FromClassInstance(value) :
-    IsTypeObject(value) ? FromTypeObject(value) :
+    IsSchemaObject(value) ? FromSchemaObject(value) :
     FromPlainObject(value)
   )
 }

--- a/src/system/memory/clone.ts
+++ b/src/system/memory/clone.ts
@@ -56,12 +56,14 @@ function IsTypeObject(value: Record<PropertyKey, unknown>): boolean {
 }
 function FromTypeObject(value: Record<PropertyKey, unknown>): Record<PropertyKey, unknown> {
   const result = {} as Record<PropertyKey, unknown>
-  const descriptors = Object.getOwnPropertyDescriptors(value)
-  for (const key of Object.keys(descriptors)) {
+  for (const key of Object.getOwnPropertyNames(value)) {
     if (Guard.IsUnsafePropertyKey(key)) continue // (ignore: prototype-pollution)
-    const descriptor = descriptors[key]
-    if (Guard.HasPropertyKey(descriptor, 'value')) {
-      Object.defineProperty(result, key, { ...descriptor, value: FromValue(descriptor.value) })
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)! // safe-name!
+    descriptor.value = FromValue(descriptor.value)
+    if(Guard.IsEqual(descriptor.enumerable, true)) {
+      result[key] = descriptor.value
+    } else {
+      Object.defineProperty(result, key, descriptor)
     }
   }
   return result

--- a/src/system/memory/discard.ts
+++ b/src/system/memory/discard.ts
@@ -4,7 +4,7 @@ TypeBox
 
 The MIT License (MIT)
 
-Copyright (c) 2017-2026 Haydn Paterson 
+Copyright (c) 2017-2026 Haydn Paterson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -38,8 +38,8 @@ type ObjectLike = Record<PropertyKey, any>
 export function Discard(value: ObjectLike, propertyKeys: PropertyKey[]): ObjectLike {
   Metrics.discard += 1
   const result: ObjectLike = {}
-  for(const key of Object.getOwnPropertyNames(value)) {
-    if(propertyKeys.includes(key)) continue
+  for (const key of Object.getOwnPropertyNames(value)) {
+    if (propertyKeys.includes(key)) continue
     const descriptor = Object.getOwnPropertyDescriptor(value, key)! // safe-name!
     descriptor.value = Clone(descriptor.value)
     Object.defineProperty(result, key, descriptor)

--- a/src/system/memory/discard.ts
+++ b/src/system/memory/discard.ts
@@ -38,11 +38,11 @@ type ObjectLike = Record<PropertyKey, any>
 export function Discard(value: ObjectLike, propertyKeys: PropertyKey[]): ObjectLike {
   Metrics.discard += 1
   const result: ObjectLike = {}
-  const descriptors = Object.getOwnPropertyDescriptors(Clone(value))
-  const keysToDiscard = new Set(propertyKeys)
-  for (const key of Object.keys(descriptors)) {
-    if (keysToDiscard.has(key)) continue
-    Object.defineProperty(result, key, descriptors[key])
+  for(const key of Object.getOwnPropertyNames(value)) {
+    if(propertyKeys.includes(key)) continue
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)! // safe-name!
+    descriptor.value = Clone(descriptor.value)
+    Object.defineProperty(result, key, descriptor)
   }
   return result
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.3.10'
+const Version = '1.3.11'
 
 // ------------------------------------------------------------------
 // Build


### PR DESCRIPTION
This PR implements optimizations for System.Memory.Clone and System.Memory.Discard to improve type initialization. 

### Updates

The optimizations were as follows:

- Use Object.getOwnPropertyNames(...) to Enumerate Keys
- Call Object.getOwnPropertyDescriptor(...) on Per Enumerated Key
- Check IsEnumerable on Descriptor before assignment.
- Use Object.defineProperty(...) if NonEnumerable
- Use Record[Key] = X if Enumerable

The primary performance boost comes from `record[key] = value` assignment over `defineProperty`, and the per key `getOwnPropertyDescriptor(...)` call.

### Benchmarks

Updates were tested against the TB `turing` benchmark. Performance shows approx 3-4x throughput performance for the "time to complete" test.

```bash
turing: 14492ms  # before
turing: 3915ms   # after
```

#### Before

```typescript
Program {
  gc: {
    rss: "186.47 MB",
    heapTotal: "88.08 MB",
    heapUsed: "31.56 MB",
    external: "1.12 MB",
    arrayBuffers: "0.00 MB"
  },
  tb: {
    assign: 11624,
    create: 746063,
    clone: 96587,
    discard: 86376,
    update: 10211
  }
}
// turing: 14492ms 
```

#### After

```typescript
Program {
  gc: {
    rss: "185.29 MB",
    heapTotal: "86.08 MB",
    heapUsed: "49.36 MB",
    external: "1.12 MB",
    arrayBuffers: "0.00 MB"
  },
  tb: {
    assign: 11624,
    create: 746063,
    clone: 10211,
    discard: 86376,
    update: 10211
  },
}
// turing: 3915ms
```




