### PR TITLE
Version 1.3.21

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -4,6 +4,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.3.21](https://github.com/sinclairzx81/typebox/pull/1677)
+  - Optimization for True or Empty AdditionalProperties 
 - [Revision 1.3.20](https://github.com/sinclairzx81/typebox/pull/1676)
   - Ensure Sparse Arrays are handled uniformly in Compile and Check
   - Provisional Specification for Sparse Array Handling

--- a/src/schema/engine/additionalProperties.ts
+++ b/src/schema/engine/additionalProperties.ts
@@ -37,9 +37,20 @@ import { UnicodeRegExp } from './_regexp.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 import { BuildSchemaPushStack, CheckSchemaPushStack, ErrorSchemaPushStack } from './schema.ts'
 
-
 // ------------------------------------------------------------------
-// Common: GetPropertiesPattern
+// Optimization: IsAdditionalPropertiesIgnored
+//
+// We can ignore additionalProperties if the schema is true-like and
+// we are not in an unevaluated context, noting that additional
+// properties are considered tracked, evaluated keys.
+// ------------------------------------------------------------------
+function IsAdditionalPropertiesIgnored(context: BuildContext, additionalProperties: S.XSchema): boolean {
+  return !context.UseUnevaluated() &&
+    (G.IsEqual(additionalProperties, true) ||
+      (G.IsObject(additionalProperties) && G.IsEqual(G.Keys(additionalProperties).length, 0)))
+}
+// ------------------------------------------------------------------
+// Optimization: GetPropertiesPattern
 //
 // Constructs a regular expression that matches all property keys
 // and pattern properties defined in a schema. This approach unifies
@@ -101,6 +112,7 @@ export function BuildAdditionalPropertiesStandard(stack: Stack, context: BuildCo
 // Build
 // ------------------------------------------------------------------
 export function BuildAdditionalProperties(stack: Stack, context: BuildContext, schema: S.XAdditionalProperties, value: string): string {
+  if (IsAdditionalPropertiesIgnored(context, schema.additionalProperties)) return E.Constant(true)
   return CanAdditionalPropertiesFast(context, schema, value)
     ? BuildAdditionalPropertiesFast(context, schema, value)
     : BuildAdditionalPropertiesStandard(stack, context, schema, value)

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.3.20'
+const Version = '1.3.21'
 
 // ------------------------------------------------------------------
 // Build


### PR DESCRIPTION
This PR is a small optimization for `additionalProperties` where an empty value of `{}` or `true` can be ignored when NOT in unevaluated contexts. It has been noted that superfluous schema properties may cause a de-optimization as the specification requires implementations to track evaluated / unknown keys (relates to `unevaluatedProperties`)

This PR skips key tracking for `{}` and `true` for `additionalProperties` if possible.



