### PR TITLE
Fix (Memory): Ensure Immutability for Assign, Discard and Update

### DIFF
--- a/src/system/memory/assign.ts
+++ b/src/system/memory/assign.ts
@@ -30,10 +30,11 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import { Metrics } from './metrics.ts'
+import { Freeze } from './freeze.ts'
 
 type ObjectLike = Record<PropertyKey, any>
 
-/** 
+/**
  * Performs an Object assign using the Left and Right object types. We track this operation as it
  * creates a new GC handle per assignment.
  */
@@ -41,11 +42,11 @@ export type TAssign<Left extends ObjectLike, Right extends ObjectLike,
   Assigned extends ObjectLike = Omit<Left, keyof Right> & Right
 > = {[Key in keyof Assigned]: Assigned[Key] } & {}
 
-/** 
+/**
  * Performs an Object assign using the Left and Right object types. We track this operation as it
  * creates a new GC handle per assignment.
  */
 export function Assign<Left extends ObjectLike, Right extends ObjectLike>(left: Left, right: Right): TAssign<Left, Right> {
   Metrics.assign += 1
-  return  {...left, ...right } as never
+  return Freeze({...left, ...right }) as never
 }

--- a/src/system/memory/create.ts
+++ b/src/system/memory/create.ts
@@ -31,7 +31,7 @@ THE SOFTWARE.
 
 import { Settings } from '../settings/index.ts'
 import { Metrics } from './metrics.ts'
-
+import { Freeze } from './freeze.ts'
 
 type ObjectLike = Record<PropertyKey, any>
 
@@ -53,11 +53,10 @@ function Merge(left: ObjectLike, right: ObjectLike): ObjectLike {
  * Creates an object with hidden, enumerable, and optional property sets. This function 
  * ensures types are instantiated according to configuration rules for enumerable and 
  * non-enumerable properties.  
- */  
+ */
 export function Create(hidden: ObjectLike, enumerable: ObjectLike, options: ObjectLike = {}): ObjectLike {
   Metrics.create += 1
-  const settings = Settings.Get()
   const withOptions = Merge(enumerable, options)
-  const withHidden = settings.enumerableKind ? Merge(withOptions, hidden) : MergeHidden(withOptions, hidden) 
-  return settings.immutableTypes ? Object.freeze(withHidden) : withHidden
+  const withHidden = Settings.Get().enumerableKind ? Merge(withOptions, hidden) : MergeHidden(withOptions, hidden) 
+  return Freeze(withHidden)
 }

--- a/src/system/memory/discard.ts
+++ b/src/system/memory/discard.ts
@@ -31,6 +31,7 @@ THE SOFTWARE.
 
 import { Guard } from '../../guard/index.ts'
 import { Metrics } from './metrics.ts'
+import { Freeze } from './freeze.ts'
 import { Clone } from './clone.ts'
 
 type ObjectLike = Record<PropertyKey, any>
@@ -45,5 +46,5 @@ export function Discard(value: ObjectLike, propertyKeys: PropertyKey[]): ObjectL
     descriptor.value = Clone(descriptor.value)
     Object.defineProperty(result, key, descriptor)
   }
-  return result
+  return Freeze(result)
 }

--- a/src/system/memory/freeze.ts
+++ b/src/system/memory/freeze.ts
@@ -4,7 +4,7 @@ TypeBox
 
 The MIT License (MIT)
 
-Copyright (c) 2017-2026 Haydn Paterson 
+Copyright (c) 2017-2026 Haydn Paterson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -26,41 +26,12 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-// deno-fmt-ignore-file
-
 import { Settings } from '../settings/index.ts'
-import { Metrics } from './metrics.ts'
-import { Freeze } from './freeze.ts'
-import { Clone } from './clone.ts'
 
 // deno-lint-ignore no-explicit-any
 type ObjectLike = Record<PropertyKey, any>
 
-/**  
- * Updates a value with new properties while preserving property enumerability. Use this function to modify 
- * existing types without altering their configuration.  
- */  
-export function Update(current: ObjectLike, hidden: ObjectLike, enumerable: ObjectLike): ObjectLike {
-  Metrics.update += 1
-  const settings = Settings.Get()
-  const result = Clone(current)
-  // hidden
-  for(const key of Object.keys(hidden)) {
-    Object.defineProperty(result, key, {
-      configurable: true,
-      writable: true,
-      enumerable: settings.enumerableKind,
-      value: hidden[key]
-    })
-  }
-  // enumerable
-  for(const key of Object.keys(enumerable)) {
-    Object.defineProperty(result, key, {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: enumerable[key]
-    })
-  }
-  return Freeze(result)
+/** Conditionally freezes the value if `immutableTypes` is true, otherwise no action. */
+export function Freeze(value: ObjectLike): ObjectLike {
+  return Settings.Get().immutableTypes ? Object.freeze(value) : value
 }

--- a/src/system/memory/update.ts
+++ b/src/system/memory/update.ts
@@ -61,5 +61,5 @@ export function Update(current: ObjectLike, hidden: ObjectLike, enumerable: Obje
       value: enumerable[key]
     })
   }
