### PR TITLE
Version 1.3.19

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -4,6 +4,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.3.19](https://github.com/sinclairzx81/typebox/pull/1674)
+  - Refine IdnHostname for Specification Adherence
 - [Revision 1.3.18](https://github.com/sinclairzx81/typebox/pull/1673)
   - [1672](https://github.com/sinclairzx81/typebox/pull/1672) Ensure Immutable Types Enforced for Assign, Update and Discard
 - [Revision 1.3.17](https://github.com/sinclairzx81/typebox/pull/1671)

--- a/src/format/idna/idn-hostname.ts
+++ b/src/format/idna/idn-hostname.ts
@@ -45,14 +45,16 @@ function IsLabel(value: string): boolean {
 // ------------------------------------------------------------------
 // NormalizeHostname
 //
-// Normalizes a hostname for label validation. Normalizes for NFC
-// such that equivalent codepoint sequences can be uniformly
-// compared. It also removes codepoints that IDNA mapping ignores,
-// and converts full stop variants to ASCII '.' so the hostname can
-// be split into labels.
+// Normalizes a hostname for label validation. Maps fullwidth
+// codepoints to their ASCII equivalent (e.g. 'ａ' U+FF41 maps to
+// 'a'), then normalizes for NFC such that equivalent codepoint
+// sequences can be uniformly compared. It also removes codepoints
+// that IDNA mapping ignores, and converts full stop variants to
+// ASCII '.' so the hostname can be split into labels.
 // ------------------------------------------------------------------
 function NormalizeHostname(value: string): string {
   return value
+    .replace(/[\uff01-\uff5e]/g, (char) => String.fromCharCode(char.charCodeAt(0) - 0xfee0)) // RE_FULLWIDTH_MAPPING
     .normalize('NFC')
     .replace(/[\u00ad\u034f\u180b-\u180d\u200b\ufe00-\ufe0f\u{e0100}-\u{e01ef}]/gu, '') // RE_IGNORED_MAPPING
     .replace(/[\u002E\u3002\uFF0E\uFF61]/g, '.') // RE_FULL_STOP_MAPPING

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.3.18'
+const Version = '1.3.19'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/jsonschema/cases/draft2019-09/optional/format/idn-hostname.json
+++ b/test/jsonschema/cases/draft2019-09/optional/format/idn-hostname.json
@@ -368,6 +368,24 @@
         "valid": false
       },
       {
+        "description": "a non-NFC U-label is valid after UTS 46 normalisation",
+        "comment": "UTS 46 section 4 normalises to NFC before validating, so the decomposed form is accepted",
+        "data": "café.com",
+        "valid": true
+      },
+      {
+        "description": "a label of 63 fullwidth characters is valid after mapping",
+        "comment": "UTS 46 maps each U+FF41 to an ASCII letter, so this label is 63 octets in its mapped form",
+        "data": "ａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａ",
+        "valid": true
+      },
+      {
+        "description": "an ACE prefix produced by the mapping step is decoded as an A-label",
+        "comment": "UTS 46 maps U+FF58 U+FF4E to \"xn\", so the mapped label is the A-label xn--nxasmq6b",
+        "data": "ｘｎ--nxasmq6b",
+        "valid": true
+      },
+      {
         "description": "zero width non-joiner must pass at every occurrence",
         "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
         "data": "क्‌षx‌y",

--- a/test/jsonschema/cases/draft2019-09/optional/format/time.json
+++ b/test/jsonschema/cases/draft2019-09/optional/format/time.json
@@ -178,16 +178,6 @@
         "valid": false
       },
       {
-        "description": "an invalid time string with invalid leap second (wrong hour)",
-        "data": "22:59:60Z",
-        "valid": false
-      },
-      {
-        "description": "an invalid time string with invalid leap second (wrong minute)",
-        "data": "23:58:60Z",
-        "valid": false
-      },
-      {
         "description": "an invalid time string with invalid time numoffset hour",
         "data": "01:02:03+24:00",
         "valid": false
@@ -240,6 +230,66 @@
       {
         "description": "an invalid time string in date-time format",
         "data": "2020-11-28T23:55:45Z",
+        "valid": false
+      },
+      {
+        "description": "a numeric time-offset requires the colon separator",
+        "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+        "data": "08:30:06+0130",
+        "valid": false
+      },
+      {
+        "description": "a numeric time-offset requires the minutes component",
+        "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+        "data": "08:30:06+01",
+        "valid": false
+      },
+      {
+        "description": "a trailing newline after a valid time",
+        "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
+        "data": "08:30:06Z\n",
+        "valid": false
+      },
+      {
+        "description": "hour 24 is invalid with a numeric time-offset",
+        "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
+        "data": "24:59:00+01:00",
+        "valid": false
+      },
+      {
+        "description": "minute 60 is invalid with a numeric time-offset",
+        "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
+        "data": "23:60:00+00:01",
+        "valid": false
+      },
+      {
+        "description": "a valid time string with a 15 digit second fraction",
+        "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
+        "data": "00:59:59.999999999999999Z",
+        "valid": true
+      },
+      {
+        "description": "a second fraction with no digits",
+        "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
+        "data": "08:30:06.Z",
+        "valid": false
+      },
+      {
+        "description": "partial-time requires the seconds component",
+        "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
+        "data": "12:00Z",
+        "valid": false
+      },
+      {
+        "description": "a comma decimal separator with a time-offset",
+        "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
+        "data": "08:30:06,5Z",
+        "valid": false
+      },
+      {
+        "description": "leading whitespace before a valid time",
+        "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
+        "data": " 08:30:06Z",
         "valid": false
       }
     ]

--- a/test/jsonschema/cases/draft2020-12/optional/format/idn-hostname.json
+++ b/test/jsonschema/cases/draft2020-12/optional/format/idn-hostname.json
@@ -368,6 +368,24 @@
         "valid": false
       },
       {
+        "description": "a non-NFC U-label is valid after UTS 46 normalisation",
+        "comment": "UTS 46 section 4 normalises to NFC before validating, so the decomposed form is accepted",
+        "data": "café.com",
+        "valid": true
+      },
+      {
+        "description": "a label of 63 fullwidth characters is valid after mapping",
+        "comment": "UTS 46 maps each U+FF41 to an ASCII letter, so this label is 63 octets in its mapped form",
+        "data": "ａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａ",
+        "valid": true
+      },
+      {
+        "description": "an ACE prefix produced by the mapping step is decoded as an A-label",
+        "comment": "UTS 46 maps U+FF58 U+FF4E to \"xn\", so the mapped label is the A-label xn--nxasmq6b",
+        "data": "ｘｎ--nxasmq6b",
+        "valid": true
+      },
+      {
         "description": "zero width non-joiner must pass at every occurrence",
         "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
         "data": "क्‌षx‌y",

--- a/test/jsonschema/cases/draft2020-12/optional/format/time.json
+++ b/test/jsonschema/cases/draft2020-12/optional/format/time.json
@@ -178,16 +178,6 @@
         "valid": false
       },
       {
-        "description": "an invalid time string with invalid leap second (wrong hour)",
-        "data": "22:59:60Z",
-        "valid": false
-      },
-      {
-        "description": "an invalid time string with invalid leap second (wrong minute)",
-        "data": "23:58:60Z",
-        "valid": false
-      },
-      {
         "description": "an invalid time string with invalid time numoffset hour",
         "data": "01:02:03+24:00",
         "valid": false
@@ -240,6 +230,66 @@
       {
         "description": "an invalid time string in date-time format",
         "data": "2020-11-28T23:55:45Z",
+        "valid": false
+      },
+      {
+        "description": "a numeric time-offset requires the colon separator",
+        "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+        "data": "08:30:06+0130",
+        "valid": false
+      },
+      {
+        "description": "a numeric time-offset requires the minutes component",
+        "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+        "data": "08:30:06+01",
+        "valid": false
+      },
+      {
+        "description": "a trailing newline after a valid time",
+        "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
+        "data": "08:30:06Z\n",
+        "valid": false
+      },
+      {
+        "description": "hour 24 is invalid with a numeric time-offset",
+        "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
+        "data": "24:59:00+01:00",
+        "valid": false
+      },
+      {
+        "description": "minute 60 is invalid with a numeric time-offset",
+        "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
+        "data": "23:60:00+00:01",
+        "valid": false
+      },
+      {
+        "description": "a valid time string with a 15 digit second fraction",
+        "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
+        "data": "00:59:59.999999999999999Z",
+        "valid": true
+      },
+      {
+        "description": "a second fraction with no digits",
+        "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
+        "data": "08:30:06.Z",
+        "valid": false
+      },
+      {
+        "description": "partial-time requires the seconds component",
+        "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
+        "data": "12:00Z",
+        "valid": false
+      },
+      {
+        "description": "a comma decimal separator with a time-offset",
+        "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
+        "data": "08:30:06,5Z",
+        "valid": false
+      },
+      {
+        "description": "leading whitespace before a valid time",
+        "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
+        "data": " 08:30:06Z",
         "valid": false
       }
     ]

--- a/test/jsonschema/cases/draft7/optional/format/idn-hostname.json
+++ b/test/jsonschema/cases/draft7/optional/format/idn-hostname.json
@@ -362,6 +362,24 @@
         "valid": false
       },
       {
+        "description": "a non-NFC U-label is valid after UTS 46 normalisation",
+        "comment": "UTS 46 section 4 normalises to NFC before validating, so the decomposed form is accepted",
+        "data": "café.com",
+        "valid": true
+      },
+      {
+        "description": "a label of 63 fullwidth characters is valid after mapping",
+        "comment": "UTS 46 maps each U+FF41 to an ASCII letter, so this label is 63 octets in its mapped form",
+        "data": "ａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａ",
+        "valid": true
+      },
+      {
+        "description": "an ACE prefix produced by the mapping step is decoded as an A-label",
+        "comment": "UTS 46 maps U+FF58 U+FF4E to \"xn\", so the mapped label is the A-label xn--nxasmq6b",
+        "data": "ｘｎ--nxasmq6b",
+        "valid": true
+      },
+      {
         "description": "zero width non-joiner must pass at every occurrence",
         "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
         "data": "क्‌षx‌y",

--- a/test/jsonschema/cases/draft7/optional/format/time.json
+++ b/test/jsonschema/cases/draft7/optional/format/time.json
@@ -177,16 +177,6 @@
         "valid": false
       },
       {
-        "description": "an invalid time string with invalid leap second (wrong hour)",
-        "data": "22:59:60Z",
-        "valid": false
-      },
-      {
-        "description": "an invalid time string with invalid leap second (wrong minute)",
-        "data": "23:58:60Z",
-        "valid": false
-      },
-      {
         "description": "an invalid time string with invalid time numoffset hour",
         "data": "01:02:03+24:00",
         "valid": false
@@ -239,6 +229,66 @@
       {
         "description": "an invalid time string in date-time format",
         "data": "2020-11-28T23:55:45Z",
+        "valid": false
+      },
+      {
+        "description": "a numeric time-offset requires the colon separator",
+        "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+        "data": "08:30:06+0130",
+        "valid": false
+      },
+      {
+        "description": "a numeric time-offset requires the minutes component",
+        "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+        "data": "08:30:06+01",
+        "valid": false
+      },
+      {
+        "description": "a trailing newline after a valid time",
+        "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
+        "data": "08:30:06Z\n",
+        "valid": false
+      },
+      {
+        "description": "hour 24 is invalid with a numeric time-offset",
+        "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
+        "data": "24:59:00+01:00",
+        "valid": false
+      },
+      {
+        "description": "minute 60 is invalid with a numeric time-offset",
+        "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
+        "data": "23:60:00+00:01",
+        "valid": false
+      },
+      {
+        "description": "a valid time string with a 15 digit second fraction",
+        "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
+        "data": "00:59:59.999999999999999Z",
+        "valid": true
+      },
+      {
+        "description": "a second fraction with no digits",
+        "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
+        "data": "08:30:06.Z",
+        "valid": false
+      },
+      {
+        "description": "partial-time requires the seconds component",
+        "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
+        "data": "12:00Z",
+        "valid": false
+      },
+      {
+        "description": "a comma decimal separator with a time-offset",
+        "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
+        "data": "08:30:06,5Z",
+        "valid": false
+      },
+      {
+        "description": "leading whitespace before a valid time",
+        "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
+        "data": " 08:30:06Z",
         "valid": false
       }
     ]

--- a/test/jsonschema/cases/v1/format/_time.json
+++ b/test/jsonschema/cases/v1/format/_time.json
@@ -1,0 +1,41 @@
+[
+  {
+    "description": "validation of time strings",
+    "schema": {
+      "$schema": "https://json-schema.org/v1",
+      "format": "time"
+    },
+    "tests": [
+      {
+        "description": "a leap second is not a valid time",
+        "data": "23:59:60Z",
+        "valid": false
+      },
+      {
+        "description": "a leap second with a zero time-offset is not a valid time",
+        "data": "23:59:60+00:00",
+        "valid": false
+      },
+      {
+        "description": "a leap second with a positive time-offset is not a valid time",
+        "data": "01:29:60+01:30",
+        "valid": false
+      },
+      {
+        "description": "a leap second with a large positive time-offset is not a valid time",
+        "data": "23:29:60+23:30",
+        "valid": false
+      },
+      {
+        "description": "a leap second with a negative time-offset is not a valid time",
+        "data": "15:59:60-08:00",
+        "valid": false
+      },
+      {
+        "description": "a leap second with a large negative time-offset is not a valid time",
+        "data": "00:29:60-23:30",
+        "valid": false
+      }
+    ]
+  }
+]

--- a/test/jsonschema/cases/v1/format/idn-hostname.json
+++ b/test/jsonschema/cases/v1/format/idn-hostname.json
@@ -368,6 +368,24 @@
         "valid": false
       },
       {
+        "description": "a non-NFC U-label is valid after UTS 46 normalisation",
+        "comment": "UTS 46 section 4 normalises to NFC before validating, so the decomposed form is accepted",
+        "data": "café.com",
+        "valid": true
+      },
+      {
+        "description": "a label of 63 fullwidth characters is valid after mapping",
+        "comment": "UTS 46 maps each U+FF41 to an ASCII letter, so this label is 63 octets in its mapped form",
+        "data": "ａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａａ",
+        "valid": true
+      },
+      {
+        "description": "an ACE prefix produced by the mapping step is decoded as an A-label",
+        "comment": "UTS 46 maps U+FF58 U+FF4E to \"xn\", so the mapped label is the A-label xn--nxasmq6b",
+        "data": "ｘｎ--nxasmq6b",
+        "valid": true
+      },
+      {
         "description": "zero width non-joiner must pass at every occurrence",
         "comment": "https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1",
         "data": "क्‌षx‌y",

--- a/test/jsonschema/cases/v1/format/time.json
+++ b/test/jsonschema/cases/v1/format/time.json
@@ -57,11 +57,6 @@
         "valid": false
       },
       {
-        "description": "a valid time string with leap second, Zulu",
-        "data": "23:59:60Z",
-        "valid": true
-      },
-      {
         "description": "invalid leap second, Zulu (wrong hour)",
         "data": "22:59:60Z",
         "valid": false
@@ -70,11 +65,6 @@
         "description": "invalid leap second, Zulu (wrong minute)",
         "data": "23:58:60Z",
         "valid": false
-      },
-      {
-        "description": "valid leap second, zero time-offset",
-        "data": "23:59:60+00:00",
-        "valid": true
       },
       {
         "description": "invalid leap second, zero time-offset (wrong hour)",
@@ -87,16 +77,6 @@
         "valid": false
       },
       {
-        "description": "valid leap second, positive time-offset",
-        "data": "01:29:60+01:30",
-        "valid": true
-      },
-      {
-        "description": "valid leap second, large positive time-offset",
-        "data": "23:29:60+23:30",
-        "valid": true
-      },
-      {
         "description": "invalid leap second, positive time-offset (wrong hour)",
         "data": "23:59:60+01:00",
         "valid": false
@@ -105,16 +85,6 @@
         "description": "invalid leap second, positive time-offset (wrong minute)",
         "data": "23:59:60+00:30",
         "valid": false
-      },
-      {
-        "description": "valid leap second, negative time-offset",
-        "data": "15:59:60-08:00",
-        "valid": true
-      },
-      {
-        "description": "valid leap second, large negative time-offset",
-        "data": "00:29:60-23:30",
-        "valid": true
       },
       {
         "description": "invalid leap second, negative time-offset (wrong hour)",
@@ -178,16 +148,6 @@
         "valid": false
       },
       {
-        "description": "an invalid time string with invalid leap second (wrong hour)",
-        "data": "22:59:60Z",
-        "valid": false
-      },
-      {
-        "description": "an invalid time string with invalid leap second (wrong minute)",
-        "data": "23:58:60Z",
-        "valid": false
-      },
-      {
         "description": "an invalid time string with invalid time numoffset hour",
         "data": "01:02:03+24:00",
         "valid": false
@@ -240,6 +200,66 @@
       {
         "description": "an invalid time string in date-time format",
         "data": "2020-11-28T23:55:45Z",
+        "valid": false
+      },
+      {
+        "description": "a numeric time-offset requires the colon separator",
+        "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+        "data": "08:30:06+0130",
+        "valid": false
+      },
+      {
+        "description": "a numeric time-offset requires the minutes component",
+        "comment": "RFC 3339 section 5.6: time-numoffset = (\"+\" / \"-\") time-hour \":\" time-minute",
+        "data": "08:30:06+01",
+        "valid": false
+      },
+      {
+        "description": "a trailing newline after a valid time",
+        "comment": "RFC 3339 section 5.6: no production of full-time emits a line feed",
+        "data": "08:30:06Z\n",
+        "valid": false
+      },
+      {
+        "description": "hour 24 is invalid with a numeric time-offset",
+        "comment": "RFC 3339 section 5.6: time-hour = 2DIGIT ; 00-23, and section 5.7 only allows 00 to 23",
+        "data": "24:59:00+01:00",
+        "valid": false
+      },
+      {
+        "description": "minute 60 is invalid with a numeric time-offset",
+        "comment": "RFC 3339 section 5.6: time-minute = 2DIGIT ; 00-59",
+        "data": "23:60:00+00:01",
+        "valid": false
+      },
+      {
+        "description": "a valid time string with a 15 digit second fraction",
+        "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT, with no upper bound on the number of digits",
+        "data": "00:59:59.999999999999999Z",
+        "valid": true
+      },
+      {
+        "description": "a second fraction with no digits",
+        "comment": "RFC 3339 section 5.6: time-secfrac = \".\" 1*DIGIT requires at least one digit",
+        "data": "08:30:06.Z",
+        "valid": false
+      },
+      {
+        "description": "partial-time requires the seconds component",
+        "comment": "RFC 3339 section 5.6: partial-time = time-hour \":\" time-minute \":\" time-second [time-secfrac]",
+        "data": "12:00Z",
+        "valid": false
+      },
+      {
+        "description": "a comma decimal separator with a time-offset",
+        "comment": "RFC 3339 section 5.6: the decimal separator in time-secfrac is \".\" - the ISO 8601 comma is not part of this profile",
+        "data": "08:30:06,5Z",
+        "valid": false
+      },
+      {
+        "description": "leading whitespace before a valid time",
+        "comment": "RFC 3339 section 5.6: no production of full-time emits whitespace",
+        "data": " 08:30:06Z",
         "valid": false
       }
     ]


### PR DESCRIPTION
This PR is additional specification adherence update for `idn-hostname`. 

---

### Note

Regarding failed v1 `time` assertions.

> Have noted a possible issue with the upstream test suite where the assertions of `time` disagree about leap seconds in v1. Have suggested that older draft assertions be updated inline with the v1 definition of `time` (which is assumed to be the correct assertion for RFC 3339). And will defer updates until feedback. 

---

Will keep to the 2020-12 draft definition for `time` as it passes the broader range of tests and because V1 is still a work in progress. Will make a decision on whether to adopt V1 definition based on feedback, but ideally hoping that the `time` assertions are back ported to older drafts.