### PR TITLE
Version 1.3.15

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -4,6 +4,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.3.15](https://github.com/sinclairzx81/typebox/pull/1668)
+  - Support the PropertyNames Keyword in JSON Schema Inference
 - [Revision 1.3.14](https://github.com/sinclairzx81/typebox/pull/1667)
   - Refine Iri, Uri, UriReference, UrlTemplate for Specification Adherence
   - Add Format Submodule to Compression Metrics

--- a/src/schema/static/propertyNames.ts
+++ b/src/schema/static/propertyNames.ts
@@ -36,8 +36,8 @@ import type { XStaticSchema } from './schema.ts'
 // XStaticPropertyNames
 // ------------------------------------------------------------------
 export type XStaticPropertyNames<Stack extends string[], Root extends XSchema, Schema extends XSchema,
-  AllowedKey extends unknown = XStaticSchema<Stack, Root, Schema>,
-  Result extends Record<string, unknown> = [AllowedKey] extends [PropertyKey] 
-   ? { [Key in AllowedKey]?: unknown }
+  StaticKey extends unknown = XStaticSchema<Stack, Root, Schema>,
+  Result extends Record<string, unknown> = [StaticKey] extends [PropertyKey] 
+   ? { [Key in StaticKey]?: unknown }
    : {}
 > = Result

--- a/src/schema/static/propertyNames.ts
+++ b/src/schema/static/propertyNames.ts
@@ -1,0 +1,43 @@
+/*--------------------------------------------------------------------------
+
+TypeBox
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2026 Haydn Paterson 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------------------------------------------------*/
+
+// deno-lint-ignore-file ban-types
+// deno-fmt-ignore-file
+
+import type { XSchema } from '../types/schema.ts'
+import type { XStaticSchema } from './schema.ts'
+
+// ------------------------------------------------------------------
+// XStaticPropertyNames
+// ------------------------------------------------------------------
+export type XStaticPropertyNames<Stack extends string[], Root extends XSchema, Schema extends XSchema,
+  AllowedKey extends unknown = XStaticSchema<Stack, Root, Schema>,
+  Result extends Record<string, unknown> = [AllowedKey] extends [PropertyKey] 
+   ? { [Key in AllowedKey]?: unknown }
+   : {}
+> = Result

--- a/src/schema/static/schema.ts
+++ b/src/schema/static/schema.ts
@@ -39,11 +39,13 @@ import type { XOneOf } from '../types/oneOf.ts'
 import type { XPatternProperties } from '../types/patternProperties.ts'
 import type { XPrefixItems } from '../types/prefixItems.ts'
 import type { XProperties } from '../types/properties.ts'
+import type { XPropertyNames } from '../types/propertyNames.ts'
 import type { XRef } from '../types/ref.ts'
 import type { XRequired } from '../types/required.ts'
 import type { XSchema } from '../types/schema.ts'
 import type { XType } from '../types/type.ts'
 import type { XUnevaluatedProperties } from '../types/unevaluatedProperties.ts'
+
 import type { XStaticAdditionalProperties } from './additionalProperties.ts'
 import type { XStaticAllOf } from './allOf.ts'
 import type { XStaticAnyOf } from './anyOf.ts'
@@ -55,6 +57,7 @@ import type { XStaticOneOf } from './oneOf.ts'
 import type { XStaticPatternProperties } from './patternProperties.ts'
 import type { XStaticPrefixItems } from './prefixItems.ts'
 import type { XStaticProperties } from './properties.ts'
+import type { XStaticPropertyNames } from './propertyNames.ts'
 import type { XStaticRef } from './ref.ts'
 import type { XStaticRequired } from './required.ts'
 import type { XStaticType } from './type.ts'
@@ -75,6 +78,7 @@ type XFromKeywords<Stack extends string[], Root extends XSchema, Schema extends 
   Schema extends XPatternProperties<infer Properties extends Record<PropertyKey, XSchema>> ? XStaticPatternProperties<Stack, Root, Properties> : unknown,
   Schema extends XPrefixItems<infer Types extends XSchema[]> ? XStaticPrefixItems<Stack, Root, Schema, Types> : unknown,
   Schema extends XProperties<infer Properties extends Record<PropertyKey, XSchema>> ? XStaticProperties<Stack, Root, Schema, Properties> : unknown,
+  Schema extends XPropertyNames<infer Type extends XSchema> ? XStaticPropertyNames<Stack, Root, Type> : unknown,
   Schema extends XRef<infer Ref extends string> ? XStaticRef<Stack, Root, Ref> : unknown,
   Schema extends XRequired<infer Keys extends string[]> ? XStaticRequired<Stack, Root, Schema, Keys> : unknown,
   Schema extends XType<infer TypeName extends string[] | string> ? XStaticType<TypeName> : unknown,

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.3.14'
+const Version = '1.3.15'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/static/schema/propertyNames.ts
+++ b/test/typebox/static/schema/propertyNames.ts
@@ -1,0 +1,190 @@
+import { Assert } from 'test'
+import { type XStatic } from 'typebox/schema'
+
+// ------------------------------------------------------------------
+// Broad
+// ------------------------------------------------------------------
+Assert.IsExtendsMutual<
+  XStatic<{
+    propertyNames: { type: 'string' }
+  }>,
+  {
+    [x: string]: unknown
+  }
+>(true)
+Assert.IsExtendsMutual<
+  XStatic<{
+    propertyNames: { type: 'number' }
+  }>,
+  {
+    [x: number]: unknown
+  }
+>(true)
+// ------------------------------------------------------------------
+// Narrow
+// ------------------------------------------------------------------
+Assert.IsExtendsMutual<
+  XStatic<{
+    propertyNames: { const: 'A' }
+  }>,
+  {
+    A?: unknown
+  }
+>(true)
+// ------------------------------------------------------------------
+// Logical: And
+// ------------------------------------------------------------------
+Assert.IsExtendsMutual<
+  XStatic<{
+    propertyNames: { allOf: [{ const: 'A' }, { type: 'string' }] }
+  }>,
+  {
+    A?: unknown
+  }
+>(true)
+Assert.IsExtendsMutual<
+  XStatic<{
+    propertyNames: { allOf: [{ type: 'string' }, { const: 'A' }] }
+  }>,
+  {
+    A?: unknown
+  }
+>(true)
+// ------------------------------------------------------------------
+// Logical: Or
+// ------------------------------------------------------------------
+Assert.IsExtendsMutual<
+  XStatic<{
+    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
+  }>,
+  {
+    A?: unknown
+    B?: unknown
+  }
+>(true)
+Assert.IsExtendsMutual<
+  XStatic<{
+    propertyNames: { anyOf: [{ const: 'A' }, { anyOf: [{ const: 'B' }, { const: 'C' }] }] }
+  }>,
+  {
+    A?: unknown
+    B?: unknown
+    C?: unknown
+  }
+>(true)
+// ------------------------------------------------------------------
+// Logical: Or (Enum)
+// ------------------------------------------------------------------
+Assert.IsExtendsMutual<
+  XStatic<{
+    propertyNames: { enum: ['A', 'B'] }
+  }>,
+  {
+    A?: unknown
+    B?: unknown
+  }
+>(true)
+// ------------------------------------------------------------------
+// Logical: Xor
+// ------------------------------------------------------------------
+Assert.IsExtendsMutual<
+  XStatic<{
+    propertyNames: { oneOf: [{ const: 'A' }, { const: 'B' }] }
+  }>,
+  {
+    A?: unknown
+    B?: unknown
+  }
+>(true)
+Assert.IsExtendsMutual<
+  XStatic<{
+    propertyNames: { oneOf: [{ const: 'A' }, { oneOf: [{ const: 'B' }, { const: 'C' }] }] }
+  }>,
+  {
+    A?: unknown
+    B?: unknown
+    C?: unknown
+  }
+>(true)
+// --------------------------------------------------------
+// Required
+// --------------------------------------------------------
+Assert.IsExtendsMutual<
+  XStatic<{
+    required: ['A']
+    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
+  }>,
+  {
+    A: unknown
+    B?: unknown
+  }
+>(true)
+Assert.IsExtendsMutual<
+  XStatic<{
+    required: ['A', 'B']
+    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
+  }>,
+  {
+    A: unknown
+    B: unknown
+  }
+>(true)
+// --------------------------------------------------------
+// Properties
+// --------------------------------------------------------
+Assert.IsExtendsMutual<
+  XStatic<{
+    properties: {
+      A: { type: 'number' }
+    }
+    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
+  }>,
+  {
+    A?: number
+    B?: unknown
+  }
+>(true)
+Assert.IsExtendsMutual<
+  XStatic<{
+    properties: {
+      A: { type: 'number' }
+      B: { type: 'string' }
+    }
+    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
+  }>,
+  {
+    A?: number
+    B?: string
+  }
+>(true)
+// --------------------------------------------------------
+// Properties + Required
+// --------------------------------------------------------
+Assert.IsExtendsMutual<
+  XStatic<{
+    required: ['A']
+    properties: {
+      A: { type: 'number' }
+      B: { type: 'string' }
+    }
+    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
+  }>,
+  {
+    A: number
+    B?: string
+  }
+>(true)
+Assert.IsExtendsMutual<
+  XStatic<{
+    required: ['A', 'B']
+    properties: {
+      A: { type: 'number' }
+      B: { type: 'string' }
+    }
+    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
+  }>,
+  {
+    A: number
+    B: string
+  }
+>(true)


### PR DESCRIPTION
This PR adds an inference path for the JSON Schema `propertyNames` keyword. Updates are inference only.

Inference test cases as follows:

```typescript

// ------------------------------------------------------------------
// Broad
// ------------------------------------------------------------------
Assert.IsExtendsMutual<
  XStatic<{
    propertyNames: { type: 'string' }
  }>,
  {
    [x: string]: unknown
  }
>(true)
Assert.IsExtendsMutual<
  XStatic<{
    propertyNames: { type: 'number' }
  }>,
  {
    [x: number]: unknown
  }
>(true)
// ------------------------------------------------------------------
// Narrow
// ------------------------------------------------------------------
Assert.IsExtendsMutual<
  XStatic<{
    propertyNames: { const: 'A' }
  }>,
  {
    A?: unknown
  }
>(true)
// ------------------------------------------------------------------
// Logical: And
// ------------------------------------------------------------------
Assert.IsExtendsMutual<
  XStatic<{
    propertyNames: { allOf: [{ const: 'A' }, { type: 'string' }] }
  }>,
  {
    A?: unknown
  }
>(true)
Assert.IsExtendsMutual<
  XStatic<{
    propertyNames: { allOf: [{ type: 'string' }, { const: 'A' }] }
  }>,
  {
    A?: unknown
  }
>(true)
// ------------------------------------------------------------------
// Logical: Or
// ------------------------------------------------------------------
Assert.IsExtendsMutual<
  XStatic<{
    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
  }>,
  {
    A?: unknown
    B?: unknown
  }
>(true)
Assert.IsExtendsMutual<
  XStatic<{
    propertyNames: { anyOf: [{ const: 'A' }, { anyOf: [{ const: 'B' }, { const: 'C' }] }] }
  }>,
  {
    A?: unknown
    B?: unknown
    C?: unknown
  }
>(true)
// ------------------------------------------------------------------
// Logical: Or (Enum)
// ------------------------------------------------------------------
Assert.IsExtendsMutual<
  XStatic<{
    propertyNames: { enum: ['A', 'B'] }
  }>,
  {
    A?: unknown
    B?: unknown
  }
>(true)
// ------------------------------------------------------------------
// Logical: Xor
// ------------------------------------------------------------------
Assert.IsExtendsMutual<
  XStatic<{
    propertyNames: { oneOf: [{ const: 'A' }, { const: 'B' }] }
  }>,
  {
    A?: unknown
    B?: unknown
  }
>(true)
Assert.IsExtendsMutual<
  XStatic<{
    propertyNames: { oneOf: [{ const: 'A' }, { oneOf: [{ const: 'B' }, { const: 'C' }] }] }
  }>,
  {
    A?: unknown
    B?: unknown
    C?: unknown
  }
>(true)
// --------------------------------------------------------
// Required
// --------------------------------------------------------
Assert.IsExtendsMutual<
  XStatic<{
    required: ['A']
    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
  }>,
  {
    A: unknown
    B?: unknown
  }
>(true)
Assert.IsExtendsMutual<
  XStatic<{
    required: ['A', 'B']
    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
  }>,
  {
    A: unknown
    B: unknown
  }
>(true)
// --------------------------------------------------------
// Properties
// --------------------------------------------------------
Assert.IsExtendsMutual<
  XStatic<{
    properties: {
      A: { type: 'number' }
    }
    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
  }>,
  {
    A?: number
    B?: unknown
  }
>(true)
Assert.IsExtendsMutual<
  XStatic<{
    properties: {
      A: { type: 'number' }
      B: { type: 'string' }
    }
    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
  }>,
  {
    A?: number
    B?: string
  }
>(true)
// --------------------------------------------------------
// Properties + Required
// --------------------------------------------------------
Assert.IsExtendsMutual<
  XStatic<{
    required: ['A']
    properties: {
      A: { type: 'number' }
      B: { type: 'string' }
    }
    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
  }>,
  {
    A: number
    B?: string
  }
>(true)
Assert.IsExtendsMutual<
  XStatic<{
    required: ['A', 'B']
    properties: {
      A: { type: 'number' }
      B: { type: 'string' }
    }
    propertyNames: { anyOf: [{ const: 'A' }, { const: 'B' }] }
  }>,
  {
    A: number
    B: string
  }
>(true)
```