-  return result
+  return settings.immutableTypes ? Object.freeze(result) : result
 }

--- a/test/typebox/runtime/system/memory.ts
+++ b/test/typebox/runtime/system/memory.ts
@@ -34,7 +34,7 @@ Test('Should Clone 4', () => {
 // ------------------------------------------------------------------
 // Create
 // ------------------------------------------------------------------
-Test('Should Create 1', () => {
+Test('Should Create 5', () => {
   const A: any = Memory.Create({ x: 1 }, { y: 2 }, { z: 3 })
   Assert.IsEqual(A.x, 1)
   Assert.IsEqual(A.y, 2)
@@ -43,7 +43,7 @@ Test('Should Create 1', () => {
 // ------------------------------------------------------------------
 // EnumerableKind
 // ------------------------------------------------------------------
-Test('Should Create 3', () => {
+Test('Should Create 6', () => {
   Settings.Set({ enumerableKind: true })
   const A: any = Memory.Create({ x: 1 }, { y: 2 }, { z: 3 })
   Assert.IsEqual(A.x, 1)
@@ -54,41 +54,27 @@ Test('Should Create 3', () => {
   Settings.Reset()
 })
 // ------------------------------------------------------------------
-// ImmutableTypes
-// ------------------------------------------------------------------
-Test('Should Create 4', () => {
-  Settings.Set({ immutableTypes: true })
-  const A: any = Memory.Create({ x: 1 }, { y: 2 }, { z: 3 })
-  Assert.IsEqual(A.x, 1)
-  Assert.IsEqual(A.y, 2)
-  Assert.IsEqual(A.z, 3)
-  Assert.Throws(() => {
-    A.x = 123
-  })
-  Settings.Reset()
-})
-// ------------------------------------------------------------------
 // UnsafePropertyKey
 //
 // Note: If these tests fail, ensure you update to Deno to 2.9.0. The
 // Deno team has made changes to __proto__ handling that differs to
 // earlier versions. The following tests are written for 2.9.0.
 // ------------------------------------------------------------------
-Test('Should Create 5', () => {
+Test('Should Create 7', () => {
   const A = { '~kind': 'test', '__proto__': 1 }
   const B = Memory.Clone(A)
   Assert.HasPropertyKey(B, '~kind')
   Assert.HasPropertyKey(B, '__proto__')
   Assert.NotEqual(B['__proto__'], 1)
 })
-Test('Should Create 6', () => {
+Test('Should Create 8', () => {
   const A = { '~kind': 'test', 'constructor': 1 }
   const B = Memory.Clone(A)
   Assert.HasPropertyKey(B, '~kind')
   Assert.HasPropertyKey(B, 'constructor')
   Assert.NotEqual(B['constructor'], 1)
 })
-Test('Should Create 7', () => {
+Test('Should Create 9', () => {
   const A = { '~kind': 'test', 'prototype': 1 }
   const B = Memory.Clone(A)
   Assert.HasPropertyKey(B, '~kind')
@@ -97,24 +83,24 @@ Test('Should Create 7', () => {
 // ------------------------------------------------------------------
 // TypedObject (Kind + Unsafe)
 // ------------------------------------------------------------------
-Test('Should Create 8', () => {
+Test('Should Create 10', () => {
   const A = Type.String()
   const B = Memory.Clone(A)
   Assert.NotPropertyIsEnumerable(B, '~kind')
 })
-Test('Should Create 9', () => {
+Test('Should Create 11', () => {
   const A = Type.Unsafe({ type: 'Date' })
   const B = Memory.Clone(A)
   Assert.NotPropertyIsEnumerable(B, '~unsafe')
 })
-Test('Should Create 10', () => {
+Test('Should Create 12', () => {
   Settings.Set({ enumerableKind: true })
   const A = Type.String()
   const B = Memory.Clone(A)
   Assert.PropertyIsEnumerable(B, '~kind')
   Settings.Reset()
 })
-Test('Should Create 11', () => {
+Test('Should Create 13', () => {
   Settings.Set({ enumerableKind: true })
   const A = Type.Unsafe({ type: 'Date' })
   const B = Memory.Clone(A)
@@ -122,22 +108,63 @@ Test('Should Create 11', () => {
   Settings.Reset()
 })
 // ------------------------------------------------------------------
-// Update: ImmutableTypes
+// ImmutableTypes: Create
 // ------------------------------------------------------------------
-Test('Should Update 1', () => {
+Test('Should Create 14', () => {
   Settings.Set({ immutableTypes: true })
-  const A = Type.Object({ x: Type.Number() })
-  const B: any = Memory.Update(A, {}, { $id: 'A' })
-  Assert.IsEqual(B.$id, 'A')
-  Assert.IsTrue(Object.isFrozen(B))
+  const A: any = Memory.Create({ x: 1 }, { y: 2 }, { z: 3 })
+  Assert.IsEqual(A.x, 1)
+  Assert.IsEqual(A.y, 2)
+  Assert.IsEqual(A.z, 3)
   Assert.Throws(() => {
-    B.sneaky = 1
+    A.x = 2
   })
   Settings.Reset()
 })
-Test('Should Update 2', () => {
-  const A = Type.Object({ x: Type.Number() })
-  const B: any = Memory.Update(A, {}, { $id: 'A' })
-  Assert.IsEqual(B.$id, 'A')
-  Assert.IsFalse(Object.isFrozen(B))
+// ------------------------------------------------------------------
+// ImmutableTypes: Update
+// ------------------------------------------------------------------
+Test('Should Update 15', () => {
+  Settings.Set({ immutableTypes: true })
+  const A: any = Memory.Update({ x: 1 }, { y: 2 }, { z: 3 })
+  Assert.IsEqual(A.x, 1)
+  Assert.IsEqual(A.y, 2)
+  Assert.IsEqual(A.z, 3)
+  Assert.IsTrue(Object.isFrozen(A))
+  Assert.Throws(() => {
+    A.x = 2
+  })
+  Settings.Reset()
+})
+Test('Should Update 16', () => {
+  Settings.Set({ immutableTypes: true })
+  const A: any = Memory.Update({ x: 1 }, { x: 2 }, { y: 2 })
+  Assert.IsEqual(A.x, 2)
+  Assert.IsEqual(A.y, 2)
+  Assert.IsTrue(Object.isFrozen(A))
+  Assert.Throws(() => {
+    A.x = 3
+  })
+  Settings.Reset()
+})
+// ------------------------------------------------------------------
+// ImmutableTypes: Discard
+// ------------------------------------------------------------------
+Test('Should Update 17', () => {
+  Settings.Set({ immutableTypes: true })
+  const A: any = Memory.Create({ x: 1 }, { y: 2 }, { z: 3 })
+  Assert.IsEqual(A.x, 1)
+  Assert.IsEqual(A.y, 2)
+  Assert.IsEqual(A.z, 3)
+  Assert.IsTrue(Object.isFrozen(A))
+  // Discard
+  const B: any = Memory.Discard(A, ['x', 'y'])
+  Assert.NotHasPropertyKey(B, 'x')
+  Assert.NotHasPropertyKey(B, 'y')
+  Assert.IsEqual(A.z, 3)
+  Assert.IsTrue(Object.isFrozen(B))
+  Assert.Throws(() => {
+    B.x = 1
+  })
+  Settings.Reset()
 })

--- a/test/typebox/runtime/system/memory.ts
+++ b/test/typebox/runtime/system/memory.ts
@@ -168,3 +168,17 @@ Test('Should Update 17', () => {
   })
   Settings.Reset()
 })
+// ------------------------------------------------------------------
+// ImmutableTypes: Assign
+// ------------------------------------------------------------------
+Test('Should Update 18', () => {
+  Settings.Set({ immutableTypes: true })
+  const A: any = Memory.Assign({ x: 1 }, { y: 2 })
+  Assert.IsEqual(A.x, 1)
+  Assert.IsEqual(A.y, 2)
+  Assert.IsTrue(Object.isFrozen(A))
+  Assert.Throws(() => {
+    A.z = 3
+  })
+  Settings.Reset()
+})

--- a/test/typebox/runtime/system/memory.ts
+++ b/test/typebox/runtime/system/memory.ts
@@ -121,3 +121,23 @@ Test('Should Create 11', () => {
   Assert.PropertyIsEnumerable(B, '~unsafe')
   Settings.Reset()
 })
+// ------------------------------------------------------------------
+// Update: ImmutableTypes
+// ------------------------------------------------------------------
+Test('Should Update 1', () => {
+  Settings.Set({ immutableTypes: true })
+  const A = Type.Object({ x: Type.Number() })
+  const B: any = Memory.Update(A, {}, { $id: 'A' })
+  Assert.IsEqual(B.$id, 'A')
+  Assert.IsTrue(Object.isFrozen(B))
+  Assert.Throws(() => {
+    B.sneaky = 1
+  })
+  Settings.Reset()
+})
+Test('Should Update 2', () => {
+  const A = Type.Object({ x: Type.Number() })
+  const B: any = Memory.Update(A, {}, { $id: 'A' })
+  Assert.IsEqual(B.$id, 'A')
+  Assert.IsFalse(Object.isFrozen(B))
+})


### PR DESCRIPTION
When `immutableTypes` is true, `Memory.Create` freezes every schema it produces, but schema produced by `Memory.Update` are not frozen.

```ts
import Type from 'typebox'
import { Settings } from 'typebox/system'

Settings.Set({ immutableTypes: true })

const N = Type.Number()
const O = Type.Optional(Type.Number())

Object.isFrozen(N)  // true
Object.isFrozen(O)  // false
```