### PR TITLE
Version 1.3.20

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -4,6 +4,9 @@
 ---
 
 ### Version Updates
+- [Revision 1.3.20](https://github.com/sinclairzx81/typebox/pull/1676)
+  - Ensure Sparse Arrays are handled uniformly in Compile and Check
+  - Provisional Specification for Sparse Array Handling
 - [Revision 1.3.19](https://github.com/sinclairzx81/typebox/pull/1674)
   - Refine IdnHostname for Specification Adherence
 - [Revision 1.3.18](https://github.com/sinclairzx81/typebox/pull/1673)

--- a/src/guard/emit.ts
+++ b/src/guard/emit.ts
@@ -142,7 +142,7 @@ export function Some(value: string, params: [value: string, index: string], expr
   return `${value}.some((${params[0]}, ${params[1]}) => ${expression})`
 }
 export function SomeAll(value: string, params: [value: string, index: string], expression: string): string {
-  return `((value) => { let result = false; ${value}.forEach((${params[0]}, ${params[1]}) => { if (${expression}) result = true }); return result })(${value})`
+  return `((value) => { let result = false; value.forEach((${params[0]}, ${params[1]}) => { if (${expression}) result = true }); return result })(${value})`
 }
 export function Counted(value: string, params: [value: string, index: string], expression: string): string {
   return `${value}.reduce((result, ${params[0]}, ${params[1]}) => (${expression}) ? ++result : result, 0)`

--- a/src/guard/emit.ts
+++ b/src/guard/emit.ts
@@ -136,15 +136,13 @@ export function IsMaxLength(value: string, length: string): string {
 // Array
 // --------------------------------------------------------------------------
 export function Every(value: string, offset: string, params: [value: string, index: string], expression: string): string {
-  return G.IsEqual(offset, '0')
-    ? `${value}.every((${params[0]}, ${params[1]}) => ${expression})`
-    : `((value, callback) => { for(let index = ${offset}; index < value.length; index++) if (!callback(value[index], index)) return false; return true })(${value}, (${params[0]}, ${params[1]}) => ${expression})`
+  return G.IsEqual(offset, '0') ? `${value}.every((${params[0]}, ${params[1]}) => (${expression}))` : `${value}.every((${params[0]}, ${params[1]}) => (${params[1]} < ${offset}) || (${expression}))`
 }
 export function Some(value: string, params: [value: string, index: string], expression: string): string {
   return `${value}.some((${params[0]}, ${params[1]}) => ${expression})`
 }
 export function SomeAll(value: string, params: [value: string, index: string], expression: string): string {
-  return `((value, callback) => { let result = false; for(let index = 0; index < value.length; index++) if (callback(value[index], index)) result = true; return result })(${value}, (${params[0]}, ${params[1]}) => ${expression})`
+  return `((value) => { let result = false; ${value}.forEach((${params[0]}, ${params[1]}) => { if (${expression}) result = true }); return result })(${value})`
 }
 export function Counted(value: string, params: [value: string, index: string], expression: string): string {
   return `${value}.reduce((result, ${params[0]}, ${params[1]}) => (${expression}) ? ++result : result, 0)`

--- a/src/guard/guard.ts
+++ b/src/guard/guard.ts
@@ -163,32 +163,22 @@ export function IsMinLength(value: string, length: number): boolean {
 // --------------------------------------------------------------------------
 /** Returns true if every element from offset satisfies the callback, short-circuiting on the first failure */
 export function Every<T>(value: T[], offset: number, callback: (value: T, index: number) => boolean): boolean {
-  for (let index = offset; index < value.length; index++) {
-    if (!callback(value[index], index)) return false
-  }
-  return true
+  return value.every((item, index) => (index < offset) || callback(item, index))
 }
 /** Returns true if every element from offset satisfies the callback, using exhaustive enumeration */
 export function EveryAll<T>(value: T[], offset: number, callback: (value: T, index: number) => boolean): boolean {
   let result = true
-  for (let index = offset; index < value.length; index++) {
-    if (!callback(value[index], index)) result = false
-  }
+  value.forEach((item, index) => { if ((index >= offset) && !callback(item, index)) result = false })
   return result
 }
 /** Returns true if some element satisfies the callback, short-circuiting on the first success */
 export function Some<T>(value: T[], callback: (value: T, index: number) => boolean): boolean {
-  for (let index = 0; index < value.length; index++) {
-    if (callback(value[index], index)) return true
-  }
-  return false
+  return value.some((value, index) => callback(value, index))
 }
 /** Returns true if some element satisfies the callback, using exhaustive enumeration */
 export function SomeAll<T>(value: T[], callback: (value: T, index: number) => boolean): boolean {
   let result = false
-  for (let index = 0; index < value.length; index++) {
-    if (callback(value[index], index)) result = true
-  }
+  value.forEach((item, index) => { if (callback(item, index)) result = true })
   return result
 }
 /** Returns the count of elements that satisfy the callback */

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.3.19'
+const Version = '1.3.20'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/value/check/array.ts
+++ b/test/typebox/runtime/value/check/array.ts
@@ -184,3 +184,212 @@ Test('Should correctly handle undefined array properties', () => {
     ]
   })
 })
+// ----------------------------------------------------------------
+// SparseArray
+//
+// TypeBox validates arrays using .every() and .some(). Per
+// ECMA262, these methods skip <empty> elements when enumerating
+// a sparse array. As a result, TypeBox never visits empty
+// elements, and cannot validate values it never visits. These
+// tests assert array validation behavior for sparse arrays.
+//
+// ----------------------------------------------------------------
+Test('Should handle sparse array 1', () => {
+  const T = Type.Array(Type.Number())
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  Ok(T, A) //                 ok: is array, but no elements were visited
+})
+Test('Should handle sparse array 2', () => {
+  const T = Type.Array(Type.Number())
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  A[1] = 1 //                 [<empty>, 1, <empty>]
+  Ok(T, A) //                 ok: is array, one element is number
+})
+Test('Should handle sparse array 3', () => {
+  const T = Type.Array(Type.Number())
+  const A = new Array(3) // [<empty>, <empty>, <empty>]
+  A[1] = 'x' //             [<empty>, 'x', <empty>]
+  Fail(T, A) //             fail: is array, no number elements
+})
+Test('Should handle sparse array 4', () => {
+  const T = Type.Array(Type.Number())
+  const A = new Array(3) // [<empty>, <empty>, <empty>]
+  A[1] = 'x' //             [<empty>, 'x', <empty>]
+  A[2] = 1 //               [<empty>, 'x', 1]
+  Fail(T, A) //             fail: is array, one number element, failed due to string
+})
+Test('Should handle sparse array 5', () => {
+  const T = Type.Array(Type.Number())
+  const A = new Array(3) // [<empty>, <empty>, <empty>]
+  A[1] = 1 //               [<empty>, 1, <empty>]
+  A[2] = 'x' //             [<empty>, 1, 'x']
+  Fail(T, A) //             fail: is array, one number element, failed due to string
+})
+// ----------------------------------------------------------------
+// SparseArray: MinItems
+//
+// TypeBox checks array size using the array's `.length`
+// property. This check is unaffected by sparseness, since
+// `.length` includes empty elements. A sparse array can
+// therefore satisfy minItems even though enumeration only
+// visits its non-empty elements.
+//
+// ----------------------------------------------------------------
+Test('Should handle sparse array minItems 1', () => {
+  const T = Type.Array(Type.Number(), { minItems: 1 })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  Ok(T, A) //                 ok: is array, array.length === 3
+})
+Test('Should handle sparse array minItems 2', () => {
+  const T = Type.Array(Type.Number(), { minItems: 1 })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  A[1] = 1 //                 [<empty>, 1, <empty>]
+  Ok(T, A) //                 ok: is array, array.length === 3
+})
+// ----------------------------------------------------------------
+// SparseArray: MaxItems
+//
+// TypeBox checks array size using the array's `.length`
+// property. This check is unaffected by sparseness, since
+// `.length` includes empty elements. A sparse array can
+// therefore fail maxItems even though enumeration only
+// visits its non-empty elements.
+//
+// ----------------------------------------------------------------
+Test('Should handle sparse array maxItems 1', () => {
+  const T = Type.Array(Type.Number(), { maxItems: 2 })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  Fail(T, A) //                fail: is array, array.length === 3
+})
+Test('Should handle sparse array maxItems 2', () => {
+  const T = Type.Array(Type.Number(), { maxItems: 2 })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  A[1] = 1 //                 [<empty>, 1, <empty>]
+  Fail(T, A) //                fail: is array, array.length === 3
+})
+Test('Should handle sparse array maxItems 3', () => {
+  const T = Type.Array(Type.Number(), { maxItems: 3 })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  Ok(T, A) //                  ok: is array, array.length === 3
+})
+Test('Should handle sparse array maxItems 4', () => {
+  const T = Type.Array(Type.Number(), { maxItems: 3 })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  A[1] = 1 //                 [<empty>, 1, <empty>]
+  Ok(T, A) //                  ok: is array, array.length === 3
+})
+// ----------------------------------------------------------------
+// SparseArray: Undefined is Not Empty
+//
+// A sparse array hole (<empty>) is not the same as an element
+// explicitly set to undefined. An <empty> element has no key on
+// the array and is skipped during enumeration. An element set to
+// undefined does have a key, so it is visited during enumeration
+// and is validated like any other element.
+//
+// ----------------------------------------------------------------
+Test('Should handle undefined is not empty 1', () => {
+  const T = Type.Array(Type.Undefined())
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  Ok(T, A) //                 ok: all elements are <empty>, none are visited
+})
+Test('Should handle undefined is not empty 2', () => {
+  const T = Type.Array(Type.Undefined())
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  A[1] = undefined //         [<empty>, undefined, <empty>]
+  Ok(T, A) //                 ok: element at index 1 is visited, undefined matches Type.Undefined()
+})
+Test('Should handle undefined is not empty 3', () => {
+  const T = Type.Array(Type.Undefined())
+  const A = [undefined, undefined, undefined] // not sparse, all keys exist
+  Ok(T, A) //                 ok: all elements are visited, all match Type.Undefined()
+})
+Test('Should handle undefined is not empty 4', () => {
+  const T = Type.Array(Type.Number())
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  Ok(T, A) //                 ok: all elements are <empty>, none are visited
+})
+Test('Should handle undefined is not empty 5', () => {
+  const T = Type.Array(Type.Number())
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  A[1] = undefined //         [<empty>, undefined, <empty>]
+  Fail(T, A) //               fail: element at index 1 is visited, undefined is not a number
+})
+Test('Should handle undefined is not empty 6', () => {
+  const T = Type.Array(Type.Number())
+  const A = [undefined, undefined, undefined] // not sparse, all keys exist
+  Fail(T, A) //               fail: all elements are visited, none are numbers
+})
+// ----------------------------------------------------------------
+// SparseArray: Contains
+//
+// TypeBox checks contains by testing whether at least one
+// enumerated element matches the contains schema. Since
+// enumeration skips <empty> elements, a hole can never satisfy
+// contains. A sparse array only satisfies contains if one of its
+// non-empty elements matches the schema.
+//
+// ----------------------------------------------------------------
+Test('Should handle sparse array contains 1', () => {
+  const T = Type.Array(Type.Unknown(), { contains: Type.Number() })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  Fail(T, A) //               fail: no elements are visited, contains is never matched
+})
+Test('Should handle sparse array contains 2', () => {
+  const T = Type.Array(Type.Unknown(), { contains: Type.Number() })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  A[1] = 1 //                 [<empty>, 1, <empty>]
+  Ok(T, A) //                 ok: element at index 1 is visited and matches contains
+})
+Test('Should handle sparse array contains 3', () => {
+  const T = Type.Array(Type.Unknown(), { contains: Type.Number() })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  A[1] = 'x' //               [<empty>, 'x', <empty>]
+  Fail(T, A) //               fail: element at index 1 is visited but does not match contains
+})
+// ----------------------------------------------------------------
+// SparseArray: MinContains
+//
+// TypeBox checks minContains by counting how many enumerated
+// elements match the contains schema. Since enumeration skips
+// <empty> elements, a hole can never count toward this total. A
+// sparse array only reaches minContains through its non-empty
+// elements.
+//
+// ----------------------------------------------------------------
+Test('Should handle sparse array minContains 1', () => {
+  const T = Type.Array(Type.Unknown(), { contains: Type.Number(), minContains: 2 })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  A[1] = 1 //                 [<empty>, 1, <empty>]
+  Fail(T, A) //               fail: only one visited element matches, minContains requires 2
+})
+Test('Should handle sparse array minContains 2', () => {
+  const T = Type.Array(Type.Unknown(), { contains: Type.Number(), minContains: 2 })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  A[1] = 1 //                 [<empty>, 1, <empty>]
+  A[2] = 2 //                 [<empty>, 1, 2]
+  Ok(T, A) //                 ok: two visited elements match, satisfies minContains
+})
+// ----------------------------------------------------------------
+// SparseArray: MaxContains
+//
+// TypeBox checks maxContains by counting how many enumerated
+// elements match the contains schema. Since enumeration skips
+// <empty> elements, a hole can never count toward this total. A
+// sparse array can only exceed maxContains through its non-empty
+// elements.
+//
+// ----------------------------------------------------------------
+Test('Should handle sparse array maxContains 1', () => {
+  const T = Type.Array(Type.Unknown(), { contains: Type.Number(), maxContains: 1 })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  A[1] = 1 //                 [<empty>, 1, <empty>]
+  Ok(T, A) //                 ok: one visited element matches, satisfies maxContains
+})
+Test('Should handle sparse array maxContains 2', () => {
+  const T = Type.Array(Type.Unknown(), { contains: Type.Number(), maxContains: 1 })
+  const A = new Array(3) //   [<empty>, <empty>, <empty>]
+  A[1] = 1 //                 [<empty>, 1, <empty>]
+  A[2] = 2 //                 [<empty>, 1, 2]
+  Fail(T, A) //               fail: two visited elements match, exceeds maxContains
+})


### PR DESCRIPTION
This PR is a follow-on from https://github.com/sinclairzx81/typebox/pull/1675, which fixes a Check / Compiler disparity for handling JavaScript sparse arrays. This PR fixes the same issue noted in the linked PR, but selects an inverse array enumeration strategy in line with ECMA262 enumeration rules for `.every(...)` and `.some(...)`.

---

### Array.prototype.every semantics
https://tc39.es/ecma262/#sec-array.prototype.every

This reported sparse array issue relates to `.every(...)` skipping `<empty>` elements in non-initialized arrays. This conflicted with the compiler's emit arm for `offset > 0`, which used a `for-loop` that visited `<empty>` elements and treated them as `undefined`. The fix updates the enumeration to use `.every()` for both arms, and uses a `(${params[1]} < ${offset})` guard rather than seeding the `for-loop` at the `offset`.

---

### Updates

The following shows the emit update for Every.

```typescript
// --------------------------------------------------------------------------
// Before
// --------------------------------------------------------------------------
export function Every(value: string, offset: string, params: [value: string, index: string], expression: string): string {
  return G.IsEqual(offset, '0')
    ? `${value}.every((${params[0]}, ${params[1]}) => ${expression})`
    : `((value, callback) => { for(let index = ${offset}; index < value.length; index++) if (!callback(value[index], index)) return false; return true })(${value}, (${params[0]}, ${params[1]}) => ${expression})`
}
// --------------------------------------------------------------------------
// After
// --------------------------------------------------------------------------
export function Every(value: string, offset: string, params: [value: string, index: string], expression: string): string {
  return G.IsEqual(offset, '0') 
    ? `${value}.every((${params[0]}, ${params[1]}) => (${expression}))` 
    : `${value}.every((${params[0]}, ${params[1]}) => (${params[1]} < ${offset}) || (${expression}))`
}
```

---

### Performance

Benchmarks were run for both the `index in value` guard (for-loop) and the `(${params[1]} < ${offset})` guard (for `.every()`), and found that despite the extra enumeration before the offset, the index-guard expression benchmarked faster than the `index in value` check. The reduced code also assists with TypeBox's bundle size constraints.

---

### Specification

This PR also implements a provisional specification for handling JavaScript sparse arrays under a JSON Schema validation regime. The specification tests were implemented given the following considerations:

- JavaScript sparse arrays are essentially an unspecified data structure for JSON Schema, which has no concept of arrays with holes. Because of this, TypeBox needs to devise an implementation that doesn't implicate JSON Schema behaviors. A final specification is best deferred until the V1 JSON Schema specification is ready.
- This PR opts for the ECMA262 view, where empty array elements are skipped, which enables TypeBox to point to that specification in the interim. However, this does have some implication for `minItems` and `maxItems`, which currently check based on the `.length` property for performance.
- A future potential exists to implement a similar check to `MinLength` and `MaxLength` for string, where determining the true length involves enumerating via UTF-16 / Unicode grapheme clusters. A similar check would be possible for Array (counting each non-empty element), but has been deferred for this PR to get the Check and Compile logic in sync.

---

Further work reconciling sparse arrays under JSON Schema will be explored in future TB revisions.