### PR TITLE
Version 1.3.24

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -4,6 +4,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.3.24](https://github.com/sinclairzx81/typebox/pull/1680)
+  - Optimization for Error Diagnostics by Short Circuiting at MaxError Capacity.
 - [Revision 1.3.23](https://github.com/sinclairzx81/typebox/pull/1679)
   - Intern Function for Schema Compression and JIT Inlining
 - [Revision 1.3.22](https://github.com/sinclairzx81/typebox/pull/1678)

--- a/design/website/docs/schema/4_errors.md
+++ b/design/website/docs/schema/4_errors.md
@@ -1,6 +1,8 @@
 # Schema.Errors
 
-The Errors(...) function returns a validation result containing a boolean success value, and an array of validation errors.
+The Errors(...) function returns an array of gathered validation errors up to the configured `maxErrors` limit. If the value contains no errors, an empty array is returned.
+
+> ⚠️ For performance, this function should only be called after a failed Check. The function performs an exhaustive check up to the `maxErrors` setting (the default is `8`). For additional performance, consider reducing `maxErrors` to `1`, which will terminate gathering on the first error.
 
 ## Example
 

--- a/design/website/docs/value/errors.md
+++ b/design/website/docs/value/errors.md
@@ -1,8 +1,8 @@
 # Value.Errors
 
-The Errors function returns an array of validation errors for the specified value. If the value contains no errors, an empty array is returned. This function should only be invoked after a failed Check.
+The Errors(...) function returns an array of gathered validation errors up to the configured `maxErrors` limit. If the value contains no errors, an empty array is returned.
 
-> ⚠️ For performance reasons, this function should be called only when a value fails a Check. The function performs an exhaustive recheck of the entire value and returns any errors encountered. Exhaustive validation can be costly for large values, so applications should carefully consider the performance impact of generating errors. For performance-sensitive scenarios, it is recommended to generate errors only in debugging or development environments.
+> ⚠️ For performance, this function should only be called after a failed Check. The function performs an exhaustive check up to the `maxErrors` setting (the default is `8`). For additional performance, consider reducing `maxErrors` to `1`, which will terminate gathering on the first error.
 
 ## Example
 

--- a/docs/docs/schema/4_errors.html
+++ b/docs/docs/schema/4_errors.html
@@ -1,5 +1,8 @@
 <h1>Schema.Errors</h1>
-<p>The Errors(...) function returns a validation result containing a boolean success value, and an array of validation errors.</p>
+<p>The Errors(...) function returns an array of gathered validation errors up to the configured <code>maxErrors</code> limit. If the value contains no errors, an empty array is returned.</p>
+<blockquote>
+<p>⚠️ For performance, this function should only be called after a failed Check. The function performs an exhaustive check up to the <code>maxErrors</code> setting (the default is <code>8</code>). For additional performance, consider reducing <code>maxErrors</code> to <code>1</code>, which will terminate gathering on the first error.</p>
+</blockquote>
 <h2>Example</h2>
 <pre><code class="language-typescript">import Schema from &#39;typebox/schema&#39;
 

--- a/docs/docs/value/errors.html
+++ b/docs/docs/value/errors.html
@@ -1,7 +1,7 @@
 <h1>Value.Errors</h1>
-<p>The Errors function returns an array of validation errors for the specified value. If the value contains no errors, an empty array is returned. This function should only be invoked after a failed Check.</p>
+<p>The Errors(...) function returns an array of gathered validation errors up to the configured <code>maxErrors</code> limit. If the value contains no errors, an empty array is returned.</p>
 <blockquote>
-<p>⚠️ For performance reasons, this function should be called only when a value fails a Check. The function performs an exhaustive recheck of the entire value and returns any errors encountered. Exhaustive validation can be costly for large values, so applications should carefully consider the performance impact of generating errors. For performance-sensitive scenarios, it is recommended to generate errors only in debugging or development environments.</p>
+<p>⚠️ For performance, this function should only be called after a failed Check. The function performs an exhaustive check up to the <code>maxErrors</code> setting (the default is <code>8</code>). For additional performance, consider reducing <code>maxErrors</code> to <code>1</code>, which will terminate gathering on the first error.</p>
 </blockquote>
 <h2>Example</h2>
 <p>Example usage is shown below.</p>

--- a/src/compile/validator.ts
+++ b/src/compile/validator.ts
@@ -89,7 +89,7 @@ export class Validator<Context extends TProperties = TProperties, Type extends T
     if(Settings.Get().correctiveParse) return Parser(this.Context(), this.Type(), value) as never
     throw new ParseError(value, this.Errors(value))
   }
-  /** Inspects a value and returns a detailed list of validation errors. */
+  /** Returns an array of validation errors for the given value. */
   public Errors(value: unknown): TLocalizedValidationError[] {
     if (this.IsAccelerated() && this.Check(value)) return []
     return Errors(this.Context(), this.Type(), value)

--- a/src/schema/compile.ts
+++ b/src/schema/compile.ts
@@ -43,20 +43,17 @@ import { ThrowParseError } from './parse.ts'
 export class Validator<const Schema extends Schema.XSchema = Schema.XSchema, 
   Value extends unknown = Static<Schema>
 >  {
-  private readonly check: (value: unknown) => boolean
-  private readonly isAccelerated: boolean
+  private readonly evaluateResult: Build.EvaluateResult
   private readonly context: Record<string, Schema.XSchema>
   private readonly schema: Schema.XSchema
   constructor(context: Record<string, Schema.XSchema>, schema: Schema) {
-    const evaluateResult = Build.Build(context, schema).Evaluate()
-    this.check = (value: unknown) => evaluateResult.Check(value)
-    this.isAccelerated = evaluateResult.IsAccelerated()
+    this.evaluateResult = Build.Build(context, schema).Evaluate()
     this.context = context
     this.schema = schema
   }
   /** Returns true if this Validator is using JIT acceleration. */
   public IsAccelerated(): boolean {
-    return this.isAccelerated
+    return this.evaluateResult.IsAccelerated()
   }
   /** Returns the underlying Schema used to construct this Validator. */
   public Schema(): Schema {
@@ -64,11 +61,11 @@ export class Validator<const Schema extends Schema.XSchema = Schema.XSchema,
   }
   /** Performs a type-guard check on the provided value. */
   public Check(value: unknown): value is Value {
-    return this.check(value)
+    return this.evaluateResult.Check(value)
   }
   /** Validates a value and returns it. Will throw if invalid. */
   public Parse(value: unknown): Value {
-    if(this.check(value)) return value as never
+    if(this.evaluateResult.Check(value)) return value as never
     ThrowParseError(this.context, this.schema, value)
   }
   /** Returns an array of validation errors for the given value. */

--- a/src/schema/compile.ts
+++ b/src/schema/compile.ts
@@ -35,7 +35,7 @@ import { type Static } from '../type/types/static.ts'
 import * as Schema from './types/index.ts'
 import * as Build from './build.ts'
 import { Errors } from './errors.ts'
-import { ParseError } from './parse.ts'
+import { ThrowParseError } from './parse.ts'
 
 // ------------------------------------------------------------------
 // Validator
@@ -43,33 +43,37 @@ import { ParseError } from './parse.ts'
 export class Validator<const Schema extends Schema.XSchema = Schema.XSchema, 
   Value extends unknown = Static<Schema>
 >  {
-  private readonly buildResult: Build.BuildResult
-  private readonly evaluateResult: Build.EvaluateResult
+  private readonly check: (value: unknown) => boolean
+  private readonly isAccelerated: boolean
+  private readonly context: Record<string, Schema.XSchema>
+  private readonly schema: Schema.XSchema
   constructor(context: Record<string, Schema.XSchema>, schema: Schema) {
-    this.buildResult = Build.Build(context, schema)
-    this.evaluateResult = this.buildResult.Evaluate()
+    const evaluateResult = Build.Build(context, schema).Evaluate()
+    this.check = (value: unknown) => evaluateResult.Check(value)
+    this.isAccelerated = evaluateResult.IsAccelerated()
+    this.context = context
+    this.schema = schema
   }
   /** Returns true if this Validator is using JIT acceleration. */
   public IsAccelerated(): boolean {
-    return this.evaluateResult.IsAccelerated()
+    return this.isAccelerated
   }
   /** Returns the underlying Schema used to construct this Validator. */
   public Schema(): Schema {
-    return this.buildResult.Schema() as never
+    return this.schema as never
   }
   /** Performs a type-guard check on the provided value. */
   public Check(value: unknown): value is Value {
-    return this.evaluateResult.Check(value)
+    return this.check(value)
   }
   /** Validates a value and returns it. Will throw if invalid. */
   public Parse(value: unknown): Value {
-    if(this.evaluateResult.Check(value)) return value as never
-    const [_result, errors] = Errors(this.buildResult.Context(), this.buildResult.Schema(), value)
-    throw new ParseError(this.buildResult.Schema(), value, errors)
+    if(this.check(value)) return value as never
+    ThrowParseError(this.context, this.schema, value)
   }
-  /** Inspects a value and returns a detailed list of validation errors. */
+  /** Returns an array of validation errors for the given value. */
   public Errors(value: unknown): [result: boolean, errors: TLocalizedValidationError[]] {
-    return Errors(this.buildResult.Context(), this.buildResult.Schema(), value)
+    return Errors(this.context, this.schema, value)
   }
 }
 // ------------------------------------------------------------------

--- a/src/schema/engine/_context.ts
+++ b/src/schema/engine/_context.ts
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
+import { Settings } from '../../system/settings/index.ts'
 import * as Schema from '../types/index.ts'
 import type { TValidationError } from '../../error/index.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
@@ -141,27 +142,17 @@ export class CheckContext {
 // ------------------------------------------------------------------
 // ErrorContext
 // ------------------------------------------------------------------
-export type ErrorContextCallback = (error: TValidationError) => unknown
 export class ErrorContext extends CheckContext {
-  constructor(private readonly callback: ErrorContextCallback) {
-    super()
-  }
-  public AddError(error: TValidationError): false {
-    this.callback(error)
-    return false
-  }
-}
-// ------------------------------------------------------------------
-// AccumulatedErrorContext
-// ------------------------------------------------------------------
-export class AccumulatedErrorContext extends ErrorContext {
   private readonly errors: TValidationError[]
   constructor() {
-    super(error => this.errors.push(error))
+    super()
     this.errors = []
   }
-  public override AddError(error: TValidationError): false {
-    this.errors.push(error)
+  public AtCapacity(): boolean {
+    return this.errors.length >= Settings.Get().maxErrors
+  }
+  public AddError(error: TValidationError): false {
+    if(!this.AtCapacity()) this.errors.push(error)
     return false
   }
   public GetErrors(): TValidationError[] {

--- a/src/schema/engine/additionalProperties.ts
+++ b/src/schema/engine/additionalProperties.ts
@@ -137,9 +137,8 @@ export function ErrorAdditionalProperties(stack: Stack, context: ErrorContext, s
   const isAdditionalProperties = G.EveryAll(G.Keys(value), 0, (key, _index) => {
     const nextSchemaPath = `${schemaPath}/additionalProperties`
     const nextInstancePath = `${instancePath}/${key}`
-    const nextContext = new ErrorContext()
     const isAdditionalProperty = regexp.test(key) ||
-      (ErrorSchemaPushStack(stack, nextContext, nextSchemaPath, nextInstancePath, schema.additionalProperties, value[key]) && context.AddKey(key))
+      (ErrorSchemaPushStack(stack, context, nextSchemaPath, nextInstancePath, schema.additionalProperties, value[key]) && context.AddKey(key))
 
     if (!isAdditionalProperty) additionalProperties.push(key)
     return isAdditionalProperty

--- a/src/schema/engine/additionalProperties.ts
+++ b/src/schema/engine/additionalProperties.ts
@@ -32,7 +32,7 @@ import * as S from '../types/index.ts'
 import * as V from './_externals.ts'
 import { Stack } from './_stack.ts'
 import { Unique } from './_unique.ts'
-import { BuildContext, CheckContext, ErrorContext, AccumulatedErrorContext } from './_context.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { UnicodeRegExp } from './_regexp.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 import { BuildSchemaPushStack, CheckSchemaPushStack, ErrorSchemaPushStack } from './schema.ts'
@@ -137,7 +137,7 @@ export function ErrorAdditionalProperties(stack: Stack, context: ErrorContext, s
   const isAdditionalProperties = G.EveryAll(G.Keys(value), 0, (key, _index) => {
     const nextSchemaPath = `${schemaPath}/additionalProperties`
     const nextInstancePath = `${instancePath}/${key}`
-    const nextContext = new AccumulatedErrorContext()
+    const nextContext = new ErrorContext()
     const isAdditionalProperty = regexp.test(key) ||
       (ErrorSchemaPushStack(stack, nextContext, nextSchemaPath, nextInstancePath, schema.additionalProperties, value[key]) && context.AddKey(key))
 

--- a/src/schema/engine/allOf.ts
+++ b/src/schema/engine/allOf.ts
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 import * as Schema from '../types/index.ts'
 import { Stack } from './_stack.ts'
-import { BuildContext, CheckContext, ErrorContext, AccumulatedErrorContext } from './_context.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Reducer } from './_reducer.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
@@ -63,10 +63,10 @@ export function CheckAllOf(stack: Stack, context: CheckContext, schema: Schema.X
 // Error
 // ------------------------------------------------------------------
 export function ErrorAllOf(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XAllOf, value: unknown): boolean {
-  const failedContexts: AccumulatedErrorContext[] = []
-  const results = schema.allOf.reduce<AccumulatedErrorContext[]>((result, schema, index) => {
+  const failedContexts: ErrorContext[] = []
+  const results = schema.allOf.reduce<ErrorContext[]>((result, schema, index) => {
     const nextSchemaPath = `${schemaPath}/allOf/${index}`
-    const nextContext = new AccumulatedErrorContext()
+    const nextContext = new ErrorContext()
     const isSchema = ErrorSchema(stack, nextContext, nextSchemaPath, instancePath, schema, value)
     if (!isSchema) failedContexts.push(nextContext)
     return isSchema ? [...result, nextContext] : result

--- a/src/schema/engine/anyOf.ts
+++ b/src/schema/engine/anyOf.ts
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 import * as Schema from '../types/index.ts'
 import { Stack } from './_stack.ts'
-import { BuildContext, CheckContext, ErrorContext, AccumulatedErrorContext } from './_context.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Reducer } from './_reducer.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
@@ -63,9 +63,9 @@ export function CheckAnyOf(stack: Stack, context: CheckContext, schema: Schema.X
 // Error
 // ------------------------------------------------------------------
 export function ErrorAnyOf(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XAnyOf, value: unknown): boolean {
-  const failedContexts: AccumulatedErrorContext[] = []
-  const results = schema.anyOf.reduce<AccumulatedErrorContext[]>((result, schema, index) => {
-    const nextContext = new AccumulatedErrorContext()
+  const failedContexts: ErrorContext[] = []
+  const results = schema.anyOf.reduce<ErrorContext[]>((result, schema, index) => {
+    const nextContext = new ErrorContext()
     const nextSchemaPath = `${schemaPath}/anyOf/${index}`
     const isSchema = ErrorSchema(stack, nextContext, nextSchemaPath, instancePath, schema, value)
     if (!isSchema) failedContexts.push(nextContext)

--- a/src/schema/engine/if.ts
+++ b/src/schema/engine/if.ts
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 import * as Schema from '../types/index.ts'
 import { Stack } from './_stack.ts'
-import { BuildContext, CheckContext, ErrorContext, AccumulatedErrorContext } from './_context.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
 
@@ -60,7 +60,7 @@ export function CheckIf(stack: Stack, context: CheckContext, schema: Schema.XIf,
 export function ErrorIf(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XIf, value: unknown): boolean {
   const thenSchema = Schema.IsThen(schema) ? schema.then : true
   const elseSchema = Schema.IsElse(schema) ? schema.else : true
-  const trueContext = new AccumulatedErrorContext()
+  const trueContext = new ErrorContext()
   const isIf = ErrorSchema(stack, trueContext, `${schemaPath}/if`, instancePath, schema.if, value)
     ? ErrorSchema(stack, trueContext, `${schemaPath}/then`, instancePath, thenSchema, value) || context.AddError({
       keyword: 'if',

--- a/src/schema/engine/oneOf.ts
+++ b/src/schema/engine/oneOf.ts
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 import * as Schema from '../types/index.ts'
 import { Stack } from './_stack.ts'
-import { BuildContext, CheckContext, ErrorContext, AccumulatedErrorContext } from './_context.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Reducer } from './_reducer.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
@@ -67,11 +67,11 @@ export function CheckOneOf(stack: Stack, context: CheckContext, schema: Schema.X
 // Error
 // ------------------------------------------------------------------
 export function ErrorOneOf(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XOneOf, value: unknown): boolean {
-  const failedContexts: AccumulatedErrorContext[] = []
+  const failedContexts: ErrorContext[] = []
   const passingSchemas: number[] = []
 
-  const passedContexts = schema.oneOf.reduce<AccumulatedErrorContext[]>((result, schema, index) => {
-    const nextContext = new AccumulatedErrorContext()
+  const passedContexts = schema.oneOf.reduce<ErrorContext[]>((result, schema, index) => {
+    const nextContext = new ErrorContext()
     const nextSchemaPath = `${schemaPath}/oneOf/${index}`
     const isSchema = ErrorSchema(stack, nextContext, nextSchemaPath, instancePath, schema, value)
     if (isSchema) passingSchemas.push(index)

--- a/src/schema/engine/propertyNames.ts
+++ b/src/schema/engine/propertyNames.ts
@@ -56,8 +56,7 @@ export function ErrorPropertyNames(stack: Stack, context: ErrorContext, schemaPa
   const isPropertyNames = G.EveryAll(G.Keys(value), 0, (key, _index) => {
     const nextInstancePath = `${instancePath}/${key}`
     const nextSchemaPath = `${schemaPath}/propertyNames`
-    const nextContext = new ErrorContext()
-    const isPropertyName = ErrorSchema(stack, nextContext, nextSchemaPath, nextInstancePath, schema.propertyNames, key)
+    const isPropertyName = ErrorSchema(stack, context, nextSchemaPath, nextInstancePath, schema.propertyNames, key)
     if (!isPropertyName) propertyNames.push(key)
     return isPropertyName
   })

--- a/src/schema/engine/propertyNames.ts
+++ b/src/schema/engine/propertyNames.ts
@@ -31,7 +31,7 @@ THE SOFTWARE.
 import * as Schema from '../types/index.ts'
 import { Stack } from './_stack.ts'
 import { Unique } from './_unique.ts'
-import { BuildContext, CheckContext, ErrorContext, AccumulatedErrorContext } from './_context.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
 
@@ -56,7 +56,7 @@ export function ErrorPropertyNames(stack: Stack, context: ErrorContext, schemaPa
   const isPropertyNames = G.EveryAll(G.Keys(value), 0, (key, _index) => {
     const nextInstancePath = `${instancePath}/${key}`
     const nextSchemaPath = `${schemaPath}/propertyNames`
-    const nextContext = new AccumulatedErrorContext()
+    const nextContext = new ErrorContext()
     const isPropertyName = ErrorSchema(stack, nextContext, nextSchemaPath, nextInstancePath, schema.propertyNames, key)
     if (!isPropertyName) propertyNames.push(key)
     return isPropertyName

--- a/src/schema/engine/ref.ts
+++ b/src/schema/engine/ref.ts
@@ -31,7 +31,7 @@ THE SOFTWARE.
 import * as Functions from './_functions.ts'
 import * as Schema from '../types/index.ts'
 import { Stack } from './_stack.ts'
-import { BuildContext, CheckContext, ErrorContext, AccumulatedErrorContext } from './_context.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E } from '../../guard/index.ts'
 import { CheckSchema, ErrorSchema } from './schema.ts'
 
@@ -72,7 +72,7 @@ export function CheckRef(stack: Stack, context: CheckContext, schema: Schema.XRe
 // ------------------------------------------------------------------
 export function ErrorRef(stack: Stack, context: ErrorContext, _schemaPath: string, instancePath: string, schema: Schema.XRef, value: unknown): boolean {
   const target = stack.Ref(schema) ?? false
-  const nextContext = new AccumulatedErrorContext()
+  const nextContext = new ErrorContext()
   const result = (Schema.IsSchema(target) && ErrorSchema(stack, nextContext, '#', instancePath, target, value))
   if (result) context.Merge([nextContext])
   if (!result) nextContext.GetErrors().forEach(error => context.AddError(error))

--- a/src/schema/engine/schema.ts
+++ b/src/schema/engine/schema.ts
@@ -321,6 +321,10 @@ export function ErrorSchemaPushStack(stack: Stack, context: ErrorContext, schema
   return (context.Push() && ErrorSchema(stack, context, schemaPath, instancePath, schema, value)) && context.Pop()
 }
 export function ErrorSchema(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XSchema, value: unknown): boolean {
+  // Optimization: We can safely terminate here when the context is at capacity because we are unable to
+  // append additional errors. It is worth being mindful that logical keywords such as allOf, anyOf,
+  // oneOf pass a new context per operand, so the capacity check applies per context, not across the
+  // full set of errors accumulated by the schema as a whole. (review)
   if(context.AtCapacity()) return false
   stack.Push(schema)
   const result = (Schema.IsSchemaBoolean(schema)) ? ErrorSchemaBoolean(stack, context, schemaPath, instancePath, schema, value) : (

--- a/src/schema/engine/schema.ts
+++ b/src/schema/engine/schema.ts
@@ -321,6 +321,7 @@ export function ErrorSchemaPushStack(stack: Stack, context: ErrorContext, schema
   return (context.Push() && ErrorSchema(stack, context, schemaPath, instancePath, schema, value)) && context.Pop()
 }
 export function ErrorSchema(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XSchema, value: unknown): boolean {
+  if(context.AtCapacity()) return false
   stack.Push(schema)
   const result = (Schema.IsSchemaBoolean(schema)) ? ErrorSchemaBoolean(stack, context, schemaPath, instancePath, schema, value) : (
     !!(

--- a/src/schema/engine/unevaluatedItems.ts
+++ b/src/schema/engine/unevaluatedItems.ts
@@ -31,7 +31,7 @@ THE SOFTWARE.
 import * as Schema from '../types/index.ts'
 import { Stack } from './_stack.ts'
 import { Unique } from './_unique.ts'
-import { BuildContext, CheckContext, ErrorContext, AccumulatedErrorContext } from './_context.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
 
@@ -67,7 +67,7 @@ export function ErrorUnevaluatedItems(stack: Stack, context: ErrorContext, schem
   const indices = context.GetIndices()
   const unevaluatedItems: number[] = []
   const isUnevaluatedItems = G.EveryAll(value, 0, (item, index) => {
-    const nextContext = new AccumulatedErrorContext()
+    const nextContext = new ErrorContext()
     const isEvaluatedItem = (indices.has(index) || ErrorSchema(stack, nextContext, schemaPath, instancePath, schema.unevaluatedItems, item))
       && context.AddIndex(index)
     if (!isEvaluatedItem) unevaluatedItems.push(index)

--- a/src/schema/engine/unevaluatedProperties.ts
+++ b/src/schema/engine/unevaluatedProperties.ts
@@ -31,7 +31,7 @@ THE SOFTWARE.
 import * as Schema from '../types/index.ts'
 import { Stack } from './_stack.ts'
 import { Unique } from './_unique.ts'
-import { BuildContext, CheckContext, ErrorContext, AccumulatedErrorContext } from './_context.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
 
@@ -68,7 +68,7 @@ export function ErrorUnevaluatedProperties(stack: Stack, context: ErrorContext, 
   const keys = context.GetKeys()
   const unevaluatedProperties: PropertyKey[] = []
   const isUnevaluatedProperties = G.EveryAll(G.Entries(value), 0, ([key, prop]) => {
-    const nextContext = new AccumulatedErrorContext()
+    const nextContext = new ErrorContext()
     const isEvaluatedProperty = keys.has(key)
       || (ErrorSchema(stack, nextContext, schemaPath, instancePath, schema.unevaluatedProperties, prop) && context.AddKey(key))
     if (!isEvaluatedProperty) unevaluatedProperties.push(key)

--- a/src/schema/errors.ts
+++ b/src/schema/errors.ts
@@ -30,32 +30,27 @@ THE SOFTWARE.
 
 import { Arguments } from '../system/arguments/index.ts'
 import { Settings } from '../system/settings/index.ts'
-import { Get as LocaleGet } from '../system/locale/_config.ts'
-import { Guard } from '../guard/index.ts'
+import { Get as GetLocalizationFunction } from '../system/locale/_config.ts'
 
 import { type TLocalizedValidationError } from '../error/index.ts'
 import * as Schema from './types/index.ts'
 import * as Engine from './engine/index.ts'
 
-/** Checks a value and returns validation errors */
+/** Returns an array of validation errors for the given value. */
 export function Errors(schema: Schema.XSchema, value: unknown): [boolean, TLocalizedValidationError[]]
-/** Checks a value and returns validation errors */
+/** Returns an array of validation errors for the given value. */
 export function Errors(context: Record<PropertyKey, Schema.XSchema>, schema: Schema.XSchema, value: unknown): [boolean, TLocalizedValidationError[]]
-/** Checks a value and returns validation errors */
+/** Returns an array of validation errors for the given value. */
 export function Errors(...args: unknown[]): [boolean, TLocalizedValidationError[]] {
   const [context, schema, value] = Arguments.Match<[Record<PropertyKey, Schema.XSchema>, Schema.XSchema, unknown]>(args, {
     3: (context, schema, value) => [context, schema, value],
     2: (schema, value) => [{}, schema, value]
   })
-  const settings = Settings.Get()
-  const locale = LocaleGet()
-  const errors: TLocalizedValidationError[] = []
-
   const stack = new Engine.Stack(context, schema)
-  const errorContext = new Engine.ErrorContext(error => {
-    if(Guard.IsGreaterEqualThan(errors.length, settings.maxErrors)) return
-    return errors.push({ ...error, message: locale(error) })
-  })
+  const errorContext = new Engine.ErrorContext()
   const result = Engine.ErrorSchema(stack, errorContext, '#', '', schema, value)
-  return [result, errors]
+  const errors = errorContext.GetErrors().slice(0, Settings.Get().maxErrors)
+  const locale = GetLocalizationFunction()
+  const localized = errors.map(error => ({ ...error, message: locale(error) }))
+  return [result, localized]
 }

--- a/src/schema/parse.ts
+++ b/src/schema/parse.ts
@@ -47,6 +47,13 @@ export class ParseError {
   ) {}
 }
 // ------------------------------------------------------------------
+// ThrowParseError
+// ------------------------------------------------------------------
+export function ThrowParseError(context: Record<PropertyKey, Schema.XSchema>, schema: Schema.XSchema, value: unknown): never {
+  const result = Errors(context, schema, value)
+  throw new ParseError(schema, value, result[1])
+}
+// ------------------------------------------------------------------
 // Parse
 // ------------------------------------------------------------------
 /** Parses a value against the provided schema */
@@ -59,9 +66,6 @@ export function Parse(...args: unknown[]): unknown {
     3: (context, schema, value) => [context, schema, value],
     2: (schema, value) => [{}, schema, value]
   })
-  if(!Check(context, schema, value)) {
-    const [_result, errors] = Errors(context, schema, value)
-    throw new ParseError(schema, value, errors)
-  }
-  return value
+  if(Check(context, schema, value)) return value
+  ThrowParseError(context, schema, value)
 }

--- a/src/value/errors/errors.ts
+++ b/src/value/errors/errors.ts
@@ -31,30 +31,13 @@ THE SOFTWARE.
 import { Arguments } from '../../system/arguments/index.ts'
 import type { TProperties, TSchema } from '../../type/index.ts'
 import type { TLocalizedValidationError } from '../../error/index.ts'
-import { Errors as SchemaErrors,  } from '../../schema/index.ts'
+import { Errors as SchemaErrors } from '../../schema/index.ts'
 
-/** 
- * Performs an exhaustive Check on the specified value and reports any errors found.
- * If no errors are found, an empty array is returned. Unlike Check, this function
- * does not terminate at the first occurrence of an error. For best performance, call 
- * Check first and call Errors only if Check returns false.
- */
+/** Returns an array of validation errors for the given value. */
 export function Errors<Type extends TSchema>(type: Type, value: unknown): TLocalizedValidationError[]
-
-/** 
- * Performs an exhaustive Check on the specified value and reports any errors found.
- * If no errors are found, an empty array is returned. Unlike Check, this function
- * does not terminate at the first occurrence of an error. For best performance, call 
- * Check first and call Errors only if Check returns false.
- */
+/** Returns an array of validation errors for the given value. */
 export function Errors<Context extends TProperties, Type extends TSchema>(context: Context, type: Type, value: unknown): TLocalizedValidationError[]
-
-/** 
- * Performs an exhaustive Check on the specified value and reports any errors found.
- * If no errors are found, an empty array is returned. Unlike Check, this function
- * does not terminate at the first occurrence of an error. For best performance, call 
- * Check first and call Errors only if Check returns false.
- */
+/** Returns an array of validation errors for the given value. */
 export function Errors(...args: unknown[]): TLocalizedValidationError[] {
   const [context, type, value] = Arguments.Match<[TProperties, TSchema, unknown]>(args, {
     3: (context, type, value) => [context, type, value],

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.3.23'
+const Version = '1.3.24'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/schema/errors.ts
+++ b/test/typebox/runtime/schema/errors.ts
@@ -1,3 +1,4 @@
+import System from 'typebox/system'
 import Schema from 'typebox/schema'
 import { Assert } from 'test'
 
@@ -27,4 +28,93 @@ Test('Should Errors 4', () => {
   const [ok, errors] = Schema.Errors({ A: { type: 'string' } }, { $ref: 'A' }, 1)
   Assert.IsFalse(ok)
   Assert.IsTrue(errors.length > 0)
+})
+// ------------------------------------------------------------------
+// MaxErrors:
+// ------------------------------------------------------------------
+const Vector = {
+  type: 'object',
+  required: ['x', 'y', 'z'],
+  properties: {
+    x: { type: 'number' },
+    y: { type: 'number' },
+    z: { type: 'number' }
+  }
+}
+// ------------------------------------------------------------------
+// MaxErrors: Accumulate Up to MaxError
+// ------------------------------------------------------------------
+Test('Should Errors 5', () => {
+  System.Settings.Set({ maxErrors: 1 })
+  const [ok, errors] = Schema.Errors(Vector, { x: null, y: null, z: null })
+  Assert.IsFalse(ok)
+  Assert.IsEqual(errors.length, 1)
+  System.Settings.Reset()
+})
+Test('Should Errors 6', () => {
+  System.Settings.Set({ maxErrors: 2 })
+  const [ok, errors] = Schema.Errors(Vector, { x: null, y: null, z: null })
+  Assert.IsFalse(ok)
+  Assert.IsEqual(errors.length, 2)
+  System.Settings.Reset()
+})
+Test('Should Errors 7', () => {
+  System.Settings.Set({ maxErrors: 3 })
+  const [ok, errors] = Schema.Errors(Vector, { x: null, y: null, z: null })
+  Assert.IsFalse(ok)
+  Assert.IsEqual(errors.length, 3)
+  System.Settings.Reset()
+})
+// ------------------------------------------------------------------
+// MaxErrors: Ensure Partial Errors are Collected
+// ------------------------------------------------------------------
+Test('Should Errors 8', () => {
+  System.Settings.Set({ maxErrors: 3 })
+  const [ok, errors] = Schema.Errors(Vector, { x: 1, y: null, z: null })
+  Assert.IsFalse(ok)
+  Assert.IsEqual(errors.length, 2)
+  System.Settings.Reset()
+})
+Test('Should Errors 9', () => {
+  System.Settings.Set({ maxErrors: 3 })
+  const [ok, errors] = Schema.Errors(Vector, { x: 1, y: 1, z: null })
+  Assert.IsFalse(ok)
+  Assert.IsEqual(errors.length, 1)
+  System.Settings.Reset()
+})
+Test('Should Errors 10', () => {
+  System.Settings.Set({ maxErrors: 3 })
+  const [ok, errors] = Schema.Errors(Vector, { x: 1, y: 1, z: 1 })
+  Assert.IsTrue(ok)
+  Assert.IsEqual(errors.length, 0)
+  System.Settings.Reset()
+})
+// ------------------------------------------------------------------
+// MaxErrors: MaxErrors of Zero is Always False
+//
+// IMPORTANT: When MaxErrors is 0, no assertion logic runs, so we
+// have no meaningful basis for the result. The safest option is to
+// report 'false', even in cases where the value would otherwise be
+// valid. We do this because Errors() is a diagnostic function, not
+// a checker: the boolean result indicates whether an error was
+// found, not whether the full schema is satisfied. As a result,
+// callers who set maxErrors to 0 and then call Errors() for
+// diagnostics will always get 'false' back.
+//
+// (review) -> remove boolean return from Errors()
+//
+// ------------------------------------------------------------------
+Test('Should Errors 11', () => {
+  System.Settings.Set({ maxErrors: 0 })
+  const [ok, errors] = Schema.Errors(Vector, { x: null, y: null, z: null })
+  Assert.IsFalse(ok)
+  Assert.IsEqual(errors.length, 0)
+  System.Settings.Reset()
+})
+Test('Should Errors 12', () => {
+  System.Settings.Set({ maxErrors: 0 })
+  const [ok, errors] = Schema.Errors(Vector, { x: 1, y: 1, z: 1 })
+  Assert.IsFalse(ok) // false, because no assertion was run.
+  Assert.IsEqual(errors.length, 0)
+  System.Settings.Reset()
 })


### PR DESCRIPTION
This PR optimizes TypeBox's error diagnostics gathering by using a new termination strategy based on `maxErrors` capacity. The optimization works by terminating lexical traversal if the current `ErrorContext` is at error capacity. This avoids subsequent sub-schema checking, except within `allOf`, `anyOf`, and `oneOf`, where each operand is checked against a fresh context.

### Update

The following is the at-capacity optimization.

```typescript
export function ErrorSchema(stack: Stack, context: ErrorContext, ...): boolean {
  if(context.AtCapacity()) return false // (new) if at capacity, we do not need to gather
  stack.Push(schema)
  // <exhaustive-keyword-gathering-here> 
  stack.Pop()
 }
```

### Settings

The optimization better represents `maxError` intent, where `1` terminates at the first error and `0` eliminates all diagnostics and is effectively a no-op.

```typescript
import System from 'typebox/system'

System.Settings.Set({ maxErrors: 8 })  // default
System.Settings.Set({ maxErrors: 1 })  // terminate at first error condition
System.Settings.Set({ maxErrors: 0 })  // disable all diagnostics (very fast)
```

### Testing

The following additional test cases were added, with some consideration given to case 12, where `Errors()` reports false for a valid schema. The interpretation here is that, because no diagnostics were run, we can't say anything meaningful about the validity of the value (so we just assume false). We may be able to change the `Errors` return type from `[ok, errors]` to simply `errors` in later versions, but since case 12 only applies to cases where `maxErrors: 0`, we allow the invariant, as one wouldn't call `Errors()` while expecting none.

```typescript
import System from 'typebox/system'

// ------------------------------------------------------------------
// MaxErrors:
// ------------------------------------------------------------------
const Vector = {
  type: 'object',
  required: ['x', 'y', 'z'],
  properties: {
    x: { type: 'number' },
    y: { type: 'number' },
    z: { type: 'number' }
  }
}
// ------------------------------------------------------------------
// MaxErrors: Accumulate Up to MaxError
// ------------------------------------------------------------------
Test('Should Errors 5', () => {
  System.Settings.Set({ maxErrors: 1 })
  const [ok, errors] = Schema.Errors(Vector, { x: null, y: null, z: null })
  Assert.IsFalse(ok)
  Assert.IsEqual(errors.length, 1)
  System.Settings.Reset()
})
Test('Should Errors 6', () => {
  System.Settings.Set({ maxErrors: 2 })
  const [ok, errors] = Schema.Errors(Vector, { x: null, y: null, z: null })
  Assert.IsFalse(ok)
  Assert.IsEqual(errors.length, 2)
  System.Settings.Reset()
})
Test('Should Errors 7', () => {
  System.Settings.Set({ maxErrors: 3 })
  const [ok, errors] = Schema.Errors(Vector, { x: null, y: null, z: null })
  Assert.IsFalse(ok)
  Assert.IsEqual(errors.length, 3)
  System.Settings.Reset()
})
// ------------------------------------------------------------------
// MaxErrors: Ensure Partial Errors are Collected
// ------------------------------------------------------------------
Test('Should Errors 8', () => {
  System.Settings.Set({ maxErrors: 3 })
  const [ok, errors] = Schema.Errors(Vector, { x: 1, y: null, z: null })
  Assert.IsFalse(ok)
  Assert.IsEqual(errors.length, 2)
  System.Settings.Reset()
})
Test('Should Errors 9', () => {
  System.Settings.Set({ maxErrors: 3 })
  const [ok, errors] = Schema.Errors(Vector, { x: 1, y: 1, z: null })
  Assert.IsFalse(ok)
  Assert.IsEqual(errors.length, 1)
  System.Settings.Reset()
})
Test('Should Errors 10', () => {
  System.Settings.Set({ maxErrors: 3 })
  const [ok, errors] = Schema.Errors(Vector, { x: 1, y: 1, z: 1 })
  Assert.IsTrue(ok)
  Assert.IsEqual(errors.length, 0)
  System.Settings.Reset()
})
// ------------------------------------------------------------------
// MaxErrors: MaxErrors of Zero is Always False
// ------------------------------------------------------------------
Test('Should Errors 11', () => {
  System.Settings.Set({ maxErrors: 0 })
  const [ok, errors] = Schema.Errors(Vector, { x: null, y: null, z: null })
  Assert.IsFalse(ok)
  Assert.IsEqual(errors.length, 0)
  System.Settings.Reset()
})
Test('Should Errors 12', () => {
  System.Settings.Set({ maxErrors: 0 })
  const [ok, errors] = Schema.Errors(Vector, { x: 1, y: 1, z: 1 })
  Assert.IsFalse(ok) // false, because no assertion was run.
  Assert.IsEqual(errors.length, 0)
  System.Settings.Reset()
})
```

### Additional Updates

- `AccumulatedErrorContext` has been removed, with accumulators moved to `ErrorContext`.
- The Schema Validator class internals have been refactored to remove coupling to `BuildResult`. The intent here is to remove any associated GC handles so that the engine can dispose of the object. The public interface remains unchanged.
- Updated `Parse` to remove the explicit throw. Moved the logic to a new `ThrowParseError(...)`, which is used to correct a de-opt that occurs when destructuring the `Errors()` tuple (observed in Deno and Node).