### PR TITLE
Version 1.3.25

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -4,6 +4,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.3.25](https://github.com/sinclairzx81/typebox/pull/1681)
+  - Ensure Intern Function Returns Canonical Idempotent Result
 - [Revision 1.3.24](https://github.com/sinclairzx81/typebox/pull/1680)
   - Optimization for Error Diagnostics by Short Circuiting at MaxError Capacity.
 - [Revision 1.3.23](https://github.com/sinclairzx81/typebox/pull/1679)

--- a/src/schema/errors.ts
+++ b/src/schema/errors.ts
@@ -29,7 +29,6 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import { Arguments } from '../system/arguments/index.ts'
-import { Settings } from '../system/settings/index.ts'
 import { Get as GetLocalizationFunction } from '../system/locale/_config.ts'
 
 import { type TLocalizedValidationError } from '../error/index.ts'
@@ -49,7 +48,7 @@ export function Errors(...args: unknown[]): [boolean, TLocalizedValidationError[
   const stack = new Engine.Stack(context, schema)
   const errorContext = new Engine.ErrorContext()
   const result = Engine.ErrorSchema(stack, errorContext, '#', '', schema, value)
-  const errors = errorContext.GetErrors().slice(0, Settings.Get().maxErrors)
+  const errors = errorContext.GetErrors()
   const locale = GetLocalizationFunction()
   const localized = errors.map(error => ({ ...error, message: locale(error) }))
   return [result, localized]

--- a/src/schema/intern/intern.ts
+++ b/src/schema/intern/intern.ts
@@ -167,15 +167,16 @@ function ResolveRef(context: Record<string, S.XSchema>, schema: S.XSchemaObject,
   return Resolve.Ref(context, schema, ref) ?? UnresolvableRef(ref)
 }
 function FromRef(context: RefContext, schema: S.XRef): S.XSchema {
-  // Resolve target, boolean schemas return as is.
+  // Resolve target
   const target = ResolveRef(context.context, context.schema, schema.$ref)
-  if (S.IsSchemaBoolean(target)) return target
+
   // Check if target is resolving, if not, resolve
-  const pending = context.resolving.get(target)
-  if (Guard.IsUndefined(pending)) return FromSchema(context, target)
+  const resolving = context.resolving.get(target)
+  if (Guard.IsUndefined(resolving)) return FromSchema(context, target)
+
   // Target is mid-intern, so this is a cycle (point at its reserved placeholder)
-  pending.used = true
-  return { $ref: `#/$defs/${pending.key}` }
+  resolving.used = true
+  return { $ref: `#/$defs/${resolving.key}` }
 }
 // ----------------------------------------------------------------
 // Then
@@ -243,6 +244,20 @@ function FromSchemaObject(context: RefContext, schema: S.XSchemaObject): S.XSche
   const key = reservation.used ? reservation.key : HashKey(interned)
   registry.set(key, interned)
 
+  // Result
+  const result: S.XSchema = { $ref: `#/$defs/${key}` }
+  resolved.set(schema, result)
+  return result
+}
+// ----------------------------------------------------------------
+// SchemaBoolean
+// ----------------------------------------------------------------
+function FromSchemaBoolean(_context: RefContext, schema: S.XSchemaBoolean): S.XSchema {
+  // Finalize and register the result
+  const key = HashKey(schema)
+  registry.set(key, schema)
+
+  // Result
   const result: S.XSchema = { $ref: `#/$defs/${key}` }
   resolved.set(schema, result)
   return result
@@ -251,13 +266,19 @@ function FromSchemaObject(context: RefContext, schema: S.XSchemaObject): S.XSche
 // Schema
 // ----------------------------------------------------------------
 function FromSchema(context: RefContext, schema: S.XSchema): S.XSchema {
-  return S.IsSchemaBoolean(schema) ? schema : FromSchemaObject(context, schema)
+  return S.IsSchemaBoolean(schema) ? FromSchemaBoolean(context, schema) : FromSchemaObject(context, schema)
 }
-
+// ----------------------------------------------------------------
+// BooleanEntry
+// ----------------------------------------------------------------
+function BooleanEntry(schema: S.XSchemaBoolean): S.XSchemaObject {
+  const key = HashKey(schema)
+  return { $ref: `#/$defs/${key}`, $defs: { [key]: schema } }
+}
 // ----------------------------------------------------------------
 // Module-level accumulator state
 // ----------------------------------------------------------------
-const registry = new Map<string, S.XSchemaObject>()
+const registry = new Map<string, S.XSchema>()
 const resolved = new Map<S.XSchema, S.XSchema>()
 // ----------------------------------------------------------------
 // XIntern
@@ -267,12 +288,6 @@ export interface XIntern<Type extends unknown = unknown> {
   $ref: string
   $defs: Record<string, S.XSchemaObject>
 }
-// ----------------------------------------------------------------
-// BooleanIntern
-// ----------------------------------------------------------------
-function BooleanIntern(schema: S.XSchemaBoolean): S.XSchemaObject {
-  return { $ref: `#/$defs/${HashKey(schema)}`, $defs: { [HashKey(schema)]: schema } }
-}
 /**
  * [Experimental] Performs a Common Subexpression Elimination (CSE) transform on the given schema. This function restructures the schema such that each distinct sub-schema is stored exactly once in a
  * $defs object, keyed by its content hash. The result of Intern(...) is a canonical referential schema, and repeated calls are idempotent. This function can be used to both compress and optimize schemas prior to compilation.
@@ -280,10 +295,10 @@ function BooleanIntern(schema: S.XSchemaBoolean): S.XSchemaObject {
 export function Intern<const Schema extends S.XSchema>(schema: Schema): XIntern<XStatic<Schema>> {
   registry.clear()
   resolved.clear()
-  if (S.IsSchemaBoolean(schema)) return BooleanIntern(schema) as never
+  if (S.IsSchemaBoolean(schema)) return BooleanEntry(schema) as never
   const context = S.IsDefs(schema) ? schema.$defs : {}
   const entry = S.IsRef(schema) ? ResolveRef(context, schema, schema.$ref) : schema
-  if (S.IsSchemaBoolean(entry)) return BooleanIntern(entry) as never
+  if (S.IsSchemaBoolean(entry)) return BooleanEntry(entry) as never
   const ref_context: RefContext = { schema, context, resolving: new Map() }
   const result = FromSchema(ref_context, entry) as { $ref: string }
   return { $ref: result.$ref, $defs: Object.fromEntries(registry) } as never

--- a/src/schema/intern/intern.ts
+++ b/src/schema/intern/intern.ts
@@ -275,7 +275,7 @@ function BooleanIntern(schema: S.XSchemaBoolean): S.XSchemaObject {
 }
 /**
  * [Experimental] Performs a Common Subexpression Elimination (CSE) transform on the given schema. This function restructures the schema such that each distinct sub-schema is stored exactly once in a
- * $defs object, keyed by its content hash. The result of Intern(...) is a canonical referential schema, and repeated calls are idempotent. This function can be used to both compress and optimize schemas prior to compilation. 
+ * $defs object, keyed by its content hash. The result of Intern(...) is a canonical referential schema, and repeated calls are idempotent. This function can be used to both compress and optimize schemas prior to compilation.
  */
 export function Intern<const Schema extends S.XSchema>(schema: Schema): XIntern<XStatic<Schema>> {
   registry.clear()

--- a/src/schema/intern/intern.ts
+++ b/src/schema/intern/intern.ts
@@ -289,8 +289,10 @@ export interface XIntern<Type extends unknown = unknown> {
   $defs: Record<string, S.XSchemaObject>
 }
 /**
- * [Experimental] Performs a Common Subexpression Elimination (CSE) transform on the given schema. This function restructures the schema such that each distinct sub-schema is stored exactly once in a
- * $defs object, keyed by its content hash. The result of Intern(...) is a canonical referential schema, and repeated calls are idempotent. This function can be used to both compress and optimize schemas prior to compilation.
+ * [Experimental] Performs a Common Subexpression Elimination (CSE) transform on the given
+ * schema. This function restructures the schema such that each distinct sub-schema is stored
+ * exactly once in a $defs object and keyed by content hash. This function can be used to
+ * both compress and optimize schemas prior to compilation.
  */
 export function Intern<const Schema extends S.XSchema>(schema: Schema): XIntern<XStatic<Schema>> {
   registry.clear()

--- a/src/schema/intern/intern.ts
+++ b/src/schema/intern/intern.ts
@@ -167,13 +167,13 @@ function ResolveRef(context: Record<string, S.XSchema>, schema: S.XSchemaObject,
   return Resolve.Ref(context, schema, ref) ?? UnresolvableRef(ref)
 }
 function FromRef(context: RefContext, schema: S.XRef): S.XSchema {
-  // resolve target, boolean schemas return as is.
+  // Resolve target, boolean schemas return as is.
   const target = ResolveRef(context.context, context.schema, schema.$ref)
   if (S.IsSchemaBoolean(target)) return target
-  // check if target is resolving, if not, resolve
+  // Check if target is resolving, if not, resolve
   const pending = context.resolving.get(target)
   if (Guard.IsUndefined(pending)) return FromSchema(context, target)
-  // target is mid-conversion, so this is a cycle (point at its reserved placeholder)
+  // Target is mid-intern, so this is a cycle (point at its reserved placeholder)
   pending.used = true
   return { $ref: `#/$defs/${pending.key}` }
 }
@@ -236,7 +236,6 @@ function FromSchemaObject(context: RefContext, schema: S.XSchemaObject): S.XSche
     ...(S.IsUnevaluatedItems(schema) ? { unevaluatedItems: FromUnevaluatedItems(context, schema) } : {}),
     ...(S.IsUnevaluatedProperties(schema) ? { unevaluatedProperties: FromUnevaluatedProperties(context, schema) } : {})
   }
-
   context.resolving.delete(schema)
 
   // Finalize and register the result
@@ -275,8 +274,8 @@ function BooleanIntern(schema: S.XSchemaBoolean): S.XSchemaObject {
   return { $ref: `#/$defs/${HashKey(schema)}`, $defs: { [HashKey(schema)]: schema } }
 }
 /**
- * (Experimental) Performs a Common Subexpression Elimination-like transform on the given schema. It restructures the schema such that each distinct sub-schema is stored exactly once in a
- * `$defs` object, keyed by its content hash. This function can be used to compress and optimize schematics prior to compilation.
+ * [Experimental] Performs a Common Subexpression Elimination (CSE) transform on the given schema. This function restructures the schema such that each distinct sub-schema is stored exactly once in a
+ * $defs object, keyed by its content hash. The result of Intern(...) is a canonical referential schema, and repeated calls are idempotent. This function can be used to both compress and optimize schemas prior to compilation. 
  */
 export function Intern<const Schema extends S.XSchema>(schema: Schema): XIntern<XStatic<Schema>> {
   registry.clear()

--- a/src/schema/intern/intern.ts
+++ b/src/schema/intern/intern.ts
@@ -56,8 +56,7 @@ function HashKey(schema: S.XSchema): string {
 interface RefContext {
   context: Record<string, S.XSchema>
   schema: S.XSchemaObject
-  entry: S.XSchemaObject
-  cyclic: boolean
+  resolving: Map<S.XSchema, { key: string; used: boolean }>
 }
 // ----------------------------------------------------------------
 // AdditionalItems
@@ -168,17 +167,15 @@ function ResolveRef(context: Record<string, S.XSchema>, schema: S.XSchemaObject,
   return Resolve.Ref(context, schema, ref) ?? UnresolvableRef(ref)
 }
 function FromRef(context: RefContext, schema: S.XRef): S.XSchema {
+  // resolve target, boolean schemas return as is.
   const target = ResolveRef(context.context, context.schema, schema.$ref)
-  if (Guard.IsEqual(target, context.entry) && context.cyclic) return { $ref: '#' }
-  const existing = resolved.get(target)
-  if (!Guard.IsUndefined(existing)) return existing
-  const isRoot = Guard.IsEqual(target, context.entry)
-  if (isRoot) context.cyclic = true
-  const reserved: S.XSchema = isRoot ? { $ref: '#' } : { $ref: `#/$defs/x-ref-${counter++}` }
-  resolved.set(target, reserved)
-  const converted = FromSchema(context, target)
-  if (!isRoot) registry.set((reserved as { $ref: string }).$ref.slice('#/$defs/'.length), converted as S.XSchemaObject)
-  return isRoot ? converted : reserved
+  if (S.IsSchemaBoolean(target)) return target
+  // check if target is resolving, if not, resolve
+  const pending = context.resolving.get(target)
+  if (Guard.IsUndefined(pending)) return FromSchema(context, target)
+  // target is mid-conversion, so this is a cycle (point at its reserved placeholder)
+  pending.used = true
+  return { $ref: `#/$defs/${pending.key}` }
 }
 // ----------------------------------------------------------------
 // Then
@@ -202,12 +199,22 @@ function FromUnevaluatedProperties(context: RefContext, schema: S.XUnevaluatedPr
 // SchemaObject
 // ----------------------------------------------------------------
 function FromSchemaObject(context: RefContext, schema: S.XSchemaObject): S.XSchema {
-  // unsupported
+  // Reference schemas cannot contain other keywords
+  if (S.IsRef(schema)) return FromRef(context, schema)
+
+  // Check if the schema has already been resolved
+  const existing = resolved.get(schema)
+  if (!Guard.IsUndefined(existing)) return existing
+
+  // These keywords are unsupported
   if (S.IsDynamicRef(schema)) UnsupportedKeyword('$dynamicRef')
   if (S.IsRecursiveRef(schema)) UnsupportedKeyword('$recursiveRef')
-  // reference
-  if (S.IsRef(schema)) return FromRef(context, schema)
-  // remapped
+
+  // Reserve a placeholder key in case a nested ref cycles back to this schema
+  const reservation = { key: `x-ref-${context.resolving.size}`, used: false }
+  context.resolving.set(schema, reservation)
+
+  // Intern each subschema
   const remapped = {
     ...(S.IsRefine(schema) ? { ['~refine']: schema['~refine'] } : {}),
     ...(S.IsAdditionalItems(schema) ? { additionalItems: FromAdditionalItems(context, schema) } : {}),
@@ -229,31 +236,30 @@ function FromSchemaObject(context: RefContext, schema: S.XSchemaObject): S.XSche
     ...(S.IsUnevaluatedItems(schema) ? { unevaluatedItems: FromUnevaluatedItems(context, schema) } : {}),
     ...(S.IsUnevaluatedProperties(schema) ? { unevaluatedProperties: FromUnevaluatedProperties(context, schema) } : {})
   }
+
+  context.resolving.delete(schema)
+
+  // Finalize and register the result
   const interned = Memory.Discard(Memory.Assign(schema, remapped), ['$id'])
-  const hashkey = HashKey(interned)
-  registry.set(hashkey, interned)
-  return { $ref: `#/$defs/${hashkey}` }
-}
-// ----------------------------------------------------------------
-// SchemaBoolean
-// ----------------------------------------------------------------
-function FromSchemaBoolean(schema: S.XSchemaBoolean): S.XSchema {
-  return schema
+  const key = reservation.used ? reservation.key : HashKey(interned)
+  registry.set(key, interned)
+
+  const result: S.XSchema = { $ref: `#/$defs/${key}` }
+  resolved.set(schema, result)
+  return result
 }
 // ----------------------------------------------------------------
 // Schema
 // ----------------------------------------------------------------
 function FromSchema(context: RefContext, schema: S.XSchema): S.XSchema {
-  return (
-    S.IsSchemaBoolean(schema) ? FromSchemaBoolean(schema) : FromSchemaObject(context, schema)
-  )
+  return S.IsSchemaBoolean(schema) ? schema : FromSchemaObject(context, schema)
 }
+
 // ----------------------------------------------------------------
 // Module-level accumulator state
 // ----------------------------------------------------------------
 const registry = new Map<string, S.XSchemaObject>()
 const resolved = new Map<S.XSchema, S.XSchema>()
-let counter = 0
 // ----------------------------------------------------------------
 // XIntern
 // ----------------------------------------------------------------
@@ -269,19 +275,17 @@ function BooleanIntern(schema: S.XSchemaBoolean): S.XSchemaObject {
   return { $ref: `#/$defs/${HashKey(schema)}`, $defs: { [HashKey(schema)]: schema } }
 }
 /**
- * (Experimental) Performs a [Common Subexpression Elimination](https://en.wikipedia.org/wiki/Common_subexpression_elimination)-like
- * transform on the given schema. It restructures the schema such that each distinct sub-schema is stored exactly once in a
+ * (Experimental) Performs a Common Subexpression Elimination-like transform on the given schema. It restructures the schema such that each distinct sub-schema is stored exactly once in a
  * `$defs` object, keyed by its content hash. This function can be used to compress and optimize schematics prior to compilation.
  */
 export function Intern<const Schema extends S.XSchema>(schema: Schema): XIntern<XStatic<Schema>> {
   registry.clear()
   resolved.clear()
-  counter = 0
   if (S.IsSchemaBoolean(schema)) return BooleanIntern(schema) as never
   const context = S.IsDefs(schema) ? schema.$defs : {}
   const entry = S.IsRef(schema) ? ResolveRef(context, schema, schema.$ref) : schema
   if (S.IsSchemaBoolean(entry)) return BooleanIntern(entry) as never
-  const ref_context: RefContext = { schema, context, entry, cyclic: false }
-  const result = FromSchema(ref_context, schema) as { $ref: string }
+  const ref_context: RefContext = { schema, context, resolving: new Map() }
+  const result = FromSchema(ref_context, entry) as { $ref: string }
   return { $ref: result.$ref, $defs: Object.fromEntries(registry) } as never
 }

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.3.24'
+const Version = '1.3.25'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/schema/intern/intern.ts
+++ b/test/typebox/runtime/schema/intern/intern.ts
@@ -4,9 +4,16 @@ import Schema, { Intern } from 'typebox/schema'
 const Test = Assert.Context('Schema.Intern')
 
 // ------------------------------------------------------------------
+// Identity Check
+// ------------------------------------------------------------------
+function Identity(a: Schema.XSchema): void {
+  Assert.IsEqual(Intern(a), Intern(Intern(a)))
+}
+// ------------------------------------------------------------------
 // Parity Check
 // ------------------------------------------------------------------
-function Parity(a: Schema.XSchema, value: unknown) {
+function Parity(a: Schema.XSchema, value: unknown): boolean {
+  Identity(a)
   const b = Intern(a)
   const R1 = Schema.Compile(a).Check(value)
   const R2 = Schema.Compile(b).Check(value)

--- a/test/typebox/runtime/schema/intern/intern.ts
+++ b/test/typebox/runtime/schema/intern/intern.ts
@@ -838,34 +838,34 @@ Test('Should Intern 124', () => {
 // ----------------------------------------------------------------
 Test('Should Intern 124', () => {
   const A = {
-    $defs: { condition: true },
-    $ref: '#/$defs/condition'
+    $defs: { foo: true },
+    $ref: '#/$defs/foo'
   }
   Ok(A, 1)
 })
-Test('Should Intern 124', () => {
+Test('Should Intern 125', () => {
   const A = {
-    $defs: { condition: false },
-    $ref: '#/$defs/condition'
+    $defs: { foo: false },
+    $ref: '#/$defs/foo'
   }
   Fail(A, 1)
 })
 // ----------------------------------------------------------------
 // UnsupportedKeyword
 // ----------------------------------------------------------------
-Test('Should Intern 125', () => {
+Test('Should Intern 128', () => {
   Assert.Throws(() => Schema.Intern({ $dynamicRef: 'x' }))
 })
-Test('Should Intern 126', () => {
+Test('Should Intern 129', () => {
   Assert.Throws(() => Schema.Intern({ $recursiveRef: 'x' }))
 })
 // ----------------------------------------------------------------
 // UnresolvableRef
 // ----------------------------------------------------------------
-Test('Should Intern 127', () => {
+Test('Should Intern 130', () => {
   Assert.Throws(() => Schema.Intern({ $ref: 'unresolvable' }))
 })
-Test('Should Intern 128', () => {
+Test('Should Intern 131', () => {
   Assert.Throws(() =>
     Schema.Intern({
       $defs: {
@@ -874,4 +874,116 @@ Test('Should Intern 128', () => {
       $ref: '#/defs/A'
     })
   )
+})
+// ----------------------------------------------------------------
+// Multi-Ref-Indirection
+// ----------------------------------------------------------------
+Test('Should Intern 132', () => {
+  const A = {
+    $defs: {
+      foo: { $ref: '#/$defs/bar' },
+      bar: true
+    },
+    $ref: '#/$defs/foo'
+  }
+  Ok(A, 1)
+})
+Test('Should Intern 133', () => {
+  const A = {
+    $defs: {
+      foo: { $ref: '#/$defs/bar' },
+      bar: false
+    },
+    $ref: '#/$defs/foo'
+  }
+  Fail(A, 1)
+})
+Test('Should Intern 134', () => {
+  // 2 levels of indirection
+  const A = {
+    $defs: {
+      a: { $ref: '#/$defs/b' },
+      b: { type: 'number' }
+    },
+    $ref: '#/$defs/a'
+  }
+  Ok(A, 1)
+  Fail(A, 'hello')
+})
+Test('Should Intern 135', () => {
+  // 3 levels of indirection
+  const A = {
+    $defs: {
+      a: { $ref: '#/$defs/b' },
+      b: { $ref: '#/$defs/c' },
+      c: { type: 'string' }
+    },
+    $ref: '#/$defs/a'
+  }
+  Ok(A, 'hello')
+  Fail(A, 123)
+})
+Test('Should Intern 136', () => {
+  // 4 levels of indirection
+  const A = {
+    $defs: {
+      a: { $ref: '#/$defs/b' },
+      b: { $ref: '#/$defs/c' },
+      c: { $ref: '#/$defs/d' },
+      d: { type: 'boolean' }
+    },
+    $ref: '#/$defs/a'
+  }
+  Ok(A, true)
+  Fail(A, 'true')
+})
+Test('Should Intern 137', () => {
+  // 4 levels of indirection pointing to an object schema
+  const A = {
+    $defs: {
+      a: { $ref: '#/$defs/b' },
+      b: { $ref: '#/$defs/c' },
+      c: { $ref: '#/$defs/d' },
+      d: { type: 'object', properties: { x: { type: 'number' } }, required: ['x'] }
+    },
+    $ref: '#/$defs/a'
+  }
+  Ok(A, { x: 1 })
+  Fail(A, { x: '1' })
+})
+// ----------------------------------------------------------------
+// Pathological: Indirect Mutual Cycles + Shared Subexpressions
+// ----------------------------------------------------------------
+Test('Should Intern 138', () => {
+  const A = {
+    $defs: {
+      A: { $ref: '#/$defs/B' },
+      B: { $ref: '#/$defs/C' },
+      C: {
+        type: 'object',
+        properties: {
+          val: { $ref: '#/$defs/H' },
+          next: { $ref: '#/$defs/D' }
+        },
+        required: ['val']
+      },
+      D: { $ref: '#/$defs/E' },
+      E: {
+        type: 'object',
+        properties: {
+          val: { $ref: '#/$defs/H' },
+          next: { $ref: '#/$defs/F' }
+        },
+        required: ['val']
+      },
+      F: { $ref: '#/$defs/G' },
+      G: { $ref: '#/$defs/C' },
+      H: { $ref: '#/$defs/I' },
+      I: { type: 'number' }
+    },
+    $ref: '#/$defs/A'
+  }
+  Ok(A, { val: 1, next: { val: 2, next: { val: 3 } } })
+  Fail(A, { val: 'invalid' })
+  Fail(A, { val: 1, next: { val: 'invalid' } })
 })

--- a/test/typebox/runtime/schema/intern/intern.ts
+++ b/test/typebox/runtime/schema/intern/intern.ts
@@ -4,16 +4,16 @@ import Schema, { Intern } from 'typebox/schema'
 const Test = Assert.Context('Schema.Intern')
 
 // ------------------------------------------------------------------
-// Identity Check
+// Idempotent Check
 // ------------------------------------------------------------------
-function Identity(a: Schema.XSchema): void {
+function Idempotent(a: Schema.XSchema): void {
   Assert.IsEqual(Intern(a), Intern(Intern(a)))
 }
 // ------------------------------------------------------------------
 // Parity Check
 // ------------------------------------------------------------------
 function Parity(a: Schema.XSchema, value: unknown): boolean {
-  Identity(a)
+  Idempotent(a)
   const b = Intern(a)
   const R1 = Schema.Compile(a).Check(value)
   const R2 = Schema.Compile(b).Check(value)


### PR DESCRIPTION
This PR is an update to `Intern(...)` to ensure that recurrent calls (such as `Intern(Intern(...))`) are idempotent. This PR also corrects an unnecessary array slice(...) call for localized error mapping (added in the 1.3.24 update).

## Intern Update

This update fixes an issue where resolver markers were incorrectly appearing in the output when making recurrent calls to `Intern(...)`. The output below shows the before and after comparison.

```typescript
const T = Type.Object({
  x: Type.Number(),
  y: Type.Number()
})
const A = Schema.Intern(T)
const B = Schema.Intern(Schema.Intern(T))
console.log({ A, B })

// ----------------------------------------------------------
// Version 1.3.24
// ----------------------------------------------------------
{
  A: {
    "$ref": "#/$defs/x-9cd1a120fd4b8736",
    "$defs": {
      "x-b3d1b3fb56d0fb6e": { type: "number" },
      "x-9cd1a120fd4b8736": {
        type: "object",
        required: [ "x", "y" ],
        properties: { x: [Object], y: [Object] }
      }
    }
  },
  B: {
    "$ref": "#/$defs/x-eb035f82a21c5d14",
    "$defs": {
      "x-b3d1b3fb56d0fb6e": { type: "number" },
      "x-ref-0": { "$ref": "#/$defs/x-b3d1b3fb56d0fb6e" }, // <- x-ref-0 marker shouldn't be here
      "x-eb035f82a21c5d14": {
        type: "object",
        required: [ "x", "y" ],
        properties: { x: [Object], y: [Object] }
      }
    }
  }
}
// ----------------------------------------------------------
// Version 1.3.25
// ----------------------------------------------------------
{
  A: {
    "$ref": "#/$defs/x-9cd1a120fd4b8736",
    "$defs": {
      "x-b3d1b3fb56d0fb6e": { type: "number" },
      "x-9cd1a120fd4b8736": {
        type: "object",
        required: [ "x", "y" ],
        properties: { x: [Object], y: [Object] }
      }
    }
  },
  B: {
    "$ref": "#/$defs/x-9cd1a120fd4b8736",
    "$defs": {
      "x-b3d1b3fb56d0fb6e": { type: "number" },
      "x-9cd1a120fd4b8736": {
        type: "object",
        required: [ "x", "y" ],
        properties: { x: [Object], y: [Object] }
      }
    }
  }
}
```

## Additional Notes

There is still an outstanding issue to resolve regarding mutually recursive schemas coming back with `x-ref-(n)` markers instead of a content-hashed `$ref`. The issue relates to the algorithm's cycle detection handling, and there isn't a clear solution without running a post-processing pass. However, the idempotency issue is resolved by this PR. I will address mutually recursive content-hashing in a subsequent revision (review)