### PR TITLE
Version 1.3.29

### DIFF
--- a/changelog/1.3.0.md
+++ b/changelog/1.3.0.md
@@ -4,6 +4,8 @@
 ---
 
 ### Version Updates
+- [Revision 1.3.29](https://github.com/sinclairzx81/typebox/pull/1685)
+  - Optimize Ref, RecursiveRef and DynamicRef
 - [Revision 1.3.28](https://github.com/sinclairzx81/typebox/pull/1684)
   - Add Meta Schema Sub Module
 - [Revision 1.3.27](https://github.com/sinclairzx81/typebox/pull/1683)

--- a/design/website/docs/schema/1_coverage.md
+++ b/design/website/docs/schema/1_coverage.md
@@ -1,10 +1,10 @@
 # Schema.Coverage
 
-TypeBox has broad coverage for all major JSON Schema drafts and is verified against the [Official JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite). TypeBox uses a progressive adoption strategy where legacy specifications are supported wherever they can be reconciled with the modern specification. Where they cannot, the modern specification takes precedence.
+TypeBox has broad support for all JSON Schema drafts and is heavily tested against the [Official JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite). TypeBox targets modern versions of the specification, but supports legacy drafts as well: legacy semantics are honored unless they conflict with a modern specification, in which case the modern behavior takes precedence.
 
-> ⚠️ TypeBox does not require a specific draft version by default; it will accept schematics from any supported draft. If an implementation needs to mandate a specific draft, use the Schema.Meta namespace to validate schematics against that draft version. TypeBox treats meta schema validation the same as ordinary schema validation, allowing developers to progressively upgrade to modern specifications without exhaustive schema rewrites.
+> ⚠️ TypeBox will accept schematics from any JSON Schema draft. If an application needs to enforce a specific draft, use `Schema.Meta` to validate schematics against that draft.
 
-The following shows test coverage for each draft.
+The table below shows test coverage per draft. Failing tests in legacy drafts are expected where legacy semantics conflict with modern drafts.
 
 ## Required Keywords
 
@@ -29,7 +29,6 @@ The following shows test coverage for each draft.
 | enum | 16/18 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | exclusiveMaximum | - | - | ✅ | ✅ | ✅ | ✅ | ✅ |
 | exclusiveMinimum | - | - | ✅ | ✅ | ✅ | ✅ | ✅ |
-| format | ✅ | ✅ | ✅ | ✅ | ✅ | 114/133 | - |
 | if-then-else | - | - | - | ✅ | ✅ | ✅ | ✅ |
 | infinite-loop-detection | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | items | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/design/website/docs/schema/6_meta.md
+++ b/design/website/docs/schema/6_meta.md
@@ -8,12 +8,12 @@ JSON Schema is JSON like any other, and can be validated the same way. TypeBox i
 
 TypeBox provides inline definitions for the following JSON Schema draft meta schemas, also available at these URLs:
 
-- [Draft 3](http://json-schema.org/draft-03/schema#)
-- [Draft 4](http://json-schema.org/draft-04/schema#)
-- [Draft 6](http://json-schema.org/draft-06/schema#)
-- [Draft 7](http://json-schema.org/draft-07/schema#)
-- [Draft 2019-09](https://json-schema.org/draft/2019-09/schema)
 - [Draft 2020-12](https://json-schema.org/draft/2020-12/schema)
+- [Draft 2019-09](https://json-schema.org/draft/2019-09/schema)
+- [Draft 7](http://json-schema.org/draft-07/schema#)
+- [Draft 6](http://json-schema.org/draft-06/schema#)
+- [Draft 4](http://json-schema.org/draft-04/schema#)
+- [Draft 3](http://json-schema.org/draft-03/schema#)
 
 ### Usage
 

--- a/docs/docs/schema/1_coverage.html
+++ b/docs/docs/schema/1_coverage.html
@@ -1,9 +1,9 @@
 <h1>Schema.Coverage</h1>
-<p>TypeBox has broad coverage for all major JSON Schema drafts and is verified against the <a href="https://github.com/json-schema-org/JSON-Schema-Test-Suite">Official JSON Schema Test Suite</a>. TypeBox uses a progressive adoption strategy where legacy specifications are supported wherever they can be reconciled with the modern specification. Where they cannot, the modern specification takes precedence.</p>
+<p>TypeBox has broad support for all JSON Schema drafts and is heavily tested against the <a href="https://github.com/json-schema-org/JSON-Schema-Test-Suite">Official JSON Schema Test Suite</a>. TypeBox targets modern versions of the specification, but supports legacy drafts as well: legacy semantics are honored unless they conflict with a modern specification, in which case the modern behavior takes precedence.</p>
 <blockquote>
-<p>⚠️ TypeBox does not require a specific draft version by default; it will accept schematics from any supported draft. If an implementation needs to mandate a specific draft, use the Schema.Meta namespace to validate schematics against that draft version. TypeBox treats meta schema validation the same as ordinary schema validation, allowing developers to progressively upgrade to modern specifications without exhaustive schema rewrites.</p>
+<p>⚠️ TypeBox will accept schematics from any JSON Schema draft. If an application needs to enforce a specific draft, use <code>Schema.Meta</code> to validate schematics against that draft.</p>
 </blockquote>
-<p>The following shows test coverage for each draft.</p>
+<p>The table below shows test coverage per draft. Failing tests in legacy drafts are expected where legacy semantics conflict with modern drafts.</p>
 <h2>Required Keywords</h2>
 <table>
 <thead>
@@ -207,16 +207,6 @@
 <td align="left">✅</td>
 <td align="left">✅</td>
 <td align="left">✅</td>
-</tr>
-<tr>
-<td align="left">format</td>
-<td align="left">✅</td>
-<td align="left">✅</td>
-<td align="left">✅</td>
-<td align="left">✅</td>
-<td align="left">✅</td>
-<td align="left">114/133</td>
-<td align="left">-</td>
 </tr>
 <tr>
 <td align="left">if-then-else</td>

--- a/docs/docs/schema/6_meta.html
+++ b/docs/docs/schema/6_meta.html
@@ -6,12 +6,12 @@
 <h3>Meta Schema Definitions</h3>
 <p>TypeBox provides inline definitions for the following JSON Schema draft meta schemas, also available at these URLs:</p>
 <ul>
-<li><a href="http://json-schema.org/draft-03/schema#">Draft 3</a></li>
-<li><a href="http://json-schema.org/draft-04/schema#">Draft 4</a></li>
-<li><a href="http://json-schema.org/draft-06/schema#">Draft 6</a></li>
-<li><a href="http://json-schema.org/draft-07/schema#">Draft 7</a></li>
-<li><a href="https://json-schema.org/draft/2019-09/schema">Draft 2019-09</a></li>
 <li><a href="https://json-schema.org/draft/2020-12/schema">Draft 2020-12</a></li>
+<li><a href="https://json-schema.org/draft/2019-09/schema">Draft 2019-09</a></li>
+<li><a href="http://json-schema.org/draft-07/schema#">Draft 7</a></li>
+<li><a href="http://json-schema.org/draft-06/schema#">Draft 6</a></li>
+<li><a href="http://json-schema.org/draft-04/schema#">Draft 4</a></li>
+<li><a href="http://json-schema.org/draft-03/schema#">Draft 3</a></li>
 </ul>
 <h3>Usage</h3>
 <p>The example below parses a schema as Draft 2020-12, then validates a value against it. The meta schema is selected by its <code>$schema</code> identifier.</p>

--- a/readme.md
+++ b/readme.md
@@ -231,7 +231,7 @@ const result = Vector.Parse({ x: 1, y: 0, z: 0 })  // const result: {
 
 [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite) | [JSON Schema Compliance Suite](https://github.com/sinclairzx81/json-schema-compliance-suite)
 
-TypeBox supports all major JSON Schema draft versions and tracks compliance against the official JSON Schema Test Suite. It also maintains a separate JavaScript compliance suite to track ecosystem adoption as JSON Schema moves toward the V1 candidate. The following table shows TypeBox specification coverage.
+TypeBox has broad support for all JSON Schema drafts and is heavily tested against the official JSON Schema Test Suite. TypeBox targets modern versions of the specification, but supports legacy drafts as well: legacy semantics are honored unless they conflict with a modern specification, in which case the modern behavior takes precedence.
 
 | Spec | 3 | 4 | 6 | 7 | 2019-09 | 2020-12 | v1 |
 |:-----|:--|:--|:--|:--|:--|:--|:--|
@@ -254,7 +254,6 @@ TypeBox supports all major JSON Schema draft versions and tracks compliance agai
 | enum | 16/18 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | exclusiveMaximum | - | - | ✅ | ✅ | ✅ | ✅ | ✅ |
 | exclusiveMinimum | - | - | ✅ | ✅ | ✅ | ✅ | ✅ |
-| format | ✅ | ✅ | ✅ | ✅ | ✅ | 114/133 | - |
 | if-then-else | - | - | - | ✅ | ✅ | ✅ | ✅ |
 | infinite-loop-detection | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | items | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -287,43 +286,47 @@ TypeBox supports all major JSON Schema draft versions and tracks compliance agai
 
 ### Performance
 
-TypeBox tracks comparative performance against AJV8 as the de facto performance standard. For broader comparative benchmarks, refer to the community maintained projects below.
+TypeBox tracks performance against AJV8 only as the defacto performance standard. For broader comparative benchmarks, refer to the following community maintained projects.
 
 [Runtime Benchmarks](https://moltar.github.io/typescript-runtime-type-benchmarks/) | [Schema Benchmarks](https://schemabenchmarks.dev/)
 
-The following table shows compilation performance for various JSON Schema structures. These benchmarks measure the time required to JIT compile schematics, with faster compilation resulting in faster application startup.
+### Compile
+
+The following table shows compile performance for various JSON Schema structures. These benchmarks measure the time required to build and runtime JIT schematics. Faster compilation results in faster application startup.
 
 ```python
 ┌──────────────────────┬──────────────┬──────────────┐
 │ Compile              │ TB1X         │ AJV8         │
 ├──────────────────────┼──────────────┼──────────────┤
-│ Boolean              │  50.4K ops/s │   7.1K ops/s │
-│ Number               │ 129.9K ops/s │   7.9K ops/s │
-│ String               │ 128.9K ops/s │   9.1K ops/s │
-│ Null                 │  91.3K ops/s │   8.4K ops/s │
-│ Literal_String       │  63.1K ops/s │   7.4K ops/s │
-│ Literal_Number       │  74.5K ops/s │   7.6K ops/s │
-│ Literal_Boolean      │ 143.3K ops/s │   7.7K ops/s │
-│ Pattern              │  94.2K ops/s │   6.4K ops/s │
-│ Object_Open          │  19.4K ops/s │   1.3K ops/s │
-│ Object_Close         │  17.6K ops/s │    991 ops/s │
-│ Object_Vector3       │  46.1K ops/s │   3.3K ops/s │
-│ Object_Basis3        │    16K ops/s │    848 ops/s │
-│ Intersect_And        │  41.3K ops/s │   4.2K ops/s │
-│ Intersect_Structural │  25.3K ops/s │   1.5K ops/s │
-│ Union_Or             │  58.6K ops/s │   2.4K ops/s │
-│ Union_Structural     │  31.5K ops/s │   1.8K ops/s │
-│ Tuple_Values         │  18.2K ops/s │   1.9K ops/s │
-│ Tuple_Objects        │   3.9K ops/s │    437 ops/s │
-│ Array_Numbers_4      │ 114.5K ops/s │   4.2K ops/s │
-│ Array_Numbers_8      │ 128.3K ops/s │   3.9K ops/s │
-│ Array_Numbers_16     │ 128.4K ops/s │     4K ops/s │
-│ Array_Objects_Open   │    22K ops/s │    780 ops/s │
-│ Array_Objects_Close  │    22K ops/s │     1K ops/s │
+│ Boolean              │  54.9K ops/s │     7K ops/s │
+│ Number               │ 154.2K ops/s │   7.8K ops/s │
+│ String               │ 161.4K ops/s │   9.7K ops/s │
+│ Null                 │ 111.9K ops/s │   8.9K ops/s │
+│ Literal_String       │  34.6K ops/s │   7.5K ops/s │
+│ Literal_Number       │  78.1K ops/s │   7.6K ops/s │
+│ Literal_Boolean      │  79.7K ops/s │   8.4K ops/s │
+│ Pattern              │  92.1K ops/s │   6.1K ops/s │
+│ Object_Open          │  18.6K ops/s │   1.3K ops/s │
+│ Object_Close         │    17K ops/s │    975 ops/s │
+│ Object_Vector3       │  33.3K ops/s │   3.4K ops/s │
+│ Object_Basis3        │  18.9K ops/s │    858 ops/s │
+│ Intersect_And        │  63.5K ops/s │   3.6K ops/s │
+│ Intersect_Structural │  25.7K ops/s │   1.7K ops/s │
+│ Union_Or             │  58.2K ops/s │   3.3K ops/s │
+│ Union_Structural     │  33.7K ops/s │     2K ops/s │
+│ Tuple_Values         │  19.5K ops/s │     2K ops/s │
+│ Tuple_Objects        │     4K ops/s │    388 ops/s │
+│ Array_Numbers_4      │  90.7K ops/s │   4.3K ops/s │
+│ Array_Numbers_8      │ 121.8K ops/s │   3.8K ops/s │
+│ Array_Numbers_16     │ 116.6K ops/s │   3.9K ops/s │
+│ Array_Objects_Open   │  22.6K ops/s │    802 ops/s │
+│ Array_Objects_Close  │  18.4K ops/s │    930 ops/s │
 └──────────────────────┴──────────────┴──────────────┘
 ```
 
-The following tables shows validation performance for various JSON Schema structures. These benchmarks measure overall validation throughput for JIT compiled schematics.
+### Validate
+
+The following table shows validation performance for various JSON Schema structures. These benchmarks measure overall validation throughput for compiled schematics.
 
 ```python
 ┌──────────────────────┬──────────────┬──────────────┐

--- a/src/schema/build.ts
+++ b/src/schema/build.ts
@@ -36,6 +36,7 @@ import { Guard } from '../guard/index.ts'
 import { Format } from '../format/index.ts'
 
 import * as Engine from './engine/index.ts'
+import * as Resolve from './resolve/index.ts'
 import * as Schema from './types/index.ts'
 
 // ------------------------------------------------------------------
@@ -59,7 +60,7 @@ function CreateEvaluatedCheck(build: BuildResult, code: string): CheckFunction {
 // CreateDynamicCheck
 // ------------------------------------------------------------------
 function CreateDynamicCheck(build: BuildResult): CheckFunction {
-  const stack = new Engine.Stack(build.Context(), build.Schema())
+  const stack = Engine.Stack(build.Context(), build.Schema())
   const context = new Engine.CheckContext()
   return (value: unknown) => Engine.CheckSchema(stack, context, build.Schema(), value)
 }
@@ -153,7 +154,7 @@ export function Build(...args: unknown[]): BuildResult {
   })
   Engine.ResetExternal()
   Engine.ResetFunctions()
-  const stack = new Engine.Stack(context, schema)
+  const stack = Engine.Stack(context, schema)
   const build = new Engine.BuildContext(Engine.HasUnevaluated(context, schema))
   const call = Engine.CreateFunction(stack, build, schema, 'value')
   const functions = Engine.GetFunctions()

--- a/src/schema/check.ts
+++ b/src/schema/check.ts
@@ -33,6 +33,7 @@ import { Arguments } from '../system/arguments/index.ts'
 import { type Static } from '../type/types/static.ts'
 import * as Engine from './engine/index.ts'
 import * as Schema from './types/index.ts'
+
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
@@ -46,7 +47,7 @@ export function Check(...args: unknown[]): boolean {
     3: (context, schema, value) => [context, schema, value],
     2: (schema, value) => [{}, schema, value]
   })
-  const stack = new Engine.Stack(context, schema)
+  const stack = Engine.Stack(context, schema)
   const checkContext = new Engine.CheckContext()
   return Engine.CheckSchema(stack, checkContext, schema, value)
 }

--- a/src/schema/engine/_context.ts
+++ b/src/schema/engine/_context.ts
@@ -148,14 +148,27 @@ export class ErrorContext extends CheckContext {
     super()
     this.errors = []
   }
+  // ----------------------------------------------------------------
+  // Public
+  // ----------------------------------------------------------------
   public AtCapacity(): boolean {
     return this.errors.length >= Settings.Get().maxErrors
   }
-  public AddError(error: TValidationError): false {
-    if(!this.AtCapacity()) this.errors.push(error)
+  public AddError<Keyword extends TValidationError['keyword']>(keyword: Keyword, schemaPath: string, instancePath: string, params: Extract<TValidationError, { keyword: Keyword }>['params']): false {
+    return this.AddErrorObject({ keyword, schemaPath, instancePath, params } as TValidationError)
+  }
+  public AddErrors(error: TValidationError[]): false {
+    error.forEach(error => this.AddErrorObject(error))
     return false
   }
   public GetErrors(): TValidationError[] {
     return this.errors
+  }
+  // ----------------------------------------------------------------
+  // Private
+  // ----------------------------------------------------------------
+  private AddErrorObject(error: TValidationError): false {
+    if (!this.AtCapacity()) this.errors.push(error)
+    return false
   }
 }

--- a/src/schema/engine/_functions.ts
+++ b/src/schema/engine/_functions.ts
@@ -29,10 +29,11 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext } from './_context.ts'
 import { EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchema } from './schema.ts'
+
 
 // ------------------------------------------------------------------
 // State
@@ -69,7 +70,7 @@ function CreateCallExpression(context: BuildContext, _schema: Schema.XSchema, na
 // ------------------------------------------------------------------
 // CreateFunctionExpression
 // ------------------------------------------------------------------
-function CreateFunctionExpression(stack: Stack, context: BuildContext, schema: Schema.XSchema, name: string): string {
+function CreateFunctionExpression(stack: Stack.XStack, context: BuildContext, schema: Schema.XSchema, name: string): string {
   const expression = BuildSchema(stack, context, schema, 'value')
   return context.UseUnevaluated()
     ? E.ConstDeclaration(`check_${name}`, E.ArrowFunction(['context', 'value'], expression))
@@ -92,8 +93,8 @@ export function GetFunctions(): string[] {
 // ------------------------------------------------------------------
 // CreateFunction
 // ------------------------------------------------------------------
-export function CreateFunction(stack: Stack, context: BuildContext, schema: Schema.XSchema, value: string): string {
-  const name = CreateName(schema, stack.LexicalBaseURL() as Href)
+export function CreateFunction(stack: Stack.XStack, context: BuildContext, schema: Schema.XSchema, value: string): string {
+  const name = CreateName(schema, stack.lexicalBase as Href)
   const call = CreateCallExpression(context, schema, name, value)
   if (funcs.has(name)) return call
   funcs.set(name, '')

--- a/src/schema/engine/_reducer.ts
+++ b/src/schema/engine/_reducer.ts
@@ -28,8 +28,8 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import * as S from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Schema from '../types/index.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext } from './_context.ts'
 import { EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchema } from './schema.ts'
@@ -68,7 +68,7 @@ import { BuildSchema } from './schema.ts'
 // })()
 //
 // ------------------------------------------------------------------
-export function Reducer(stack: Stack, context: BuildContext, schemas: S.XSchema[], value: string, check: string): string {
+export function Reducer(stack: Stack.XStack, context: BuildContext, schemas: Schema.XSchema[], value: string, check: string): string {
   const results = E.ConstDeclaration('results', '[]')
   const context_n = schemas.map((_schema, index) => E.ConstDeclaration(`context_${index}`, E.New('CheckContext', [])))
   const condition_n = schemas.map((schema, index) => E.ConstDeclaration(`condition_${index}`, E.Call(E.ArrowFunction(['context'], BuildSchema(stack, context, schema, value)), [`context_${index}`])))

--- a/src/schema/engine/_refine.ts
+++ b/src/schema/engine/_refine.ts
@@ -28,35 +28,32 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import * as S from '../types/index.ts'
-import * as V from './_externals.ts'
-import { Stack } from './_stack.ts'
+import * as Schema from '../types/index.ts'
+import * as Stack from './_stack.ts'
+import * as Externals from './_externals.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildRefine(_stack: Stack, _context: BuildContext, schema: S.XRefine, value: string): string {
-  const refinements = V.CreateVariable(schema['~refine'].map((refinement) => refinement))
+export function BuildRefine(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XRefine, value: string): string {
+  const refinements = Externals.CreateVariable(schema['~refine'].map((refinement) => refinement))
   return E.Every(refinements, E.Constant(0), ['refinement', '_'], E.Call(E.Member('refinement', 'check'), [value]))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckRefine(_stack: Stack, _context: CheckContext, schema: S.XRefine, value: unknown): boolean {
+export function CheckRefine(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XRefine, value: unknown): boolean {
   return G.Every(schema['~refine'], 0, (refinement, _) => refinement.check(value))
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorRefine(_stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: S.XRefine, value: unknown): boolean {
+export function ErrorRefine(_stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XRefine, value: unknown): boolean {
   return G.EveryAll(schema['~refine'], 0, (refinement, index) => {
-    return refinement.check(value) || context.AddError({
-      keyword: '~refine',
-      schemaPath,
-      instancePath,
-      params: { index, message: refinement.error(value) },
+    return refinement.check(value) || context.AddError('~refine', schemaPath, instancePath, {
+      index, message: refinement.error(value)
     })
   })
 }

--- a/src/schema/engine/_stack.ts
+++ b/src/schema/engine/_stack.ts
@@ -26,248 +26,184 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-// deno-fmt-ignore-file
-
-import * as Schema from '../types/index.ts'
 import { Guard } from '../../guard/index.ts'
-import { Resolve } from '../resolve/index.ts'
+import * as Schema from '../types/index.ts'
 
-// --------------------------------------------------------------------------
+// ------------------------------------------------------------------
+// DefaultUri
+// ------------------------------------------------------------------
+export const DefaultUri = 'urn:typebox:root'
+
+// ------------------------------------------------------------------
+// XStack
+//
+// Immutable frame tracking traversal and resolution state for a
+// single schema visit.
+// ------------------------------------------------------------------
+export interface XStack {
+  /** The schema context. */
+  readonly context: Record<string, Schema.XSchema>
+  /** The entry schema. */
+  readonly schema: Schema.XSchema
+  /** Visited $id schemas, kept only to detect resource re-entry (see resolve.ts FindResolvedResource). */
+  readonly ids: Schema.XId[]
+  /** Nearest enclosing $id schema, used as the root for local pointer resolution. */
+  readonly lexicalSchema: Schema.XSchema
+  /** First $recursiveAnchor: true schema seen on the path. */
+  readonly recursiveAnchor: Schema.XRecursiveAnchor | undefined
+  /** Dynamic anchors visible at this point in the traversal. */
+  readonly dynamicAnchors: Schema.XDynamicAnchor[]
+  /** Lexical base URL, used to resolve relative $id and $ref values within the current schema. */
+  readonly lexicalBase: string
+  /** Base URL of the current resource, reset each time a new resource $id is entered. */
+  readonly resourceBase: string
+  /** Base URL that $ref values resolve against. */
+  readonly referenceBase: string
+  /** Resource entry point bookkeeping: schema -> the base/root to apply when that schema is next pushed. */
+  readonly resourceEntries: Map<Schema.XSchemaObject, { base: string; root: Schema.XSchemaObject }>
+  /** True while referenceBase should track resourceBase rather than lexicalBase. */
+  readonly useResourceBaseForReference: boolean
+  /** True until the next $id schema is entered, marking it as a fresh resource root. */
+  readonly pendingResource: boolean
+  /** True once traversal has entered a retrieved or legacy resource. */
+  readonly enteredResource: boolean
+}
+// ------------------------------------------------------------------
+// NextUri
+//
+// Resolves a relative or absolute ref against a base URI or URN.
+// Hierarchical bases (http, https, etc.) resolve using the normal
+// URL rules. URN bases have no path to resolve against, so the ref
+// is appended after the base's last ':' segment instead.
+// ------------------------------------------------------------------
+export function NextUri(ref: string, base: string): URL {
+  return (URL.canParse(ref, base)) ? new URL(ref, base) : Guard.IsEqual(base, DefaultUri) ? new URL(`${base}:${ref}`) : new URL(`${base.slice(0, base.lastIndexOf(':'))}:${ref}`)
+}
+// ------------------------------------------------------------------
 // Stack
 //
-// Tracks traversal state ($ids, $anchors, stack frames) and applies scope
-// updates. Reference resolution rules ($ref, $dynamicRef) are delegated to
-// the Resolve functions using state snapshots (Resolve.Scope).
-// --------------------------------------------------------------------------
-export class Stack {
-  private readonly ids: Schema.XId[] = []
-  private readonly resourceIds: Schema.XId[] = []
-  private readonly anchors: Schema.XAnchor[] = []
-  private readonly recursiveAnchors: Schema.XRecursiveAnchor[] = []
-  private readonly dynamicAnchors: Schema.XDynamicAnchor[] = []
-  private readonly retrievedResources: Map<Schema.XSchemaObject, { base: string; root: Schema.XSchemaObject }> = new Map()
-  private readonly retrievedFrames: { schema: Schema.XSchemaObject; base: string; idDepth: number; resourceDepth: number }[] = []
-  private readonly resolvedResources: Map<Schema.XSchemaObject, Schema.XId> = new Map()
-  private pendingResource: boolean = true
-  constructor(
-    private readonly context: Record<PropertyKey, Schema.XSchema>,
-    private readonly schema: Schema.XSchema
-  ) {}
-  // ----------------------------------------------------------------
-  // LexicalBaseURL
-  // ----------------------------------------------------------------
-  public LexicalBaseURL(): string {
-    return this.#BuildBase(this.ids)
+// Creates the root frame a schema traversal starts from.
+// ------------------------------------------------------------------
+export function Stack(context: Record<string, Schema.XSchema>, schema: Schema.XSchema): XStack {
+  const base = Schema.IsSchemaObject(schema) && Schema.IsId(schema) ? NextUri(schema.$id, DefaultUri).href : DefaultUri
+  return {
+    context,
+    schema,
+    lexicalSchema: schema,
+    lexicalBase: base,
+    resourceBase: base,
+    referenceBase: base,
+    ids: [],
+    useResourceBaseForReference: true,
+    recursiveAnchor: undefined,
+    dynamicAnchors: [],
+    resourceEntries: new Map(),
+    pendingResource: true,
+    enteredResource: false
   }
-  // ----------------------------------------------------------------
-  // Push
-  // ----------------------------------------------------------------
-  public Push(schema: Schema.XSchema) {
-    if (!Schema.IsSchemaObject(schema)) return
-    if (Schema.IsId(schema)) this.#RegisterResource(schema)
-    if (Schema.IsAnchor(schema)) this.anchors.push(schema)
-    if (Schema.IsRecursiveAnchorTrue(schema)) this.recursiveAnchors.push(schema)
-    if (Schema.IsDynamicAnchor(schema)) this.dynamicAnchors.push(schema)
-    const retrievedResource = this.retrievedResources.get(schema)
-    if (retrievedResource) {
-      this.retrievedFrames.push({
-        schema: retrievedResource.root,
-        base: retrievedResource.base,
-        idDepth: this.ids.length,
-        resourceDepth: this.resourceIds.length
-      })
+}
+// ------------------------------------------------------------------
+// RegisterResourceAnchors
+//
+// Collects $dynamicAnchor schemas reachable from a resource root,
+// stopping at nested $id boundaries which own their own anchors.
+// ------------------------------------------------------------------
+function RegisterResourceAnchors(anchors: Schema.XDynamicAnchor[], schema: unknown, isRoot: boolean = true): Schema.XDynamicAnchor[] {
+  if (Schema.IsSchemaBoolean(schema)) return anchors
+  if (Array.isArray(schema)) return schema.reduce((result, item) => RegisterResourceAnchors(result, item, false), anchors)
+  if (!Schema.IsSchemaObject(schema)) return anchors
+  if (!isRoot && Schema.IsId(schema)) return anchors
+  const next = !isRoot && Schema.IsDynamicAnchor(schema) ? [...anchors, schema] : anchors
+  return Object.keys(schema).reduce((result, key) => RegisterResourceAnchors(result, (schema as never)[key], false), next)
+}
+// ------------------------------------------------------------------
+// ResourceEntry
+//
+// A ref crossing (Resolve.Ref) may have marked `schema` as the entry
+// point of a retrieved/legacy resource. If so the frame resets to
+// that resource's base/root instead of chaining onto the parent.
+// ------------------------------------------------------------------
+function ResourceEntry(stack: XStack, schema: Schema.XSchemaObject): { base: string; root: Schema.XSchemaObject } | undefined {
+  return stack.resourceEntries.get(schema)
+}
+function NextEnteredResource(stack: XStack, schema: Schema.XSchemaObject): boolean {
+  return stack.enteredResource || ResourceEntry(stack, schema) !== undefined
+}
+// ------------------------------------------------------------------
+// NextStack
+//
+// Each Next* helper below computes one XStack field in isolation from
+// the previous frame and the schema being pushed.
+// ------------------------------------------------------------------
+function IsRelativeId(schema: Schema.XId): boolean {
+  return !/^[A-Za-z][A-Za-z0-9+.-]*:/.test(schema.$id)
+}
+function NextIds(stack: XStack, schema: Schema.XSchemaObject): Schema.XId[] {
+  return Schema.IsId(schema) ? [...stack.ids, schema] : stack.ids
+}
+function NextRecursiveAnchor(stack: XStack, schema: Schema.XSchemaObject): Schema.XRecursiveAnchor | undefined {
+  return stack.recursiveAnchor ?? (Schema.IsRecursiveAnchorTrue(schema) ? schema : undefined)
+}
+function NextDynamicAnchors(stack: XStack, schema: Schema.XSchemaObject): Schema.XDynamicAnchor[] {
+  const registered = Schema.IsId(schema) ? RegisterResourceAnchors(stack.dynamicAnchors, schema) : stack.dynamicAnchors
+  return Schema.IsDynamicAnchor(schema) ? [...registered, schema] : registered
+}
+function NextPendingResource(stack: XStack, schema: Schema.XSchemaObject): boolean {
+  return Schema.IsId(schema) ? false : stack.pendingResource
+}
+function NextLexicalBase(stack: XStack, schema: Schema.XSchemaObject): string {
+  const entry = ResourceEntry(stack, schema)
+  if (entry) return entry.base
+  return Schema.IsId(schema) ? NextUri(schema.$id, stack.lexicalBase).href : stack.lexicalBase
+}
+function NextResourceBase(stack: XStack, schema: Schema.XSchemaObject): string {
+  const entry = ResourceEntry(stack, schema)
+  if (entry) return entry.base
+  return (Schema.IsId(schema) && stack.pendingResource) ? NextUri(schema.$id, stack.resourceBase).href : stack.resourceBase
+}
+function NextUseResourceBaseForReference(stack: XStack, schema: Schema.XSchemaObject): boolean {
+  return Schema.IsId(schema) ? !IsRelativeId(schema) : stack.useResourceBaseForReference
+}
+function NextReferenceBase(stack: XStack, schema: Schema.XSchemaObject): string {
+  const isRetrieved = NextEnteredResource(stack, schema)
+  const useResourceBaseForReference = NextUseResourceBaseForReference(stack, schema)
+  return (isRetrieved || useResourceBaseForReference) ? NextResourceBase(stack, schema) : NextLexicalBase(stack, schema)
+}
+function NextLexicalSchema(stack: XStack, schema: Schema.XSchemaObject): Schema.XSchema {
+  const entry = ResourceEntry(stack, schema)
+  if (entry) return entry.root
+  return Schema.IsId(schema) ? schema : stack.lexicalSchema
+}
+// ------------------------------------------------------------------
+// NextStack | HasStackKeywords (Optimization)
+//
+// HasStackKeywords narrows schema to an object and checks whether it
+// carries $id, $dynamicAnchor, a first-seen $recursiveAnchor, or a
+// resource-entry point. When none apply, NextStack skips the frame
+// rebuild and returns the parent stack as-is.
+// ------------------------------------------------------------------
+function HasStackKeywords(stack: XStack, schema: Schema.XSchema): schema is Schema.XSchemaObject {
+  return Schema.IsSchemaObject(schema) && (
+    Schema.IsId(schema) ||
+    Schema.IsDynamicAnchor(schema) ||
+    (Guard.IsUndefined(stack.recursiveAnchor) && Schema.IsRecursiveAnchorTrue(schema)) ||
+    !Guard.IsUndefined(ResourceEntry(stack, schema))
+  )
+}
+export function NextStack(stack: XStack, schema: Schema.XSchema): XStack {
+  return HasStackKeywords(stack, schema)
+    ? {
+      ...stack,
+      ids: NextIds(stack, schema),
+      dynamicAnchors: NextDynamicAnchors(stack, schema),
+      recursiveAnchor: NextRecursiveAnchor(stack, schema),
+      pendingResource: NextPendingResource(stack, schema),
+      lexicalBase: NextLexicalBase(stack, schema),
+      resourceBase: NextResourceBase(stack, schema),
+      useResourceBaseForReference: NextUseResourceBaseForReference(stack, schema),
+      referenceBase: NextReferenceBase(stack, schema),
+      lexicalSchema: NextLexicalSchema(stack, schema),
+      enteredResource: NextEnteredResource(stack, schema)
     }
-  }
-  // ----------------------------------------------------------------
-  // Pop
-  // ----------------------------------------------------------------
-  public Pop(schema: Schema.XSchema) {
-    if (!Schema.IsSchemaObject(schema)) return
-    if (Schema.IsId(schema)) this.#UnregisterResource(schema)
-    if (Schema.IsAnchor(schema)) this.anchors.pop()
-    if (Schema.IsRecursiveAnchorTrue(schema)) this.recursiveAnchors.pop()
-    if (Schema.IsDynamicAnchor(schema)) this.dynamicAnchors.pop()
-    if (this.retrievedResources.has(schema)) this.retrievedFrames.pop()
-    this.#ExitResolvedResource(schema)
-  }
-  // ----------------------------------------------------------------
-  // Ref
-  // ----------------------------------------------------------------
-  public Ref(ref: Schema.XRef): Schema.XSchema | undefined {
-    const result = Resolve.ResolveRef(this.#StackFrame(), ref)
-    this.#ApplyRefResult(result)
-    return result.schema
-  }
-  // ----------------------------------------------------------------
-  // RecursiveRef
-  // ----------------------------------------------------------------
-  public RecursiveRef(recursiveRef: Schema.XRecursiveRef): Schema.XSchema | undefined {
-    const result = Resolve.ResolveRecursiveRef(this.#StackFrame(), recursiveRef)
-    if (result) this.pendingResource = true
-    return result
-  }
-  // ----------------------------------------------------------------
-  // DynamicRef
-  // ----------------------------------------------------------------
-  public DynamicRef(dynamicRef: Schema.XDynamicRef): Schema.XSchema | undefined {
-    const result = Resolve.ResolveDynamicRef(this.#StackFrame(), dynamicRef)
-    if (result) this.pendingResource = true
-    return result
-  }
-  // ----------------------------------------------------------------
-  // StackFrame
-  //
-  // Encodes the current stack state into a read-only snapshot that
-  // Resolve needs to make resolution decisions. Nothing in Resolve
-  // mutates this or reaches back into Stack. We currently do this to
-  // decouple Stack and Resolve, but we may just pass Stack directly
-  // to Resolve in future revisions (review).
-  // ----------------------------------------------------------------
-  #StackFrame(): Resolve.StackFrame {
-    return {
-      context: this.context,
-      root: this.schema as Schema.XSchemaObject,
-      ids: this.ids,
-      lexicalSchema: this.#LexicalSchema(),
-      lexicalBase: this.LexicalBaseURL(),
-      referenceBase: this.#ReferenceBaseURL(),
-      resourceBase: this.#ResourceBaseURL(),
-      recursiveAnchors: this.recursiveAnchors,
-      dynamicAnchors: this.dynamicAnchors,
-      inRetrievedFrame: this.retrievedFrames.length > 0
-    }
-  }
-  // ----------------------------------------------------------------
-  // ApplyRefResult
-  //
-  // Updates stack state after reference resolution to reflect target
-  // scope boundaries. It immediately enters new base URIs for resolved
-  // $ids, flags the target as a pending resource root for upcoming
-  // traversal, or maps external document roots so Push can manage
-  // frame boundaries when traversal reaches them.
-  // ----------------------------------------------------------------
-  #ApplyRefResult(result: Resolve.RefResult): void {
-    if (!Guard.IsUndefined(result.schema)) this.pendingResource = true
-    if (!Guard.IsUndefined(result.resolvedResource)) {
-      this.#EnterResolvedResource(
-        result.resolvedResource.target,
-        result.resolvedResource.resource
-      )
-    }
-    if (!Guard.IsUndefined(result.retrievedResource)) {
-      this.retrievedResources.set(result.retrievedResource.target, {
-        base: result.retrievedResource.base,
-        root: result.retrievedResource.root
-      })
-    }
-  }
-  // ----------------------------------------------------------------
-  // BuildBase
-  // ----------------------------------------------------------------
-  #BuildBase(stack: Schema.XId[]): string {
-    const frame = this.retrievedFrames[this.retrievedFrames.length - 1]
-    const base = frame ? new URL(frame.base) : new URL(Resolve.DefaultBase)
-    const scoped = frame ? stack.slice(frame.idDepth) : stack
-    return scoped.reduce((result, schema) => new URL(schema.$id, result), base).href
-  }
-  // ----------------------------------------------------------------
-  // ResourceBaseURL
-  // ----------------------------------------------------------------
-  #ResourceBaseURL(): string {
-    const frame = this.retrievedFrames[this.retrievedFrames.length - 1]
-    if (!frame) return this.#BuildBase(this.resourceIds)
-    return this.resourceIds.slice(frame.resourceDepth).reduce((result, schema) => new URL(schema.$id, result), new URL(frame.base)).href
-  }
-  // ----------------------------------------------------------------
-  // ReferenceBaseURL
-  // ----------------------------------------------------------------
-  #ReferenceBaseURL(): string {
-    if (this.retrievedFrames.length > 0) return this.#ResourceBaseURL()
-    const lexical = this.ids[this.ids.length - 1]
-    if (lexical && !/^[A-Za-z][A-Za-z0-9+.-]*:/.test(lexical.$id)) return this.LexicalBaseURL()
-    return this.#ResourceBaseURL()
-  }
-  // ----------------------------------------------------------------
-  // LexicalSchema
-  // ----------------------------------------------------------------
-  #LexicalSchema(): Schema.XSchemaObject {
-    const frame = this.retrievedFrames[this.retrievedFrames.length - 1]
-    if (frame) return this.ids.length > frame.idDepth ? this.ids[this.ids.length - 1] : frame.schema
-    return this.ids.length > 0 ? this.ids[this.ids.length - 1] : (this.schema as Schema.XSchemaObject)
-  }
-  // ----------------------------------------------------------------
-  // RegisterResourceAnchorArray
-  //
-  // Note: Invalid $refs may land here, presumably via anchors
-  // embedded in logical allOf/anyOf operands. I noted a few
-  // test suite cases commented as invalid that trigger this
-  // code path. We may be able to remove these in the future as,
-  // technically, we shouldn't need to traverse arrays inside
-  // the stack instances (review).
-  // ----------------------------------------------------------------
-  #RegisterResourceAnchorArray(schema: unknown[]): void {
-    schema.forEach((schema) => this.#RegisterResourceAnchors(schema, false))
-  }
-  #UnregisterResourceAnchorArray(schema: unknown[]): void {
-    schema.forEach((schema) => this.#UnregisterResourceAnchors(schema, false))
-  }
-  // ----------------------------------------------------------------
-  // RegisterResourceAnchors
-  // ----------------------------------------------------------------
-  #RegisterResourceAnchors(schema: unknown, isRoot: boolean = true): void {
-    if (Schema.IsSchemaBoolean(schema)) return
-    if (Guard.IsArray(schema)) return this.#RegisterResourceAnchorArray(schema)
-    if (!Schema.IsSchemaObject(schema)) return
-    const current = schema as Record<PropertyKey, unknown>
-    if (!isRoot && Schema.IsId(current)) return
-    if (!isRoot && Schema.IsDynamicAnchor(current)) this.dynamicAnchors.push(current)
-    for (const key of Guard.Keys(current)) this.#RegisterResourceAnchors(current[key], false)
-  }
-  // ----------------------------------------------------------------
-  // UnregisterResourceAnchors
-  // ----------------------------------------------------------------
-  #UnregisterResourceAnchors(schema: unknown, isRoot: boolean = true): void {
-    if (Schema.IsSchemaBoolean(schema)) return
-    if (Guard.IsArray(schema)) return this.#UnregisterResourceAnchorArray(schema)
-    if (!Schema.IsSchemaObject(schema)) return
-    const current = schema as Record<PropertyKey, unknown>
-    if (!isRoot && Schema.IsId(current)) return
-    if (!isRoot && Schema.IsDynamicAnchor(current)) this.dynamicAnchors.pop()
-    for (const key of Guard.Keys(current)) this.#UnregisterResourceAnchors(current[key], false)
-  }
-  // ----------------------------------------------------------------
-  // RegisterResource
-  // ----------------------------------------------------------------
-  #RegisterResource(schema: Schema.XId): void {
-    this.ids.push(schema)
-    const isResource = this.pendingResource
-    this.pendingResource = false
-    if (isResource) this.resourceIds.push(schema)
-    this.#RegisterResourceAnchors(schema, true)
-  }
-  // ----------------------------------------------------------------
-  // UnregisterResource
-  // ----------------------------------------------------------------
-  #UnregisterResource(schema: Schema.XId): void {
-    this.ids.pop()
-    const isResource = this.resourceIds.length > 0 && Guard.IsEqual(this.resourceIds[this.resourceIds.length - 1], schema)
-    if (isResource) this.resourceIds.pop()
-    this.#UnregisterResourceAnchors(schema, true)
-  }
-  // ----------------------------------------------------------------
-  // EnterResolvedResource
-  // ----------------------------------------------------------------
-  #EnterResolvedResource(target: Schema.XSchemaObject, resource: Schema.XId): void {
-    this.#RegisterResource(resource)
-    this.resolvedResources.set(target, resource)
-  }
-  // ----------------------------------------------------------------
-  // ExitResolvedResource
-  // ----------------------------------------------------------------
-  #ExitResolvedResource(target: Schema.XSchemaObject): void {
-    if (!this.resolvedResources.has(target)) return
-    const resource = this.resolvedResources.get(target)!
-    this.#UnregisterResource(resource)
-    this.resolvedResources.delete(target)
-  }
+    : stack
 }

--- a/src/schema/engine/additionalItems.ts
+++ b/src/schema/engine/additionalItems.ts
@@ -29,7 +29,7 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Unique } from './_unique.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
@@ -44,20 +44,20 @@ function IsValid(schema: Schema.XSchemaObject): schema is Schema.XItems & { item
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-function BuildAdditionalItemsStandard(stack: Stack, context: BuildContext, schema: Schema.XAdditionalItems & Schema.XItems & { items: Schema.XSchema[] }, value: string): string {
+function BuildAdditionalItemsStandard(stack: Stack.XStack, context: BuildContext, schema: Schema.XAdditionalItems & Schema.XItems & { items: Schema.XSchema[] }, value: string): string {
   const [item, index] = [Unique(), Unique()]
   const isSchema = BuildSchemaPushStack(stack, context, schema.additionalItems, item)
   const isLength = E.IsLessThan(index, E.Constant(schema.items.length))
   const addIndex = context.AddIndex(index)
   return E.Every(value, E.Constant(0), [item, index], E.Or(isLength, E.And(isSchema, addIndex)))
 }
-function BuildAdditionalItemsFast(stack: Stack, context: BuildContext, schema: Schema.XAdditionalItems & Schema.XItems & { items: Schema.XSchema[] }, value: string): string {
+function BuildAdditionalItemsFast(stack: Stack.XStack, context: BuildContext, schema: Schema.XAdditionalItems & Schema.XItems & { items: Schema.XSchema[] }, value: string): string {
   const [item, index] = [Unique(), Unique()]
   const isSchema = BuildSchemaPushStack(stack, context, schema.additionalItems, item)
   const isLength = E.IsLessThan(index, E.Constant(schema.items.length))
   return E.Every(value, E.Constant(0), [item, index], E.Or(isLength, isSchema))
 }
-export function BuildAdditionalItems(stack: Stack, context: BuildContext, schema: Schema.XAdditionalItems, value: string): string {
+export function BuildAdditionalItems(stack: Stack.XStack, context: BuildContext, schema: Schema.XAdditionalItems, value: string): string {
   if (!IsValid(schema)) return E.Constant(true)
   return context.UseUnevaluated()
     ? BuildAdditionalItemsStandard(stack, context, schema, value)
@@ -66,7 +66,7 @@ export function BuildAdditionalItems(stack: Stack, context: BuildContext, schema
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckAdditionalItems(stack: Stack, context: CheckContext, schema: Schema.XAdditionalItems, value: unknown[]): boolean {
+export function CheckAdditionalItems(stack: Stack.XStack, context: CheckContext, schema: Schema.XAdditionalItems, value: unknown[]): boolean {
   if (!IsValid(schema)) return true
   const isAdditionalItems = G.Every(value, 0, (item, index) => {
     return G.IsLessThan(index, schema.items.length)
@@ -77,7 +77,7 @@ export function CheckAdditionalItems(stack: Stack, context: CheckContext, schema
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorAdditionalItems(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XAdditionalItems, value: unknown[]): boolean {
+export function ErrorAdditionalItems(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XAdditionalItems, value: unknown[]): boolean {
   if (!IsValid(schema)) return true
   const isAdditionalItems = G.Every(value, 0, (item, index) => {
     const nextSchemaPath = `${schemaPath}/additionalItems`

--- a/src/schema/engine/additionalProperties.ts
+++ b/src/schema/engine/additionalProperties.ts
@@ -28,9 +28,9 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import * as S from '../types/index.ts'
-import * as V from './_externals.ts'
-import { Stack } from './_stack.ts'
+import * as Schema from '../types/index.ts'
+import * as Stack from './_stack.ts'
+import * as Externals from './_externals.ts'
 import { Unique } from './_unique.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { UnicodeRegExp } from './_regexp.ts'
@@ -44,7 +44,7 @@ import { BuildSchemaPushStack, CheckSchemaPushStack, ErrorSchemaPushStack } from
 // we are not in an unevaluated context, noting that additional
 // properties are considered tracked, evaluated keys.
 // ------------------------------------------------------------------
-function IsAdditionalPropertiesIgnored(context: BuildContext, additionalProperties: S.XSchema): boolean {
+function IsAdditionalPropertiesIgnored(context: BuildContext, additionalProperties: Schema.XSchema): boolean {
   return !context.UseUnevaluated() &&
     (G.IsEqual(additionalProperties, true) ||
       (G.IsObject(additionalProperties) && G.IsEqual(G.Keys(additionalProperties).length, 0)))
@@ -64,10 +64,10 @@ function GetPropertyKeyAsPattern(key: string): string {
   const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   return `^${escaped}$`
 }
-function GetPropertiesPattern(schema: S.XSchemaObject): string {
+function GetPropertiesPattern(schema: Schema.XSchemaObject): string {
   const patterns: string[] = []
-  if (S.IsPatternProperties(schema)) patterns.push(...G.Keys(schema.patternProperties))
-  if (S.IsProperties(schema)) patterns.push(...G.Keys(schema.properties).map(GetPropertyKeyAsPattern))
+  if (Schema.IsPatternProperties(schema)) patterns.push(...G.Keys(schema.patternProperties))
+  if (Schema.IsProperties(schema)) patterns.push(...G.Keys(schema.properties).map(GetPropertyKeyAsPattern))
   return G.IsEqual(patterns.length, 0) ? '(?!)' : `(${patterns.join('|')})`
 }
 // ------------------------------------------------------------------
@@ -85,22 +85,22 @@ function GetPropertiesPattern(schema: S.XSchemaObject): string {
 // we can generate a simplified and efficient runtime check.
 //
 // ------------------------------------------------------------------
-export function CanAdditionalPropertiesFast(_context: BuildContext, schema: S.XAdditionalProperties, _value: string): schema is S.XAdditionalProperties & S.XRequired {
-  return S.IsRequired(schema)
-    && S.IsProperties(schema)
-    && !S.IsPatternProperties(schema)
+export function CanAdditionalPropertiesFast(_context: BuildContext, schema: Schema.XAdditionalProperties, _value: string): schema is Schema.XAdditionalProperties & Schema.XRequired {
+  return Schema.IsRequired(schema)
+    && Schema.IsProperties(schema)
+    && !Schema.IsPatternProperties(schema)
     && G.IsEqual(schema.additionalProperties, false)
     && G.IsEqual(G.Keys(schema.properties).length, schema.required.length)
 }
-export function BuildAdditionalPropertiesFast(_context: BuildContext, schema: S.XAdditionalProperties & S.XRequired, value: string): string {
+export function BuildAdditionalPropertiesFast(_context: BuildContext, schema: Schema.XAdditionalProperties & Schema.XRequired, value: string): string {
   return E.IsEqual(E.Member(E.Call(E.Member('Object', 'getOwnPropertyNames'), [value]), 'length'), E.Constant(schema.required.length))
 }
 // ------------------------------------------------------------------
 // BuildAdditionalPropertiesStandard
 // ------------------------------------------------------------------
-export function BuildAdditionalPropertiesStandard(stack: Stack, context: BuildContext, schema: S.XAdditionalProperties, value: string): string {
+export function BuildAdditionalPropertiesStandard(stack: Stack.XStack, context: BuildContext, schema: Schema.XAdditionalProperties, value: string): string {
   const [key, _index] = [Unique(), Unique()]
-  const regexp = V.CreateVariable(UnicodeRegExp(GetPropertiesPattern(schema)))
+  const regexp = Externals.CreateVariable(UnicodeRegExp(GetPropertiesPattern(schema)))
   const isSchema = BuildSchemaPushStack(stack, context, schema.additionalProperties, `${value}[${key}]`)
   const isKey = E.Call(E.Member(regexp, 'test'), [key])
   const addKey = context.AddKey(key)
@@ -111,7 +111,7 @@ export function BuildAdditionalPropertiesStandard(stack: Stack, context: BuildCo
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildAdditionalProperties(stack: Stack, context: BuildContext, schema: S.XAdditionalProperties, value: string): string {
+export function BuildAdditionalProperties(stack: Stack.XStack, context: BuildContext, schema: Schema.XAdditionalProperties, value: string): string {
   if (IsAdditionalPropertiesIgnored(context, schema.additionalProperties)) return E.Constant(true)
   return CanAdditionalPropertiesFast(context, schema, value)
     ? BuildAdditionalPropertiesFast(context, schema, value)
@@ -120,7 +120,7 @@ export function BuildAdditionalProperties(stack: Stack, context: BuildContext, s
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckAdditionalProperties(stack: Stack, context: CheckContext, schema: S.XAdditionalProperties, value: Record<PropertyKey, unknown>): boolean {
+export function CheckAdditionalProperties(stack: Stack.XStack, context: CheckContext, schema: Schema.XAdditionalProperties, value: Record<PropertyKey, unknown>): boolean {
   const regexp = UnicodeRegExp(GetPropertiesPattern(schema))
   const isAdditionalProperties = G.Every(G.Keys(value), 0, (key, _index) => {
     return regexp.test(key) ||
@@ -131,7 +131,7 @@ export function CheckAdditionalProperties(stack: Stack, context: CheckContext, s
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorAdditionalProperties(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: S.XAdditionalProperties, value: Record<PropertyKey, unknown>): boolean {
+export function ErrorAdditionalProperties(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XAdditionalProperties, value: Record<PropertyKey, unknown>): boolean {
   const regexp = UnicodeRegExp(GetPropertiesPattern(schema))
   const additionalProperties: string[] = []
   const isAdditionalProperties = G.EveryAll(G.Keys(value), 0, (key, _index) => {
@@ -143,10 +143,6 @@ export function ErrorAdditionalProperties(stack: Stack, context: ErrorContext, s
     if (!isAdditionalProperty) additionalProperties.push(key)
     return isAdditionalProperty
   })
-  return isAdditionalProperties || context.AddError({
-    keyword: 'additionalProperties',
-    schemaPath,
-    instancePath,
-    params: { additionalProperties },
-  })
+  return isAdditionalProperties ||
+    context.AddError('additionalProperties', schemaPath, instancePath, { additionalProperties })
 }

--- a/src/schema/engine/allOf.ts
+++ b/src/schema/engine/allOf.ts
@@ -29,7 +29,7 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Reducer } from './_reducer.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
@@ -38,13 +38,13 @@ import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-function BuildAllOfStandard(stack: Stack, context: BuildContext, schema: Schema.XAllOf, value: string): string {
+function BuildAllOfStandard(stack: Stack.XStack, context: BuildContext, schema: Schema.XAllOf, value: string): string {
   return Reducer(stack, context, schema.allOf, value, E.IsEqual(E.Member('results', 'length'), E.Constant(schema.allOf.length)))
 }
-function BuildAllOfFast(stack: Stack, context: BuildContext, schema: Schema.XAllOf, value: string): string {
+function BuildAllOfFast(stack: Stack.XStack, context: BuildContext, schema: Schema.XAllOf, value: string): string {
   return E.ReduceAnd(schema.allOf.map((schema) => BuildSchema(stack, context, schema, value)))
 }
-export function BuildAllOf(stack: Stack, context: BuildContext, schema: Schema.XAllOf, value: string): string {
+export function BuildAllOf(stack: Stack.XStack, context: BuildContext, schema: Schema.XAllOf, value: string): string {
   return context.UseUnevaluated()
     ? BuildAllOfStandard(stack, context, schema, value)
     : BuildAllOfFast(stack, context, schema, value)
@@ -52,7 +52,7 @@ export function BuildAllOf(stack: Stack, context: BuildContext, schema: Schema.X
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckAllOf(stack: Stack, context: CheckContext, schema: Schema.XAllOf, value: unknown): boolean {
+export function CheckAllOf(stack: Stack.XStack, context: CheckContext, schema: Schema.XAllOf, value: unknown): boolean {
   const results = schema.allOf.reduce<CheckContext[]>((result, schema) => {
     const nextContext = new CheckContext()
     return CheckSchema(stack, nextContext, schema, value) ? [...result, nextContext] : result
@@ -62,7 +62,7 @@ export function CheckAllOf(stack: Stack, context: CheckContext, schema: Schema.X
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorAllOf(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XAllOf, value: unknown): boolean {
+export function ErrorAllOf(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XAllOf, value: unknown): boolean {
   const failedContexts: ErrorContext[] = []
   const results = schema.allOf.reduce<ErrorContext[]>((result, schema, index) => {
     const nextSchemaPath = `${schemaPath}/allOf/${index}`
@@ -72,6 +72,6 @@ export function ErrorAllOf(stack: Stack, context: ErrorContext, schemaPath: stri
     return isSchema ? [...result, nextContext] : result
   }, [])
   const isAllOf = G.IsEqual(results.length, schema.allOf.length) && context.Merge(results)
-  if (!isAllOf) failedContexts.forEach(failed => failed.GetErrors().forEach(error => context.AddError(error)))
+  if (!isAllOf) failedContexts.forEach(failed => context.AddErrors(failed.GetErrors()))
   return isAllOf
 }

--- a/src/schema/engine/anyOf.ts
+++ b/src/schema/engine/anyOf.ts
@@ -29,22 +29,22 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
-import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
+import * as Stack from './_stack.ts'
 import { Reducer } from './_reducer.ts'
-import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
+import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-function BuildAnyOfStandard(stack: Stack, context: BuildContext, schema: Schema.XAnyOf, value: string): string {
+function BuildAnyOfStandard(stack: Stack.XStack, context: BuildContext, schema: Schema.XAnyOf, value: string): string {
   return Reducer(stack, context, schema.anyOf, value, E.IsGreaterThan(E.Member('results', 'length'), E.Constant(0)))
 }
-function BuildAnyOfFast(stack: Stack, context: BuildContext, schema: Schema.XAnyOf, value: string): string {
+function BuildAnyOfFast(stack: Stack.XStack, context: BuildContext, schema: Schema.XAnyOf, value: string): string {
   return E.ReduceOr(schema.anyOf.map((schema) => BuildSchema(stack, context, schema, value)))
 }
-export function BuildAnyOf(stack: Stack, context: BuildContext, schema: Schema.XAnyOf, value: string): string {
+export function BuildAnyOf(stack: Stack.XStack, context: BuildContext, schema: Schema.XAnyOf, value: string): string {
   return context.UseUnevaluated()
     ? BuildAnyOfStandard(stack, context, schema, value)
     : BuildAnyOfFast(stack, context, schema, value)
@@ -52,7 +52,7 @@ export function BuildAnyOf(stack: Stack, context: BuildContext, schema: Schema.X
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckAnyOf(stack: Stack, context: CheckContext, schema: Schema.XAnyOf, value: unknown): boolean {
+export function CheckAnyOf(stack: Stack.XStack, context: CheckContext, schema: Schema.XAnyOf, value: unknown): boolean {
   const results = schema.anyOf.reduce<CheckContext[]>((result, schema) => {
     const nextContext = new CheckContext()
     return CheckSchema(stack, nextContext, schema, value) ? [...result, nextContext] : result
@@ -62,7 +62,7 @@ export function CheckAnyOf(stack: Stack, context: CheckContext, schema: Schema.X
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorAnyOf(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XAnyOf, value: unknown): boolean {
+export function ErrorAnyOf(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XAnyOf, value: unknown): boolean {
   const failedContexts: ErrorContext[] = []
   const results = schema.anyOf.reduce<ErrorContext[]>((result, schema, index) => {
     const nextContext = new ErrorContext()
@@ -72,11 +72,6 @@ export function ErrorAnyOf(stack: Stack, context: ErrorContext, schemaPath: stri
     return isSchema ? [...result, nextContext] : result
   }, [])
   const isAnyOf = G.IsGreaterThan(results.length, 0) && context.Merge(results)
-  if (!isAnyOf) failedContexts.forEach(failed => failed.GetErrors().forEach(error => context.AddError(error)))
-  return isAnyOf || context.AddError({
-    keyword: 'anyOf',
-    schemaPath,
-    instancePath,
-    params: {}
-  })
+  if (!isAnyOf) failedContexts.forEach(failed => context.AddErrors(failed.GetErrors()))
+  return isAnyOf || context.AddError('anyOf', schemaPath, instancePath, {})
 }

--- a/src/schema/engine/boolean.ts
+++ b/src/schema/engine/boolean.ts
@@ -28,30 +28,27 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E } from '../../guard/index.ts'
+
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildSchemaBoolean(_stack: Stack, _context: BuildContext, schema: boolean, _value: string): string {
+export function BuildSchemaBoolean(_stack: Stack.XStack, _context: BuildContext, schema: boolean, _value: string): string {
   return schema ? E.Constant(true) : E.Constant(false)
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckSchemaBoolean(_stack: Stack, _context: CheckContext, schema: boolean, _value: unknown): boolean {
+export function CheckSchemaBoolean(_stack: Stack.XStack, _context: CheckContext, schema: boolean, _value: unknown): boolean {
   return schema
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorSchemaBoolean(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: boolean, value: unknown): boolean {
-  return CheckSchemaBoolean(stack, context, schema, value) || context.AddError({
-    keyword: 'boolean',
-    schemaPath,
-    instancePath,
-    params: {}
-  })
+export function ErrorSchemaBoolean(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: boolean, value: unknown): boolean {
+  return CheckSchemaBoolean(stack, context, schema, value) || 
+    context.AddError('boolean', schemaPath, instancePath, {})
 }

--- a/src/schema/engine/const.ts
+++ b/src/schema/engine/const.ts
@@ -29,15 +29,15 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
+import * as Stack from './_stack.ts'
 import * as Externals from './_externals.ts'
-import { Stack } from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildConst(_stack: Stack, _context: BuildContext, schema: Schema.XConst, value: string): string {
+export function BuildConst(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XConst, value: string): string {
   return G.IsValueLike(schema.const)
     ? E.IsEqual(value, E.Constant(schema.const))
     : E.IsDeepEqual(value, Externals.CreateVariable(schema.const))
@@ -45,7 +45,7 @@ export function BuildConst(_stack: Stack, _context: BuildContext, schema: Schema
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckConst(_stack: Stack, _context: CheckContext, schema: Schema.XConst, value: unknown): boolean {
+export function CheckConst(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XConst, value: unknown): boolean {
   return G.IsValueLike(schema.const)
     ? G.IsEqual(value, schema.const)
     : G.IsDeepEqual(value, schema.const)
@@ -53,11 +53,7 @@ export function CheckConst(_stack: Stack, _context: CheckContext, schema: Schema
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function ErrorConst(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XConst, value: unknown): boolean {
-  return CheckConst(stack, context, schema, value) || context.AddError({
-    keyword: 'const',
-    schemaPath,
-    instancePath,
-    params: { allowedValue: schema.const },
-  })
+export function ErrorConst(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XConst, value: unknown): boolean {
+  return CheckConst(stack, context, schema, value) || 
+    context.AddError('const', schemaPath, instancePath, { allowedValue: schema.const })
 }

--- a/src/schema/engine/contains.ts
+++ b/src/schema/engine/contains.ts
@@ -29,9 +29,8 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { Unique } from './_unique.ts'
-
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema } from './schema.ts'
@@ -45,19 +44,19 @@ function IsValid(schema: Schema.XContains): boolean {
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-function BuildContainsStandard(stack: Stack, context: BuildContext, schema: Schema.XContains, value: string): string {
+function BuildContainsStandard(stack: Stack.XStack, context: BuildContext, schema: Schema.XContains, value: string): string {
   const [item, index] = [Unique(), Unique()]
   const isLength = E.Not(E.IsEqual(E.Member(value, 'length'), E.Constant(0)))
   const isSome = E.SomeAll(value, [item, index], E.And(BuildSchema(stack, context, schema.contains, item), context.AddIndex(index)))
   return E.And(isLength, isSome)
 }
-function BuildContainsFast(stack: Stack, context: BuildContext, schema: Schema.XContains, value: string): string {
+function BuildContainsFast(stack: Stack.XStack, context: BuildContext, schema: Schema.XContains, value: string): string {
   const [item] = [Unique()]
   const isLength = E.Not(E.IsEqual(E.Member(value, 'length'), E.Constant(0)))
   const isSome = E.Some(value, [item, '_'], BuildSchema(stack, context, schema.contains, item))
   return E.And(isLength, isSome)
 }
-export function BuildContains(stack: Stack, context: BuildContext, schema: Schema.XContains, value: string): string {
+export function BuildContains(stack: Stack.XStack, context: BuildContext, schema: Schema.XContains, value: string): string {
   if (!IsValid(schema)) return E.Constant(true)
   return context.UseUnevaluated()
     ? BuildContainsStandard(stack, context, schema, value)
@@ -66,7 +65,7 @@ export function BuildContains(stack: Stack, context: BuildContext, schema: Schem
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckContains(stack: Stack, context: CheckContext, schema: Schema.XContains, value: unknown[]): boolean {
+export function CheckContains(stack: Stack.XStack, context: CheckContext, schema: Schema.XContains, value: unknown[]): boolean {
   if (!IsValid(schema)) return true
   return !G.IsEqual(value.length, 0) && G.SomeAll(value, (item, index) => {
     return CheckSchema(stack, context, schema.contains, item) && context.AddIndex(index)
@@ -75,11 +74,7 @@ export function CheckContains(stack: Stack, context: CheckContext, schema: Schem
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorContains(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XContains, value: unknown[]): boolean {
-  return CheckContains(stack, context, schema, value) || context.AddError({
-    keyword: 'contains',
-    schemaPath,
-    instancePath,
-    params: { minContains: 1 },
-  })
+export function ErrorContains(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XContains, value: unknown[]): boolean {
+  return CheckContains(stack, context, schema, value) ||
+    context.AddError('contains', schemaPath, instancePath, { minContains: 1 })
 }

--- a/src/schema/engine/dependencies.ts
+++ b/src/schema/engine/dependencies.ts
@@ -29,7 +29,7 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
@@ -37,7 +37,7 @@ import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildDependencies(stack: Stack, context: BuildContext, schema: Schema.XDependencies, value: string): string {
+export function BuildDependencies(stack: Stack.XStack, context: BuildContext, schema: Schema.XDependencies, value: string): string {
   const isLength = E.IsEqual(E.Member(E.Keys(value), 'length'), E.Constant(0))
   const isEveryDependency = E.ReduceAnd(
     G.Entries(schema.dependencies).map(([key, schema]) => {
@@ -52,7 +52,7 @@ export function BuildDependencies(stack: Stack, context: BuildContext, schema: S
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckDependencies(stack: Stack, context: CheckContext, schema: Schema.XDependencies, value: Record<PropertyKey, unknown>): boolean {
+export function CheckDependencies(stack: Stack.XStack, context: CheckContext, schema: Schema.XDependencies, value: Record<PropertyKey, unknown>): boolean {
   const isLength = G.IsEqual(G.Keys(value).length, 0)
   const isEvery = G.Every(G.Entries(schema.dependencies), 0, ([key, schema]) => {
     return !G.HasPropertyKey(value, key) || (
@@ -66,18 +66,15 @@ export function CheckDependencies(stack: Stack, context: CheckContext, schema: S
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorDependencies(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XDependencies, value: Record<PropertyKey, unknown>): boolean {
+export function ErrorDependencies(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XDependencies, value: Record<PropertyKey, unknown>): boolean {
   const isLength = G.IsEqual(G.Keys(value).length, 0)
   const isEvery = G.EveryAll(G.Entries(schema.dependencies), 0, ([key, schema]) => {
     const nextSchemaPath = `${schemaPath}/dependencies/${key}`
     return !G.HasPropertyKey(value, key) || (
       G.IsArray(schema)
-        ? schema.every((dependency) => G.HasPropertyKey(value, dependency) || context.AddError({
-          keyword: 'dependencies',
-          schemaPath,
-          instancePath,
-          params: { property: key, dependencies: schema },
-        })) : ErrorSchema(stack, context, nextSchemaPath, instancePath, schema, value)
+        ? schema.every((dependency) => G.HasPropertyKey(value, dependency) ||
+          context.AddError('dependencies', schemaPath, instancePath, { property: key, dependencies: schema }))
+        : ErrorSchema(stack, context, nextSchemaPath, instancePath, schema, value)
     )
   })
   return isLength || isEvery

--- a/src/schema/engine/dependentRequired.ts
+++ b/src/schema/engine/dependentRequired.ts
@@ -29,14 +29,14 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildDependentRequired(_stack: Stack, _context: BuildContext, schema: Schema.XDependentRequired, value: string): string {
+export function BuildDependentRequired(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XDependentRequired, value: string): string {
   const isLength = E.IsEqual(E.Member(E.Keys(value), 'length'), E.Constant(0))
   const isEvery = E.ReduceAnd(
     G.Entries(schema.dependentRequired).map(([key, keys]) => {
@@ -50,7 +50,7 @@ export function BuildDependentRequired(_stack: Stack, _context: BuildContext, sc
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckDependentRequired(_stack: Stack, _context: CheckContext, schema: Schema.XDependentRequired, value: Record<PropertyKey, unknown>): boolean {
+export function CheckDependentRequired(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XDependentRequired, value: Record<PropertyKey, unknown>): boolean {
   const isLength = G.IsEqual(G.Keys(value).length, 0)
   const isEvery = G.Every(G.Entries(schema.dependentRequired), 0, ([key, keys]) => {
     return !G.HasPropertyKey(value, key) ||
@@ -61,15 +61,11 @@ export function CheckDependentRequired(_stack: Stack, _context: CheckContext, sc
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorDependentRequired(_stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XDependentRequired, value: Record<PropertyKey, unknown>): boolean {
+export function ErrorDependentRequired(_stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XDependentRequired, value: Record<PropertyKey, unknown>): boolean {
   const isLength = G.IsEqual(G.Keys(value).length, 0)
   const isEveryEntry = G.EveryAll(G.Entries(schema.dependentRequired), 0, ([key, keys]) => {
-    return !G.HasPropertyKey(value, key) || G.EveryAll(keys, 0, (dependency) => G.HasPropertyKey(value, dependency) || context.AddError({
-      keyword: 'dependentRequired',
-      schemaPath,
-      instancePath,
-      params: { property: key, dependencies: keys },
-    }))
+    return !G.HasPropertyKey(value, key) || G.EveryAll(keys, 0, (dependency) => G.HasPropertyKey(value, dependency) ||
+      context.AddError('dependentRequired', schemaPath, instancePath, { property: key, dependencies: keys }))
   })
   return isLength || isEveryEntry
 }

--- a/src/schema/engine/dependentSchemas.ts
+++ b/src/schema/engine/dependentSchemas.ts
@@ -29,7 +29,7 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
@@ -37,7 +37,7 @@ import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildDependentSchemas(stack: Stack, context: BuildContext, schema: Schema.XDependentSchemas, value: string): string {
+export function BuildDependentSchemas(stack: Stack.XStack, context: BuildContext, schema: Schema.XDependentSchemas, value: string): string {
   const isLength = E.IsEqual(E.Member(E.Keys(value), 'length'), E.Constant(0))
   const isEvery = E.ReduceAnd(G.Entries(schema.dependentSchemas).map(([key, schema]) => {
     const notKey = E.Not(E.HasPropertyKey(value, E.Constant(key)))
@@ -49,7 +49,7 @@ export function BuildDependentSchemas(stack: Stack, context: BuildContext, schem
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckDependentSchemas(stack: Stack, context: CheckContext, schema: Schema.XDependentSchemas, value: Record<PropertyKey, unknown>): boolean {
+export function CheckDependentSchemas(stack: Stack.XStack, context: CheckContext, schema: Schema.XDependentSchemas, value: Record<PropertyKey, unknown>): boolean {
   const isLength = G.IsEqual(G.Keys(value).length, 0)
   const isEvery = G.Every(G.Entries(schema.dependentSchemas), 0, ([key, schema]) => {
     return !G.HasPropertyKey(value, key) ||
@@ -60,7 +60,7 @@ export function CheckDependentSchemas(stack: Stack, context: CheckContext, schem
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorDependentSchemas(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XDependentSchemas, value: Record<PropertyKey, unknown>): boolean {
+export function ErrorDependentSchemas(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XDependentSchemas, value: Record<PropertyKey, unknown>): boolean {
   const isLength = G.IsEqual(G.Keys(value).length, 0)
   const isEvery = G.EveryAll(G.Entries(schema.dependentSchemas), 0, ([key, schema]) => {
     const nextSchemaPath = `${schemaPath}/dependentSchemas/${key}`

--- a/src/schema/engine/dynamicRef.ts
+++ b/src/schema/engine/dynamicRef.ts
@@ -28,30 +28,34 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import * as Functions from './_functions.ts'
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
+import * as Resolve from '../resolve/index.ts'
+import * as Functions from './_functions.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { CheckSchema, ErrorSchema } from './schema.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildDynamicRef(stack: Stack, context: BuildContext, schema: Schema.XDynamicRef, value: string): string {
-  const target = stack.DynamicRef(schema) ?? false
-  return Functions.CreateFunction(stack, context, target, value)
+export function BuildDynamicRef(stack: Stack.XStack, context: BuildContext, schema: Schema.XDynamicRef, value: string): string {
+  const target = Resolve.DynamicRef(stack, schema) ?? false
+  const nextStack = target ? { ...stack, pendingResource: true } : stack
+  return Functions.CreateFunction(nextStack, context, target, value)
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckDynamicRef(stack: Stack, context: CheckContext, schema: Schema.XDynamicRef, value: unknown): boolean {
-  const target = stack.DynamicRef(schema) ?? false
-  return (Schema.IsSchema(target) && CheckSchema(stack, context, target, value))
+export function CheckDynamicRef(stack: Stack.XStack, context: CheckContext, schema: Schema.XDynamicRef, value: unknown): boolean {
+  const target = Resolve.DynamicRef(stack, schema) ?? false
+  const nextStack = target ? { ...stack, pendingResource: true } : stack
+  return (Schema.IsSchema(target) && CheckSchema(nextStack, context, target, value))
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorDynamicRef(stack: Stack, context: ErrorContext, _schemaPath: string, instancePath: string, schema: Schema.XDynamicRef, value: unknown): boolean {
-  const target = stack.DynamicRef(schema) ?? false
-  return (Schema.IsSchema(target) && ErrorSchema(stack, context, '#', instancePath, target, value))
+export function ErrorDynamicRef(stack: Stack.XStack, context: ErrorContext, _schemaPath: string, instancePath: string, schema: Schema.XDynamicRef, value: unknown): boolean {
+  const target = Resolve.DynamicRef(stack, schema) ?? false
+  const nextStack = target ? { ...stack, pendingResource: true } : stack
+  return (Schema.IsSchema(target) && ErrorSchema(nextStack, context, '#', instancePath, target, value))
 }

--- a/src/schema/engine/dynamicRef.ts
+++ b/src/schema/engine/dynamicRef.ts
@@ -30,8 +30,8 @@ THE SOFTWARE.
 
 import * as Schema from '../types/index.ts'
 import * as Stack from './_stack.ts'
-import * as Resolve from '../resolve/index.ts'
 import * as Functions from './_functions.ts'
+import { Resolve } from '../resolve/index.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { CheckSchema, ErrorSchema } from './schema.ts'
 

--- a/src/schema/engine/enum.ts
+++ b/src/schema/engine/enum.ts
@@ -29,15 +29,15 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
+import * as Stack from './_stack.ts'
 import * as Externals from './_externals.ts'
-import { Stack } from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildEnum(_stack: Stack, _context: BuildContext, schema: Schema.XEnum, value: string): string {
+export function BuildEnum(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XEnum, value: string): string {
   return E.ReduceOr(schema.enum.map(option => {
     if (G.IsValueLike(option)) return E.IsEqual(value, E.Constant(option))
     const variable = Externals.CreateVariable(option)
@@ -47,7 +47,7 @@ export function BuildEnum(_stack: Stack, _context: BuildContext, schema: Schema.
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckEnum(_stack: Stack, _context: CheckContext, schema: Schema.XEnum, value: unknown): boolean {
+export function CheckEnum(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XEnum, value: unknown): boolean {
   return G.Some(schema.enum, option => G.IsValueLike(option)
     ? G.IsEqual(value, option)
     : G.IsDeepEqual(value, option))
@@ -55,11 +55,7 @@ export function CheckEnum(_stack: Stack, _context: CheckContext, schema: Schema.
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorEnum(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XEnum, value: unknown): boolean {
-  return CheckEnum(stack, context, schema, value) || context.AddError({
-    keyword: 'enum',
-    schemaPath,
-    instancePath,
-    params: { allowedValues: schema.enum }
-  })
+export function ErrorEnum(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XEnum, value: unknown): boolean {
+  return CheckEnum(stack, context, schema, value) ||
+    context.AddError('enum', schemaPath, instancePath, { allowedValues: schema.enum })
 }

--- a/src/schema/engine/exclusiveMaximum.ts
+++ b/src/schema/engine/exclusiveMaximum.ts
@@ -29,30 +29,26 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildExclusiveMaximum(_stack: Stack, _context: BuildContext, schema: Schema.XExclusiveMaximum, value: string): string {
+export function BuildExclusiveMaximum(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XExclusiveMaximum, value: string): string {
   return E.IsLessThan(value, E.Constant(schema.exclusiveMaximum))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckExclusiveMaximum(_stack: Stack, _context: CheckContext, schema: Schema.XExclusiveMaximum, value: number | bigint): boolean {
+export function CheckExclusiveMaximum(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XExclusiveMaximum, value: number | bigint): boolean {
   return G.IsLessThan(value, schema.exclusiveMaximum)
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorExclusiveMaximum(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XExclusiveMaximum, value: number | bigint): boolean {
-  return CheckExclusiveMaximum(stack, context, schema, value) || context.AddError({
-    keyword: 'exclusiveMaximum',
-    schemaPath,
-    instancePath,
-    params: { comparison: '<', limit: schema.exclusiveMaximum }
-  })
+export function ErrorExclusiveMaximum(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XExclusiveMaximum, value: number | bigint): boolean {
+  return CheckExclusiveMaximum(stack, context, schema, value) ||
+    context.AddError('exclusiveMaximum', schemaPath, instancePath, { comparison: '<', limit: schema.exclusiveMaximum })
 }

--- a/src/schema/engine/exclusiveMinimum.ts
+++ b/src/schema/engine/exclusiveMinimum.ts
@@ -29,30 +29,26 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildExclusiveMinimum(_stack: Stack, _context: BuildContext, schema: Schema.XExclusiveMinimum, value: string): string {
+export function BuildExclusiveMinimum(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XExclusiveMinimum, value: string): string {
   return E.IsGreaterThan(value, E.Constant(schema.exclusiveMinimum))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckExclusiveMinimum(_stack: Stack, _context: CheckContext, schema: Schema.XExclusiveMinimum, value: number | bigint): boolean {
+export function CheckExclusiveMinimum(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XExclusiveMinimum, value: number | bigint): boolean {
   return G.IsGreaterThan(value, schema.exclusiveMinimum)
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorExclusiveMinimum(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XExclusiveMinimum, value: number | bigint): boolean {
-  return CheckExclusiveMinimum(stack, context, schema, value) || context.AddError({
-    keyword: 'exclusiveMinimum',
-    schemaPath,
-    instancePath,
-    params: { comparison: '>', limit: schema.exclusiveMinimum }
-  })
+export function ErrorExclusiveMinimum(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XExclusiveMinimum, value: number | bigint): boolean {
+  return CheckExclusiveMinimum(stack, context, schema, value) || 
+    context.AddError('exclusiveMinimum', schemaPath, instancePath, { comparison: '>', limit: schema.exclusiveMinimum })
 }

--- a/src/schema/engine/format.ts
+++ b/src/schema/engine/format.ts
@@ -28,33 +28,28 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { Format } from '../../format/index.ts'
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
+import { Format } from '../../format/index.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E } from '../../guard/index.ts'
-
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildFormat(_stack: Stack, _context: BuildContext, schema: Schema.XFormat, value: string): string {
+export function BuildFormat(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XFormat, value: string): string {
   return E.Call(E.Member('Format', 'Test'), [E.Constant(schema.format), value])
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckFormat(_stack: Stack, _context: CheckContext, schema: Schema.XFormat, value: string): boolean {
+export function CheckFormat(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XFormat, value: string): boolean {
   return Format.Test(schema.format, value)
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorFormat(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XFormat, value: string): boolean {
-  return CheckFormat(stack, context, schema, value) || context.AddError({
-    keyword: 'format',
-    schemaPath,
-    instancePath,
-    params: { format: schema.format },
-  })
+export function ErrorFormat(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XFormat, value: string): boolean {
+  return CheckFormat(stack, context, schema, value) ||
+    context.AddError('format', schemaPath, instancePath, { format: schema.format })
 }

--- a/src/schema/engine/if.ts
+++ b/src/schema/engine/if.ts
@@ -29,15 +29,15 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
-import { EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
+import { EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildIf(stack: Stack, context: BuildContext, schema: Schema.XIf, value: string): string {
+export function BuildIf(stack: Stack.XStack, context: BuildContext, schema: Schema.XIf, value: string): string {
   const thenSchema = Schema.IsThen(schema) ? schema.then : true
   const elseSchema = Schema.IsElse(schema) ? schema.else : true
   return E.Ternary(BuildSchema(stack, context, schema.if, value),
@@ -47,7 +47,7 @@ export function BuildIf(stack: Stack, context: BuildContext, schema: Schema.XIf,
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckIf(stack: Stack, context: CheckContext, schema: Schema.XIf, value: unknown): boolean {
+export function CheckIf(stack: Stack.XStack, context: CheckContext, schema: Schema.XIf, value: unknown): boolean {
   const thenSchema = Schema.IsThen(schema) ? schema.then : true
   const elseSchema = Schema.IsElse(schema) ? schema.else : true
   return CheckSchema(stack, context, schema.if, value)
@@ -57,23 +57,15 @@ export function CheckIf(stack: Stack, context: CheckContext, schema: Schema.XIf,
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorIf(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XIf, value: unknown): boolean {
+export function ErrorIf(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XIf, value: unknown): boolean {
   const thenSchema = Schema.IsThen(schema) ? schema.then : true
   const elseSchema = Schema.IsElse(schema) ? schema.else : true
   const trueContext = new ErrorContext()
   const isIf = ErrorSchema(stack, trueContext, `${schemaPath}/if`, instancePath, schema.if, value)
-    ? ErrorSchema(stack, trueContext, `${schemaPath}/then`, instancePath, thenSchema, value) || context.AddError({
-      keyword: 'if',
-      schemaPath,
-      instancePath,
-      params: { failingKeyword: 'then' },
-    })
-    : ErrorSchema(stack, context, `${schemaPath}/else`, instancePath, elseSchema, value) || context.AddError({
-      keyword: 'if',
-      schemaPath,
-      instancePath,
-      params: { failingKeyword: 'else' },
-    })
+    ? ErrorSchema(stack, trueContext, `${schemaPath}/then`, instancePath, thenSchema, value) ||
+    context.AddError('if', schemaPath, instancePath, { failingKeyword: 'then' })
+    : ErrorSchema(stack, context, `${schemaPath}/else`, instancePath, elseSchema, value) ||
+    context.AddError('if', schemaPath, instancePath, { failingKeyword: 'else' })
   if (isIf) context.Merge([trueContext])
   return isIf
-}
+} 

--- a/src/schema/engine/items.ts
+++ b/src/schema/engine/items.ts
@@ -29,15 +29,15 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
-import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchemaPushStack, CheckSchemaPushStack, ErrorSchemaPushStack } from './schema.ts'
+import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // ItemsSized
 // ------------------------------------------------------------------
-function BuildItemsSizedStandard(stack: Stack, context: BuildContext, schema: Schema.XItemsSized, value: string): string {
+function BuildItemsSizedStandard(stack: Stack.XStack, context: BuildContext, schema: Schema.XItemsSized, value: string): string {
   return E.ReduceAnd(schema.items.map((schema, index) => {
     const isLength = E.IsLessEqualThan(E.Member(value, 'length'), E.Constant(index))
     const isSchema = BuildSchemaPushStack(stack, context, schema, `${value}[${index}]`)
@@ -45,25 +45,25 @@ function BuildItemsSizedStandard(stack: Stack, context: BuildContext, schema: Sc
     return E.Or(isLength, E.And(isSchema, addIndex))
   }))
 }
-function BuildItemsSizedFast(stack: Stack, context: BuildContext, schema: Schema.XItemsSized, value: string): string {
+function BuildItemsSizedFast(stack: Stack.XStack, context: BuildContext, schema: Schema.XItemsSized, value: string): string {
   return E.ReduceAnd(schema.items.map((schema, index) => {
     const isLength = E.IsLessEqualThan(E.Member(value, 'length'), E.Constant(index))
     const isSchema = BuildSchemaPushStack(stack, context, schema, `${value}[${index}]`)
     return E.Or(isLength, isSchema)
   }))
 }
-function BuildItemsSized(stack: Stack, context: BuildContext, schema: Schema.XItemsSized, value: string): string {
+function BuildItemsSized(stack: Stack.XStack, context: BuildContext, schema: Schema.XItemsSized, value: string): string {
   return context.UseUnevaluated()
     ? BuildItemsSizedStandard(stack, context, schema, value)
     : BuildItemsSizedFast(stack, context, schema, value)
 }
-function CheckItemsSized(stack: Stack, context: CheckContext, schema: Schema.XItemsSized, value: unknown[]): boolean {
+function CheckItemsSized(stack: Stack.XStack, context: CheckContext, schema: Schema.XItemsSized, value: unknown[]): boolean {
   return G.Every(schema.items, 0, (schema, index) => {
     return G.IsLessEqualThan(value.length, index)
       || (CheckSchemaPushStack(stack, context, schema, value[index]) && context.AddIndex(index))
   })
 }
-function ErrorItemsSized(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XItemsSized, value: unknown[]): boolean {
+function ErrorItemsSized(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XItemsSized, value: unknown[]): boolean {
   return G.EveryAll(schema.items, 0, (schema, index) => {
     const nextSchemaPath = `${schemaPath}/items/${index}`
     const nextInstancePath = `${instancePath}/${index}`
@@ -74,30 +74,30 @@ function ErrorItemsSized(stack: Stack, context: ErrorContext, schemaPath: string
 // ------------------------------------------------------------------
 // ItemsUnsized
 // ------------------------------------------------------------------
-function BuildItemsUnsizedStandard(stack: Stack, context: BuildContext, schema: Schema.XItemsUnsized, value: string): string {
+function BuildItemsUnsizedStandard(stack: Stack.XStack, context: BuildContext, schema: Schema.XItemsUnsized, value: string): string {
   const offset = Schema.IsPrefixItems(schema) ? schema.prefixItems.length : 0
   const isSchema = BuildSchemaPushStack(stack, context, schema.items, 'element')
   const addIndex = context.AddIndex('index')
   return E.Every(value, E.Constant(offset), ['element', 'index'], E.And(isSchema, addIndex))
 }
-function BuildItemsUnsizedFast(stack: Stack, context: BuildContext, schema: Schema.XItemsUnsized, value: string): string {
+function BuildItemsUnsizedFast(stack: Stack.XStack, context: BuildContext, schema: Schema.XItemsUnsized, value: string): string {
   const offset = Schema.IsPrefixItems(schema) ? schema.prefixItems.length : 0
   const isSchema = BuildSchemaPushStack(stack, context, schema.items, 'element')
   return E.Every(value, E.Constant(offset), ['element', 'index'], isSchema)
 }
-function BuildItemsUnsized(stack: Stack, context: BuildContext, schema: Schema.XItemsUnsized, value: string): string {
+function BuildItemsUnsized(stack: Stack.XStack, context: BuildContext, schema: Schema.XItemsUnsized, value: string): string {
   return context.UseUnevaluated()
     ? BuildItemsUnsizedStandard(stack, context, schema, value)
     : BuildItemsUnsizedFast(stack, context, schema, value)
 }
-function CheckItemsUnsized(stack: Stack, context: CheckContext, schema: Schema.XItemsUnsized, value: unknown[]): boolean {
+function CheckItemsUnsized(stack: Stack.XStack, context: CheckContext, schema: Schema.XItemsUnsized, value: unknown[]): boolean {
   const offset = Schema.IsPrefixItems(schema) ? schema.prefixItems.length : 0
   return G.Every(value, offset, (element, index) => {
     return CheckSchemaPushStack(stack, context, schema.items, element)
       && context.AddIndex(index)
   })
 }
-function ErrorItemsUnsized(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XItemsUnsized, value: unknown[]): boolean {
+function ErrorItemsUnsized(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XItemsUnsized, value: unknown[]): boolean {
   const offset = Schema.IsPrefixItems(schema) ? schema.prefixItems.length : 0
   return G.EveryAll(value, offset, (element, index) => {
     const nextSchemaPath = `${schemaPath}/items`
@@ -109,12 +109,12 @@ function ErrorItemsUnsized(stack: Stack, context: ErrorContext, schemaPath: stri
 // ------------------------------------------------------------------
 // Items
 // ------------------------------------------------------------------
-export function BuildItems(stack: Stack, context: BuildContext, schema: Schema.XItems, value: string): string {
+export function BuildItems(stack: Stack.XStack, context: BuildContext, schema: Schema.XItems, value: string): string {
   return Schema.IsItemsSized(schema) ? BuildItemsSized(stack, context, schema, value) : BuildItemsUnsized(stack, context, schema, value)
 }
-export function CheckItems(stack: Stack, context: CheckContext, schema: Schema.XItems, value: unknown[]): boolean {
+export function CheckItems(stack: Stack.XStack, context: CheckContext, schema: Schema.XItems, value: unknown[]): boolean {
   return Schema.IsItemsSized(schema) ? CheckItemsSized(stack, context, schema, value) : CheckItemsUnsized(stack, context, schema, value)
 }
-export function ErrorItems(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XItems, value: unknown[]): boolean {
+export function ErrorItems(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XItems, value: unknown[]): boolean {
   return Schema.IsItemsSized(schema) ? ErrorItemsSized(stack, context, schemaPath, instancePath, schema, value) : ErrorItemsUnsized(stack, context, schemaPath, instancePath, schema, value)
 }

--- a/src/schema/engine/maxContains.ts
+++ b/src/schema/engine/maxContains.ts
@@ -29,7 +29,7 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { Unique } from './_unique.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
@@ -44,7 +44,7 @@ function IsValid(schema: Schema.XMaxContains): schema is Schema.XMaxContains & S
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildMaxContains(stack: Stack, context: BuildContext, schema: Schema.XMaxContains, value: string): string {
+export function BuildMaxContains(stack: Stack.XStack, context: BuildContext, schema: Schema.XMaxContains, value: string): string {
   if (!IsValid(schema)) return E.Constant(true)
   const [item] = [Unique()]
   const count = E.Counted(value, [item, '_'], BuildSchema(stack, context, schema.contains, item))
@@ -53,7 +53,7 @@ export function BuildMaxContains(stack: Stack, context: BuildContext, schema: Sc
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckMaxContains(stack: Stack, context: CheckContext, schema: Schema.XMaxContains, value: unknown[]): boolean {
+export function CheckMaxContains(stack: Stack.XStack, context: CheckContext, schema: Schema.XMaxContains, value: unknown[]): boolean {
   if (!IsValid(schema)) return true
   const count = G.Counted(value, (item) => CheckSchema(stack, context, schema.contains, item))
   return G.IsLessEqualThan(count, schema.maxContains)
@@ -61,12 +61,8 @@ export function CheckMaxContains(stack: Stack, context: CheckContext, schema: Sc
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorMaxContains(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMaxContains, value: unknown[]): boolean {
+export function ErrorMaxContains(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMaxContains, value: unknown[]): boolean {
   const minContains = Schema.IsMinContains(schema) ? schema.minContains : 1
-  return CheckMaxContains(stack, context, schema, value) || context.AddError({
-    keyword: 'contains',
-    schemaPath,
-    instancePath,
-    params: { minContains, maxContains: schema.maxContains },
-  })
+  return CheckMaxContains(stack, context, schema, value) ||
+    context.AddError('contains', schemaPath, instancePath, { minContains, maxContains: schema.maxContains })
 }

--- a/src/schema/engine/maxItems.ts
+++ b/src/schema/engine/maxItems.ts
@@ -29,30 +29,26 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildMaxItems(_stack: Stack, _context: BuildContext, schema: Schema.XMaxItems, value: string): string {
+export function BuildMaxItems(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XMaxItems, value: string): string {
   return E.IsLessEqualThan(E.Member(value, 'length'), E.Constant(schema.maxItems))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckMaxItems(_stack: Stack, _context: CheckContext, schema: Schema.XMaxItems, value: unknown[]): boolean {
+export function CheckMaxItems(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XMaxItems, value: unknown[]): boolean {
   return G.IsLessEqualThan(value.length, schema.maxItems)
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorMaxItems(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMaxItems, value: unknown[]): boolean {
-  return CheckMaxItems(stack, context, schema, value) || context.AddError({
-    keyword: 'maxItems',
-    schemaPath,
-    instancePath,
-    params: { limit: schema.maxItems }
-  })
+export function ErrorMaxItems(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMaxItems, value: unknown[]): boolean {
+  return CheckMaxItems(stack, context, schema, value) ||
+    context.AddError('maxItems', schemaPath, instancePath, { limit: schema.maxItems })
 }

--- a/src/schema/engine/maxLength.ts
+++ b/src/schema/engine/maxLength.ts
@@ -29,30 +29,26 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildMaxLength(_stack: Stack, _context: BuildContext, schema: Schema.XMaxLength, value: string): string {
+export function BuildMaxLength(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XMaxLength, value: string): string {
   return E.IsMaxLength(value, E.Constant(schema.maxLength))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckMaxLength(_stack: Stack, _context: CheckContext, schema: Schema.XMaxLength, value: string): boolean {
+export function CheckMaxLength(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XMaxLength, value: string): boolean {
   return G.IsMaxLength(value, schema.maxLength)
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorMaxLength(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMaxLength, value: string): boolean {
-  return CheckMaxLength(stack, context, schema, value) || context.AddError({
-    keyword: 'maxLength',
-    schemaPath,
-    instancePath,
-    params: { limit: schema.maxLength }
-  })
+export function ErrorMaxLength(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMaxLength, value: string): boolean {
+  return CheckMaxLength(stack, context, schema, value) ||
+    context.AddError('maxLength', schemaPath, instancePath, { limit: schema.maxLength })
 }

--- a/src/schema/engine/maxProperties.ts
+++ b/src/schema/engine/maxProperties.ts
@@ -29,30 +29,26 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildMaxProperties(_stack: Stack, _context: BuildContext, schema: Schema.XMaxProperties, value: string): string {
+export function BuildMaxProperties(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XMaxProperties, value: string): string {
   return E.IsLessEqualThan(E.Member(E.Keys(value), 'length'), E.Constant(schema.maxProperties))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckMaxProperties(_stack: Stack, _context: CheckContext, schema: Schema.XMaxProperties, value: Record<PropertyKey, unknown>): boolean {
+export function CheckMaxProperties(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XMaxProperties, value: Record<PropertyKey, unknown>): boolean {
   return G.IsLessEqualThan(G.Keys(value).length, schema.maxProperties)
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function ErrorMaxProperties(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMaxProperties, value: Record<PropertyKey, unknown>): boolean {
-  return CheckMaxProperties(stack, context, schema, value) || context.AddError({
-    keyword: 'maxProperties',
-    schemaPath,
-    instancePath,
-    params: { limit: schema.maxProperties },
-  })
+export function ErrorMaxProperties(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMaxProperties, value: Record<PropertyKey, unknown>): boolean {
+  return CheckMaxProperties(stack, context, schema, value) ||
+    context.AddError('maxProperties', schemaPath, instancePath, { limit: schema.maxProperties })
 }

--- a/src/schema/engine/maximum.ts
+++ b/src/schema/engine/maximum.ts
@@ -29,30 +29,26 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildMaximum(_stack: Stack, _context: BuildContext, schema: Schema.XMaximum, value: string): string {
+export function BuildMaximum(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XMaximum, value: string): string {
   return E.IsLessEqualThan(value, E.Constant(schema.maximum))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckMaximum(_stack: Stack, _context: CheckContext, schema: Schema.XMaximum, value: number | bigint): boolean {
+export function CheckMaximum(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XMaximum, value: number | bigint): boolean {
   return G.IsLessEqualThan(value, schema.maximum)
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorMaximum(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMaximum, value: number | bigint): boolean {
-  return CheckMaximum(stack, context, schema, value) || context.AddError({
-    keyword: 'maximum',
-    schemaPath,
-    instancePath,
-    params: { comparison: '<=', limit: schema.maximum }
-  })
+export function ErrorMaximum(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMaximum, value: number | bigint): boolean {
+  return CheckMaximum(stack, context, schema, value) ||
+    context.AddError('maximum', schemaPath, instancePath, { comparison: '<=', limit: schema.maximum })
 }

--- a/src/schema/engine/minContains.ts
+++ b/src/schema/engine/minContains.ts
@@ -29,9 +29,8 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { Unique } from './_unique.ts'
-
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema } from './schema.ts'
@@ -45,17 +44,17 @@ function IsValid(schema: Schema.XMinContains): schema is Schema.XMinContains & S
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-function BuildMinContainsStandard(stack: Stack, context: BuildContext, schema: Schema.XMinContains & Schema.XContains, value: string): string {
+function BuildMinContainsStandard(stack: Stack.XStack, context: BuildContext, schema: Schema.XMinContains & Schema.XContains, value: string): string {
   const [item, index] = [Unique(), Unique()]
   const count = E.Counted(value, [item, index], E.And(BuildSchema(stack, context, schema.contains, item), context.AddIndex(index)))
   return E.IsGreaterEqualThan(count, E.Constant(schema.minContains))
 }
-function BuildMinContainsFast(stack: Stack, context: BuildContext, schema: Schema.XMinContains & Schema.XContains, value: string): string {
+function BuildMinContainsFast(stack: Stack.XStack, context: BuildContext, schema: Schema.XMinContains & Schema.XContains, value: string): string {
   const [item] = [Unique()]
   const count = E.Counted(value, [item, '_'], BuildSchema(stack, context, schema.contains, item))
   return E.IsGreaterEqualThan(count, E.Constant(schema.minContains))
 }
-export function BuildMinContains(stack: Stack, context: BuildContext, schema: Schema.XMinContains, value: string): string {
+export function BuildMinContains(stack: Stack.XStack, context: BuildContext, schema: Schema.XMinContains, value: string): string {
   if (!IsValid(schema)) return E.Constant(true)
   return context.UseUnevaluated()
     ? BuildMinContainsStandard(stack, context, schema, value)
@@ -64,9 +63,9 @@ export function BuildMinContains(stack: Stack, context: BuildContext, schema: Sc
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckMinContains(stack: Stack, context: CheckContext, schema: Schema.XMinContains, value: unknown[]): boolean {
+export function CheckMinContains(stack: Stack.XStack, context: CheckContext, schema: Schema.XMinContains, value: unknown[]): boolean {
   if (!IsValid(schema)) return true
-  const count = G.Counted(value, (item, index) => 
+  const count = G.Counted(value, (item, index) =>
     CheckSchema(stack, context, schema.contains, item) && context.AddIndex(index)
   )
   return G.IsGreaterEqualThan(count, schema.minContains)
@@ -74,13 +73,9 @@ export function CheckMinContains(stack: Stack, context: CheckContext, schema: Sc
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorMinContains(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMinContains, value: unknown[]): boolean {
-  return CheckMinContains(stack, context, schema, value) || context.AddError({
-    keyword: 'contains',
-    schemaPath,
-    instancePath,
-    params: { minContains: schema.minContains }
-  })
+export function ErrorMinContains(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMinContains, value: unknown[]): boolean {
+  return CheckMinContains(stack, context, schema, value) ||
+    context.AddError('contains', schemaPath, instancePath, { minContains: schema.minContains })
 }
 
 

--- a/src/schema/engine/minItems.ts
+++ b/src/schema/engine/minItems.ts
@@ -28,31 +28,27 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import { Stack } from './_stack.ts'
+import * as Schema from '../types/index.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
-import * as Schema from '../types/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildMinItems(_stack: Stack, _context: BuildContext, schema: Schema.XMinItems, value: string): string {
+export function BuildMinItems(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XMinItems, value: string): string {
   return E.IsGreaterEqualThan(E.Member(value, 'length'), E.Constant(schema.minItems))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckMinItems(_stack: Stack, _context: CheckContext, schema: Schema.XMinItems, value: unknown[]): boolean {
+export function CheckMinItems(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XMinItems, value: unknown[]): boolean {
   return G.IsGreaterEqualThan(value.length, schema.minItems)
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorMinItems(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMinItems, value: unknown[]): boolean {
-  return CheckMinItems(stack, context, schema, value) || context.AddError({
-    keyword: 'minItems',
-    schemaPath,
-    instancePath,
-    params: { limit: schema.minItems }
-  })
+export function ErrorMinItems(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMinItems, value: unknown[]): boolean {
+  return CheckMinItems(stack, context, schema, value) ||
+    context.AddError('minItems', schemaPath, instancePath, { limit: schema.minItems })
 }

--- a/src/schema/engine/minLength.ts
+++ b/src/schema/engine/minLength.ts
@@ -29,30 +29,26 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildMinLength(_stack: Stack, _context: BuildContext, schema: Schema.XMinLength, value: string): string {
+export function BuildMinLength(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XMinLength, value: string): string {
   return E.IsMinLength(value, E.Constant(schema.minLength))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckMinLength(_stack: Stack, _context: CheckContext, schema: Schema.XMinLength, value: string): boolean {
+export function CheckMinLength(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XMinLength, value: string): boolean {
   return G.IsMinLength(value, schema.minLength)
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorMinLength(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMinLength, value: string): boolean {
-  return CheckMinLength(stack, context, schema, value) || context.AddError({
-    keyword: 'minLength',
-    schemaPath,
-    instancePath,
-    params: { limit: schema.minLength }
-  })
+export function ErrorMinLength(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMinLength, value: string): boolean {
+  return CheckMinLength(stack, context, schema, value) ||
+    context.AddError('minLength', schemaPath, instancePath, { limit: schema.minLength })
 }

--- a/src/schema/engine/minProperties.ts
+++ b/src/schema/engine/minProperties.ts
@@ -29,30 +29,26 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildMinProperties(_stack: Stack, _context: BuildContext, schema: Schema.XMinProperties, value: string): string {
+export function BuildMinProperties(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XMinProperties, value: string): string {
   return E.IsGreaterEqualThan(E.Member(E.Keys(value), 'length'), E.Constant(schema.minProperties))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckMinProperties(_stack: Stack, _context: CheckContext, schema: Schema.XMinProperties, value: Record<PropertyKey, unknown>): boolean {
+export function CheckMinProperties(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XMinProperties, value: Record<PropertyKey, unknown>): boolean {
   return G.IsGreaterEqualThan(G.Keys(value).length, schema.minProperties)
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorMinProperties(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMinProperties, value: Record<PropertyKey, unknown>): boolean {
-  return CheckMinProperties(stack, context, schema, value) || context.AddError({
-    keyword: 'minProperties',
-    schemaPath,
-    instancePath,
-    params: { limit: schema.minProperties },
-  })
+export function ErrorMinProperties(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMinProperties, value: Record<PropertyKey, unknown>): boolean {
+  return CheckMinProperties(stack, context, schema, value) ||
+    context.AddError('minProperties', schemaPath, instancePath, { limit: schema.minProperties })
 }

--- a/src/schema/engine/minimum.ts
+++ b/src/schema/engine/minimum.ts
@@ -29,30 +29,26 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildMinimum(_stack: Stack, _context: BuildContext, schema: Schema.XMinimum, value: string): string {
+export function BuildMinimum(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XMinimum, value: string): string {
   return E.IsGreaterEqualThan(value, E.Constant(schema.minimum))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckMinimum(_stack: Stack, _context: CheckContext, schema: Schema.XMinimum, value: number | bigint): boolean {
+export function CheckMinimum(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XMinimum, value: number | bigint): boolean {
   return G.IsGreaterEqualThan(value, schema.minimum)
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorMinimum(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMinimum, value: number | bigint): boolean {
-  return CheckMinimum(stack, context, schema, value) || context.AddError({
-    keyword: 'minimum',
-    schemaPath,
-    instancePath,
-    params: { comparison: '>=', limit: schema.minimum }
-  })
+export function ErrorMinimum(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMinimum, value: number | bigint): boolean {
+  return CheckMinimum(stack, context, schema, value) ||
+    context.AddError('minimum', schemaPath, instancePath, { comparison: '>=', limit: schema.minimum })
 }

--- a/src/schema/engine/multipleOf.ts
+++ b/src/schema/engine/multipleOf.ts
@@ -29,30 +29,26 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildMultipleOf(_stack: Stack, _context: BuildContext, schema: Schema.XMultipleOf, value: string): string {
+export function BuildMultipleOf(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XMultipleOf, value: string): string {
   return E.MultipleOf(value, E.Constant(schema.multipleOf))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckMultipleOf(_stack: Stack, _context: CheckContext, schema: Schema.XMultipleOf, value: number | bigint): boolean {
+export function CheckMultipleOf(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XMultipleOf, value: number | bigint): boolean {
   return G.IsMultipleOf(value, schema.multipleOf)
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorMultipleOf(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMultipleOf, value: number | bigint): boolean {
-  return CheckMultipleOf(stack, context, schema, value) || context.AddError({
-    keyword: 'multipleOf',
-    schemaPath,
-    instancePath,
-    params: { multipleOf: schema.multipleOf }
-  })
+export function ErrorMultipleOf(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XMultipleOf, value: number | bigint): boolean {
+  return CheckMultipleOf(stack, context, schema, value) ||
+    context.AddError('multipleOf', schemaPath, instancePath, { multipleOf: schema.multipleOf })
 }

--- a/src/schema/engine/not.ts
+++ b/src/schema/engine/not.ts
@@ -29,31 +29,30 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
-import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
+import * as Stack from './_stack.ts'
 import { Reducer } from './_reducer.ts'
-import { EmitGuard as E } from '../../guard/index.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { BuildSchema, CheckSchema } from './schema.ts'
-
+import { EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-function BuildNotStandard(stack: Stack, context: BuildContext, schema: Schema.XNot, value: string): string {
+function BuildNotStandard(stack: Stack.XStack, context: BuildContext, schema: Schema.XNot, value: string): string {
   return Reducer(stack, context, [schema.not], value, E.Not(E.IsEqual(E.Member('results', 'length'), E.Constant(1))))
 }
-function BuildNotFast(stack: Stack, context: BuildContext, schema: Schema.XNot, value: string): string {
+function BuildNotFast(stack: Stack.XStack, context: BuildContext, schema: Schema.XNot, value: string): string {
   return E.Not(BuildSchema(stack, context, schema.not, value))
 }
-export function BuildNot(stack: Stack, context: BuildContext, schema: Schema.XNot, value: string): string {
-  return context.UseUnevaluated() 
-    ? BuildNotStandard(stack, context, schema, value) 
+export function BuildNot(stack: Stack.XStack, context: BuildContext, schema: Schema.XNot, value: string): string {
+  return context.UseUnevaluated()
+    ? BuildNotStandard(stack, context, schema, value)
     : BuildNotFast(stack, context, schema, value)
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckNot(stack: Stack, context: CheckContext, schema: Schema.XNot, value: unknown): boolean {
+export function CheckNot(stack: Stack.XStack, context: CheckContext, schema: Schema.XNot, value: unknown): boolean {
   const nextContext = new CheckContext()
   const isSchema = !CheckSchema(stack, nextContext, schema.not, value)
   const isNot = isSchema && context.Merge([nextContext])
@@ -62,11 +61,7 @@ export function CheckNot(stack: Stack, context: CheckContext, schema: Schema.XNo
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorNot(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XNot, value: unknown): boolean {
-  return CheckNot(stack, context, schema, value) || context.AddError({
-    keyword: 'not',
-    schemaPath,
-    instancePath,
-    params: {},
-  })
+export function ErrorNot(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XNot, value: unknown): boolean {
+  return CheckNot(stack, context, schema, value) ||
+    context.AddError('not', schemaPath, instancePath, {})
 }

--- a/src/schema/engine/oneOf.ts
+++ b/src/schema/engine/oneOf.ts
@@ -29,26 +29,26 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
-import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
+import * as Stack from './_stack.ts'
 import { Reducer } from './_reducer.ts'
-import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
-import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
 import { Unique } from './_unique.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
+import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
+import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-function BuildOneOfStandard(stack: Stack, context: BuildContext, schema: Schema.XOneOf, value: string): string {
+function BuildOneOfStandard(stack: Stack.XStack, context: BuildContext, schema: Schema.XOneOf, value: string): string {
   return Reducer(stack, context, schema.oneOf, value, E.IsEqual(E.Member('results', 'length'), E.Constant(1)))
 }
-function BuildOneOfFast(stack: Stack, context: BuildContext, schema: Schema.XOneOf, value: string): string {
+function BuildOneOfFast(stack: Stack.XStack, context: BuildContext, schema: Schema.XOneOf, value: string): string {
   const [result] = [Unique()]
   const results = E.ArrayLiteral(schema.oneOf.map((schema) => BuildSchema(stack, context, schema, value)))
   const count = E.Counted(results, [result, '_'], E.IsEqual(result, E.Constant(true)))
   return E.IsEqual(count, E.Constant(1))
 }
-export function BuildOneOf(stack: Stack, context: BuildContext, schema: Schema.XOneOf, value: string): string {
+export function BuildOneOf(stack: Stack.XStack, context: BuildContext, schema: Schema.XOneOf, value: string): string {
   return context.UseUnevaluated() 
     ? BuildOneOfStandard(stack, context, schema, value) 
     : BuildOneOfFast(stack, context, schema, value)
@@ -56,7 +56,7 @@ export function BuildOneOf(stack: Stack, context: BuildContext, schema: Schema.X
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckOneOf(stack: Stack, context: CheckContext, schema: Schema.XOneOf, value: unknown): boolean {
+export function CheckOneOf(stack: Stack.XStack, context: CheckContext, schema: Schema.XOneOf, value: unknown): boolean {
   const passedContexts = schema.oneOf.reduce<CheckContext[]>((result, schema) => {
     const nextContext = new CheckContext()
     return CheckSchema(stack, nextContext, schema, value) ? [...result, nextContext] : result
@@ -66,10 +66,9 @@ export function CheckOneOf(stack: Stack, context: CheckContext, schema: Schema.X
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorOneOf(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XOneOf, value: unknown): boolean {
+export function ErrorOneOf(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XOneOf, value: unknown): boolean {
   const failedContexts: ErrorContext[] = []
   const passingSchemas: number[] = []
-
   const passedContexts = schema.oneOf.reduce<ErrorContext[]>((result, schema, index) => {
     const nextContext = new ErrorContext()
     const nextSchemaPath = `${schemaPath}/oneOf/${index}`
@@ -78,13 +77,8 @@ export function ErrorOneOf(stack: Stack, context: ErrorContext, schemaPath: stri
     if (!isSchema) failedContexts.push(nextContext)
     return isSchema ? [...result, nextContext] : result
   }, [])
-
+  
   const isOneOf = G.IsEqual(passedContexts.length, 1) && context.Merge(passedContexts)
-  if (!isOneOf && G.IsEqual(passingSchemas.length, 0)) failedContexts.forEach(failed => failed.GetErrors().forEach(error => context.AddError(error)))
-  return isOneOf || context.AddError({
-    keyword: 'oneOf',
-    schemaPath,
-    instancePath,
-    params: { passingSchemas },
-  })
+  if (!isOneOf && G.IsEqual(passingSchemas.length, 0)) failedContexts.forEach(failed => context.AddErrors(failed.GetErrors()))
+  return isOneOf || context.AddError('oneOf', schemaPath, instancePath, { passingSchemas })
 }

--- a/src/schema/engine/pattern.ts
+++ b/src/schema/engine/pattern.ts
@@ -29,34 +29,30 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
+import * as Stack from './_stack.ts'
 import * as Externals from './_externals.ts'
-import { Stack } from './_stack.ts'
+import { UnicodeRegExp } from './_regexp.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
-import { UnicodeRegExp } from './_regexp.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildPattern(_stack: Stack, _context: BuildContext, schema: Schema.XPattern, value: string): string {
+export function BuildPattern(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XPattern, value: string): string {
   const regexp = Externals.CreateVariable(G.IsString(schema.pattern) ? UnicodeRegExp(schema.pattern) : schema.pattern)
   return E.Call(E.Member(regexp, 'test'), [value])
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckPattern(_stack: Stack, _context: CheckContext, schema: Schema.XPattern, value: string): boolean {
+export function CheckPattern(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XPattern, value: string): boolean {
   const regexp = G.IsString(schema.pattern) ? UnicodeRegExp(schema.pattern) : schema.pattern
   return regexp.test(value)
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorPattern(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XPattern, value: string): boolean {
-  return CheckPattern(stack, context, schema, value) || context.AddError({
-    keyword: 'pattern',
-    schemaPath,
-    instancePath,
-    params: { pattern: schema.pattern }
-  })
+export function ErrorPattern(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XPattern, value: string): boolean {
+  return CheckPattern(stack, context, schema, value) ||
+    context.AddError('pattern', schemaPath, instancePath, { pattern: schema.pattern })
 }

--- a/src/schema/engine/patternProperties.ts
+++ b/src/schema/engine/patternProperties.ts
@@ -29,19 +29,18 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
+import * as Stack from './_stack.ts'
 import * as Externals from './_externals.ts'
-import { Stack } from './_stack.ts'
 import { Unique } from './_unique.ts'
-
-import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { UnicodeRegExp } from './_regexp.ts'
-import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
+import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { BuildSchemaPushStack, CheckSchemaPushStack, ErrorSchemaPushStack } from './schema.ts'
+import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildPatternProperties(stack: Stack, context: BuildContext, schema: Schema.XPatternProperties, value: string): string {
+export function BuildPatternProperties(stack: Stack.XStack, context: BuildContext, schema: Schema.XPatternProperties, value: string): string {
   return E.ReduceAnd(G.Entries(schema.patternProperties).map(([pattern, schema]) => {
     const [key, prop] = [Unique(), Unique()]
     const regexp = Externals.CreateVariable(UnicodeRegExp(pattern))
@@ -55,7 +54,7 @@ export function BuildPatternProperties(stack: Stack, context: BuildContext, sche
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckPatternProperties(stack: Stack, context: CheckContext, schema: Schema.XPatternProperties, value: Record<PropertyKey, unknown>): boolean {
+export function CheckPatternProperties(stack: Stack.XStack, context: CheckContext, schema: Schema.XPatternProperties, value: Record<PropertyKey, unknown>): boolean {
   return G.Every(G.Entries(schema.patternProperties), 0, ([pattern, schema]) => {
     const regexp = UnicodeRegExp(pattern)
     return G.Every(G.Entries(value), 0, ([key, prop]) => {
@@ -66,7 +65,7 @@ export function CheckPatternProperties(stack: Stack, context: CheckContext, sche
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorPatternProperties(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XPatternProperties, value: Record<PropertyKey, unknown>): boolean {
+export function ErrorPatternProperties(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XPatternProperties, value: Record<PropertyKey, unknown>): boolean {
   return G.EveryAll(G.Entries(schema.patternProperties), 0, ([pattern, schema]) => {
     const nextSchemaPath = `${schemaPath}/patternProperties/${pattern}`
     const regexp = UnicodeRegExp(pattern)

--- a/src/schema/engine/prefixItems.ts
+++ b/src/schema/engine/prefixItems.ts
@@ -29,15 +29,15 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
-import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchemaPushStack, CheckSchemaPushStack, ErrorSchemaPushStack } from './schema.ts'
+import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildPrefixItems(stack: Stack, context: BuildContext, schema: Schema.XPrefixItems, value: string): string {
+export function BuildPrefixItems(stack: Stack.XStack, context: BuildContext, schema: Schema.XPrefixItems, value: string): string {
   return E.ReduceAnd(schema.prefixItems.map((schema, index) => {
     const isLength = E.IsLessEqualThan(E.Member(value, 'length'), E.Constant(index))
     const isSchema = BuildSchemaPushStack(stack, context, schema, `${value}[${index}]`)
@@ -49,7 +49,7 @@ export function BuildPrefixItems(stack: Stack, context: BuildContext, schema: Sc
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckPrefixItems(stack: Stack, context: CheckContext, schema: Schema.XPrefixItems, value: unknown[]): boolean {
+export function CheckPrefixItems(stack: Stack.XStack, context: CheckContext, schema: Schema.XPrefixItems, value: unknown[]): boolean {
   return G.IsEqual(value.length, 0) || G.Every(schema.prefixItems, 0, (schema, index) => {
     return G.IsLessEqualThan(value.length, index) 
       || (CheckSchemaPushStack(stack, context, schema, value[index]) && context.AddIndex(index))
@@ -58,7 +58,7 @@ export function CheckPrefixItems(stack: Stack, context: CheckContext, schema: Sc
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorPrefixItems(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XPrefixItems, value: unknown[]): boolean {
+export function ErrorPrefixItems(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XPrefixItems, value: unknown[]): boolean {
   return G.IsEqual(value.length, 0) || G.EveryAll(schema.prefixItems, 0, (schema, index) => {
     const nextSchemaPath = `${schemaPath}/prefixItems/${index}`
     const nextInstancePath = `${instancePath}/${index}`

--- a/src/schema/engine/properties.ts
+++ b/src/schema/engine/properties.ts
@@ -28,23 +28,22 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
-import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchemaPushStack, CheckSchemaPushStack, ErrorSchemaPushStack } from './schema.ts'
 import { InexactOptionalCheck, InexactOptionalBuild, IsExactOptional } from './_exact_optional.ts'
+import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildProperties(stack: Stack, context: BuildContext, schema: Schema.XProperties, value: string): string {
+export function BuildProperties(stack: Stack.XStack, context: BuildContext, schema: Schema.XProperties, value: string): string {
   const required = Schema.IsRequired(schema) ? schema.required : []
   const everyKey = G.Entries(schema.properties).map(([key, schema]) => {
     const notKey = E.Not(E.HasPropertyKey(value, E.Constant(key)))
     const isSchema = BuildSchemaPushStack(stack, context, schema, E.Member(value, key))
     const addKey = context.AddKey(E.Constant(key))
     const guarded = context.UseUnevaluated() ? E.And(isSchema, addKey) : isSchema
-    
     // --------------------------------------------------------------
     // Optimization
     //
@@ -53,7 +52,6 @@ export function BuildProperties(stack: Stack, context: BuildContext, schema: Sch
     // only valid when Required is evaluated before Properties.
     //
     // --------------------------------------------------------------
-
     const isProperty = required.includes(key) ? guarded : E.Or(notKey, guarded)
 
     // --------------------------------------------------------------
@@ -81,7 +79,7 @@ export function BuildProperties(stack: Stack, context: BuildContext, schema: Sch
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckProperties(stack: Stack, context: CheckContext, schema: Schema.XProperties, value: Record<PropertyKey, unknown>): boolean {
+export function CheckProperties(stack: Stack.XStack, context: CheckContext, schema: Schema.XProperties, value: Record<PropertyKey, unknown>): boolean {
   const required = Schema.IsRequired(schema) ? schema.required : []
   const isProperties = G.Every(G.Entries(schema.properties), 0, ([key, schema]) => {
     const isProperty = !G.HasPropertyKey(value, key) || (CheckSchemaPushStack(stack, context, schema, value[key]) && context.AddKey(key))
@@ -94,7 +92,7 @@ export function CheckProperties(stack: Stack, context: CheckContext, schema: Sch
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorProperties(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XProperties, value: Record<PropertyKey, unknown>): boolean {
+export function ErrorProperties(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XProperties, value: Record<PropertyKey, unknown>): boolean {
   const required = Schema.IsRequired(schema) ? schema.required : []
   const isProperties = G.EveryAll(G.Entries(schema.properties), 0, ([key, schema]) => {
     const nextSchemaPath = `${schemaPath}/properties/${key}`

--- a/src/schema/engine/propertyNames.ts
+++ b/src/schema/engine/propertyNames.ts
@@ -29,29 +29,29 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { Unique } from './_unique.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
-import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
+import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildPropertyNames(stack: Stack, context: BuildContext, schema: Schema.XPropertyNames, value: string): string {
+export function BuildPropertyNames(stack: Stack.XStack, context: BuildContext, schema: Schema.XPropertyNames, value: string): string {
   const [key, _index] = [Unique(), Unique()]
   return E.Every(E.Keys(value), E.Constant(0), [key, _index], BuildSchema(stack, context, schema.propertyNames, key))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckPropertyNames(stack: Stack, context: CheckContext, schema: Schema.XPropertyNames, value: Record<PropertyKey, unknown>): boolean {
+export function CheckPropertyNames(stack: Stack.XStack, context: CheckContext, schema: Schema.XPropertyNames, value: Record<PropertyKey, unknown>): boolean {
   return G.Every(G.Keys(value), 0, (key, _index) => CheckSchema(stack, context, schema.propertyNames, key))
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorPropertyNames(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XPropertyNames, value: Record<PropertyKey, unknown>): boolean {
+export function ErrorPropertyNames(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XPropertyNames, value: Record<PropertyKey, unknown>): boolean {
   const propertyNames: string[] = []
   const isPropertyNames = G.EveryAll(G.Keys(value), 0, (key, _index) => {
     const nextInstancePath = `${instancePath}/${key}`
@@ -60,10 +60,6 @@ export function ErrorPropertyNames(stack: Stack, context: ErrorContext, schemaPa
     if (!isPropertyName) propertyNames.push(key)
     return isPropertyName
   })
-  return isPropertyNames || context.AddError({
-    keyword: 'propertyNames',
-    schemaPath,
-    instancePath,
-    params: { propertyNames }
-  })
+  return isPropertyNames ||
+    context.AddError('propertyNames', schemaPath, instancePath, { propertyNames })
 }

--- a/src/schema/engine/recursiveRef.ts
+++ b/src/schema/engine/recursiveRef.ts
@@ -28,30 +28,34 @@ THE SOFTWARE.
 
 // deno-fmt-ignore-file
 
-import * as Functions from './_functions.ts'
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
+import * as Resolve from '../resolve/index.ts'
+import * as Functions from './_functions.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { CheckSchema, ErrorSchema } from './schema.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildRecursiveRef(stack: Stack, context: BuildContext, schema: Schema.XRecursiveRef, value: string): string {
-  const target = stack.RecursiveRef(schema) ?? false
-  return Functions.CreateFunction(stack, context, target, value)
+export function BuildRecursiveRef(stack: Stack.XStack, context: BuildContext, schema: Schema.XRecursiveRef, value: string): string {
+  const target = Resolve.RecursiveRef(stack, schema) ?? false
+  const nextStack = target ? { ...stack, pendingResource: true } : stack
+  return Functions.CreateFunction(nextStack, context, target, value)
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckRecursiveRef(stack: Stack, context: CheckContext, schema: Schema.XRecursiveRef, value: unknown): boolean {
-  const target = stack.RecursiveRef(schema) ?? false
-  return (Schema.IsSchema(target) && CheckSchema(stack, context, target, value))
+export function CheckRecursiveRef(stack: Stack.XStack, context: CheckContext, schema: Schema.XRecursiveRef, value: unknown): boolean {
+  const target = Resolve.RecursiveRef(stack, schema) ?? false
+  const nextStack = target ? { ...stack, pendingResource: true } : stack
+  return (Schema.IsSchema(target) && CheckSchema(nextStack, context, target, value))
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorRecursiveRef(stack: Stack, context: ErrorContext, _schemaPath: string, instancePath: string, schema: Schema.XRecursiveRef, value: unknown): boolean {
-  const target = stack.RecursiveRef(schema) ?? false
-  return (Schema.IsSchema(target) && ErrorSchema(stack, context, '#', instancePath, target, value))
+export function ErrorRecursiveRef(stack: Stack.XStack, context: ErrorContext, _schemaPath: string, instancePath: string, schema: Schema.XRecursiveRef, value: unknown): boolean {
+  const target = Resolve.RecursiveRef(stack, schema) ?? false
+  const nextStack = target ? { ...stack, pendingResource: true } : stack
+  return (Schema.IsSchema(target) && ErrorSchema(nextStack, context, '#', instancePath, target, value))
 }

--- a/src/schema/engine/recursiveRef.ts
+++ b/src/schema/engine/recursiveRef.ts
@@ -30,8 +30,8 @@ THE SOFTWARE.
 
 import * as Schema from '../types/index.ts'
 import * as Stack from './_stack.ts'
-import * as Resolve from '../resolve/index.ts'
 import * as Functions from './_functions.ts'
+import { Resolve } from '../resolve/index.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { CheckSchema, ErrorSchema } from './schema.ts'
 

--- a/src/schema/engine/ref.ts
+++ b/src/schema/engine/ref.ts
@@ -31,7 +31,7 @@ THE SOFTWARE.
 import * as Functions from './_functions.ts'
 import * as Schema from '../types/index.ts'
 import * as Stack from './_stack.ts'
-import * as Resolve from '../resolve/index.ts'
+import { Resolve } from '../resolve/index.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E } from '../../guard/index.ts'
 import { CheckSchema, ErrorSchema } from './schema.ts'

--- a/src/schema/engine/ref.ts
+++ b/src/schema/engine/ref.ts
@@ -30,7 +30,8 @@ THE SOFTWARE.
 
 import * as Functions from './_functions.ts'
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
+import * as Resolve from '../resolve/index.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E } from '../../guard/index.ts'
 import { CheckSchema, ErrorSchema } from './schema.ts'
@@ -38,7 +39,7 @@ import { CheckSchema, ErrorSchema } from './schema.ts'
 // ------------------------------------------------------------------
 // BuildRef
 // ------------------------------------------------------------------
-function BuildRefStandard(stack: Stack, context: BuildContext, target: Schema.XSchema, value: string): string {
+function BuildRefStandard(stack: Stack.XStack, context: BuildContext, target: Schema.XSchema, value: string): string {
   const interior = E.ArrowFunction(['context', 'value'], Functions.CreateFunction(stack, context, target, 'value'))
   const exterior = E.ArrowFunction(['context', 'value'], E.Statements([
     E.ConstDeclaration('nextContext', E.New('CheckContext', [])),
@@ -48,33 +49,36 @@ function BuildRefStandard(stack: Stack, context: BuildContext, target: Schema.XS
   ]))
   return E.Call(exterior, ['context', value])
 }
-function BuildRefFast(stack: Stack, context: BuildContext, target: Schema.XSchema, value: string): string {
+function BuildRefFast(stack: Stack.XStack, context: BuildContext, target: Schema.XSchema, value: string): string {
   return Functions.CreateFunction(stack, context, target, value)
 }
-export function BuildRef(stack: Stack, context: BuildContext, schema: Schema.XRef, value: string): string {
-  const target = stack.Ref(schema) ?? false
+export function BuildRef(stack: Stack.XStack, context: BuildContext, schema: Schema.XRef, value: string): string {
+  const result = Resolve.Ref(stack, schema)
+  const target = result.schema ?? false
   return context.UseUnevaluated()
-    ? BuildRefStandard(stack, context, target, value)
-    : BuildRefFast(stack, context, target, value)
+    ? BuildRefStandard(result.stack, context, target, value)
+    : BuildRefFast(result.stack, context, target, value)
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckRef(stack: Stack, context: CheckContext, schema: Schema.XRef, value: unknown): boolean {
-  const target = stack.Ref(schema) ?? false
+export function CheckRef(stack: Stack.XStack, context: CheckContext, schema: Schema.XRef, value: unknown): boolean {
+  const result = Resolve.Ref(stack, schema)
+  const target = result.schema ?? false
   const nextContext = new CheckContext()
-  const result = (Schema.IsSchema(target) && CheckSchema(stack, nextContext, target, value))
-  if (result) context.Merge([nextContext])
-  return result
+  const valid = (Schema.IsSchema(target) && CheckSchema(result.stack, nextContext, target, value))
+  if (valid) context.Merge([nextContext])
+  return valid
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorRef(stack: Stack, context: ErrorContext, _schemaPath: string, instancePath: string, schema: Schema.XRef, value: unknown): boolean {
-  const target = stack.Ref(schema) ?? false
+export function ErrorRef(stack: Stack.XStack, context: ErrorContext, _schemaPath: string, instancePath: string, schema: Schema.XRef, value: unknown): boolean {
+  const result = Resolve.Ref(stack, schema)
+  const target = result.schema ?? false
   const nextContext = new ErrorContext()
-  const result = (Schema.IsSchema(target) && ErrorSchema(stack, nextContext, '#', instancePath, target, value))
-  if (result) context.Merge([nextContext])
-  if (!result) nextContext.GetErrors().forEach(error => context.AddError(error))
-  return result
+  const valid = (Schema.IsSchema(target) && ErrorSchema(result.stack, nextContext, '#', instancePath, target, value))
+  if (valid) context.Merge([nextContext])
+  if (!valid) context.AddErrors(nextContext.GetErrors())
+  return valid
 }

--- a/src/schema/engine/required.ts
+++ b/src/schema/engine/required.ts
@@ -29,36 +29,32 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildRequired(_stack: Stack, _context: BuildContext, schema: Schema.XRequired, value: string): string {
+export function BuildRequired(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XRequired, value: string): string {
   return E.ReduceAnd(schema.required.map((key) => E.HasPropertyKey(value, E.Constant(key))))
 }
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckRequired(_stack: Stack, _context: CheckContext, schema: Schema.XRequired, value: Record<PropertyKey, unknown>): boolean {
+export function CheckRequired(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XRequired, value: Record<PropertyKey, unknown>): boolean {
   return G.Every(schema.required, 0, (key) => G.HasPropertyKey(value, key))
 }
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorRequired(_stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XRequired, value: Record<PropertyKey, unknown>): boolean {
+export function ErrorRequired(_stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XRequired, value: Record<PropertyKey, unknown>): boolean {
   const requiredProperties: string[] = []
   const isRequired = G.EveryAll(schema.required, 0, (key) => {
     const hasKey = G.HasPropertyKey(value, key)
     if (!hasKey) requiredProperties.push(key)
     return hasKey
   })
-  return isRequired || context.AddError({
-    keyword: 'required',
-    schemaPath,
-    instancePath,
-    params: { requiredProperties }
-  })
+  return isRequired ||
+    context.AddError('required', schemaPath, instancePath, { requiredProperties })
 }

--- a/src/schema/engine/schema.ts
+++ b/src/schema/engine/schema.ts
@@ -29,9 +29,9 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { BuildRefine, CheckRefine, ErrorRefine } from './_refine.ts'
+import * as Stack from './_stack.ts'
 
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 
@@ -172,215 +172,212 @@ function HasNumberKeywords(schema: Schema.XSchemaObject): boolean {
 // ----------------------------------------------------------------
 // Build
 // ----------------------------------------------------------------
-export function BuildSchemaPushStack(stack: Stack, context: BuildContext, schema: Schema.XSchema, value: string) {
+export function BuildSchemaPushStack(stack: Stack.XStack, context: BuildContext, schema: Schema.XSchema, value: string) {
   return context.UseUnevaluated()
     ? E.And(E.And(context.Push(), BuildSchema(stack, context, schema, value)), context.Pop())
     : BuildSchema(stack, context, schema, value)
 }
-export function BuildSchema(stack: Stack, context: BuildContext, schema: Schema.XSchema, value: string): string {
-  stack.Push(schema)
+export function BuildSchema(stack: Stack.XStack, context: BuildContext, schema: Schema.XSchema, value: string): string {
+  const current = Stack.NextStack(stack, schema)
   const conditions: string[] = []
-  if (Schema.IsSchemaBoolean(schema)) return BuildSchemaBoolean(stack, context, schema, value)
-  if (Schema.IsType(schema)) conditions.push(BuildType(stack, context, schema, value))
+  if (Schema.IsSchemaBoolean(schema)) return BuildSchemaBoolean(current, context, schema, value)
+  if (Schema.IsType(schema)) conditions.push(BuildType(current, context, schema, value))
   if (HasObjectKeywords(schema)) {
     const constraints = []
-    if (Schema.IsRequired(schema)) constraints.push(BuildRequired(stack, context, schema, value))
-    if (Schema.IsAdditionalProperties(schema)) constraints.push(BuildAdditionalProperties(stack, context, schema, value))
-    if (Schema.IsDependencies(schema)) constraints.push(BuildDependencies(stack, context, schema, value))
-    if (Schema.IsDependentRequired(schema)) constraints.push(BuildDependentRequired(stack, context, schema, value))
-    if (Schema.IsDependentSchemas(schema)) constraints.push(BuildDependentSchemas(stack, context, schema, value))
-    if (Schema.IsPatternProperties(schema)) constraints.push(BuildPatternProperties(stack, context, schema, value))
-    if (Schema.IsProperties(schema)) constraints.push(BuildProperties(stack, context, schema, value))
-    if (Schema.IsPropertyNames(schema)) constraints.push(BuildPropertyNames(stack, context, schema, value))
-    if (Schema.IsMinProperties(schema)) constraints.push(BuildMinProperties(stack, context, schema, value))
-    if (Schema.IsMaxProperties(schema)) constraints.push(BuildMaxProperties(stack, context, schema, value))
+    if (Schema.IsRequired(schema)) constraints.push(BuildRequired(current, context, schema, value))
+    if (Schema.IsAdditionalProperties(schema)) constraints.push(BuildAdditionalProperties(current, context, schema, value))
+    if (Schema.IsDependencies(schema)) constraints.push(BuildDependencies(current, context, schema, value))
+    if (Schema.IsDependentRequired(schema)) constraints.push(BuildDependentRequired(current, context, schema, value))
+    if (Schema.IsDependentSchemas(schema)) constraints.push(BuildDependentSchemas(current, context, schema, value))
+    if (Schema.IsPatternProperties(schema)) constraints.push(BuildPatternProperties(current, context, schema, value))
+    if (Schema.IsProperties(schema)) constraints.push(BuildProperties(current, context, schema, value))
+    if (Schema.IsPropertyNames(schema)) constraints.push(BuildPropertyNames(current, context, schema, value))
+    if (Schema.IsMinProperties(schema)) constraints.push(BuildMinProperties(current, context, schema, value))
+    if (Schema.IsMaxProperties(schema)) constraints.push(BuildMaxProperties(current, context, schema, value))
     const reduced = E.ReduceAnd(constraints)
     const guarded = E.Or(E.Not(E.IsObjectNotArray(value)), reduced)
     conditions.push(HasObjectType(schema) ? reduced : guarded)
   }
   if (HasArrayKeywords(schema)) {
     const constraints = []
-    if (Schema.IsAdditionalItems(schema)) constraints.push(BuildAdditionalItems(stack, context, schema, value))
-    if (Schema.IsContains(schema)) constraints.push(BuildContains(stack, context, schema, value))
-    if (Schema.IsItems(schema)) constraints.push(BuildItems(stack, context, schema, value))
-    if (Schema.IsMaxContains(schema)) constraints.push(BuildMaxContains(stack, context, schema, value))
-    if (Schema.IsMaxItems(schema)) constraints.push(BuildMaxItems(stack, context, schema, value))
-    if (Schema.IsMinContains(schema)) constraints.push(BuildMinContains(stack, context, schema, value))
-    if (Schema.IsMinItems(schema)) constraints.push(BuildMinItems(stack, context, schema, value))
-    if (Schema.IsPrefixItems(schema)) constraints.push(BuildPrefixItems(stack, context, schema, value))
-    if (Schema.IsUniqueItems(schema)) constraints.push(BuildUniqueItems(stack, context, schema, value))
+    if (Schema.IsAdditionalItems(schema)) constraints.push(BuildAdditionalItems(current, context, schema, value))
+    if (Schema.IsContains(schema)) constraints.push(BuildContains(current, context, schema, value))
+    if (Schema.IsItems(schema)) constraints.push(BuildItems(current, context, schema, value))
+    if (Schema.IsMaxContains(schema)) constraints.push(BuildMaxContains(current, context, schema, value))
+    if (Schema.IsMaxItems(schema)) constraints.push(BuildMaxItems(current, context, schema, value))
+    if (Schema.IsMinContains(schema)) constraints.push(BuildMinContains(current, context, schema, value))
+    if (Schema.IsMinItems(schema)) constraints.push(BuildMinItems(current, context, schema, value))
+    if (Schema.IsPrefixItems(schema)) constraints.push(BuildPrefixItems(current, context, schema, value))
+    if (Schema.IsUniqueItems(schema)) constraints.push(BuildUniqueItems(current, context, schema, value))
     const reduced = E.ReduceAnd(constraints)
     const guarded = E.Or(E.Not(E.IsArray(value)), reduced)
     conditions.push(HasArrayType(schema) ? reduced : guarded)
   }
   if (HasStringKeywords(schema)) {
     const constraints = []
-    if (Schema.IsMaxLength(schema)) constraints.push(BuildMaxLength(stack, context, schema, value))
-    if (Schema.IsMinLength(schema)) constraints.push(BuildMinLength(stack, context, schema, value))
-    if (Schema.IsFormat(schema)) constraints.push(BuildFormat(stack, context, schema, value))
-    if (Schema.IsPattern(schema)) constraints.push(BuildPattern(stack, context, schema, value))
+    if (Schema.IsMaxLength(schema)) constraints.push(BuildMaxLength(current, context, schema, value))
+    if (Schema.IsMinLength(schema)) constraints.push(BuildMinLength(current, context, schema, value))
+    if (Schema.IsFormat(schema)) constraints.push(BuildFormat(current, context, schema, value))
+    if (Schema.IsPattern(schema)) constraints.push(BuildPattern(current, context, schema, value))
     const reduced = E.ReduceAnd(constraints)
     const guarded = E.Or(E.Not(E.IsString(value)), reduced)
     conditions.push(HasStringType(schema) ? reduced : guarded)
   }
   if (HasNumberKeywords(schema)) {
     const constraints = []
-    if (Schema.IsExclusiveMaximum(schema)) constraints.push(BuildExclusiveMaximum(stack, context, schema, value))
-    if (Schema.IsExclusiveMinimum(schema)) constraints.push(BuildExclusiveMinimum(stack, context, schema, value))
-    if (Schema.IsMaximum(schema)) constraints.push(BuildMaximum(stack, context, schema, value))
-    if (Schema.IsMinimum(schema)) constraints.push(BuildMinimum(stack, context, schema, value))
-    if (Schema.IsMultipleOf(schema)) constraints.push(BuildMultipleOf(stack, context, schema, value))
+    if (Schema.IsExclusiveMaximum(schema)) constraints.push(BuildExclusiveMaximum(current, context, schema, value))
+    if (Schema.IsExclusiveMinimum(schema)) constraints.push(BuildExclusiveMinimum(current, context, schema, value))
+    if (Schema.IsMaximum(schema)) constraints.push(BuildMaximum(current, context, schema, value))
+    if (Schema.IsMinimum(schema)) constraints.push(BuildMinimum(current, context, schema, value))
+    if (Schema.IsMultipleOf(schema)) constraints.push(BuildMultipleOf(current, context, schema, value))
     const reduced = E.ReduceAnd(constraints)
     const guarded = E.Or(E.Not(E.Or(E.IsNumber(value), E.IsBigInt(value))), reduced)
     conditions.push(HasNumberType(schema) ? reduced : guarded)
   }
-  if (Schema.IsRef(schema)) conditions.push(BuildRef(stack, context, schema, value))
-  if (Schema.IsRecursiveRef(schema)) conditions.push(BuildRecursiveRef(stack, context, schema, value))
-  if (Schema.IsDynamicRef(schema)) conditions.push(BuildDynamicRef(stack, context, schema, value))
-  if (Schema.IsConst(schema)) conditions.push(BuildConst(stack, context, schema, value))
-  if (Schema.IsEnum(schema)) conditions.push(BuildEnum(stack, context, schema, value))
-  if (Schema.IsIf(schema)) conditions.push(BuildIf(stack, context, schema, value))
-  if (Schema.IsNot(schema)) conditions.push(BuildNot(stack, context, schema, value))
-  if (Schema.IsAllOf(schema)) conditions.push(BuildAllOf(stack, context, schema, value))
-  if (Schema.IsAnyOf(schema)) conditions.push(BuildAnyOf(stack, context, schema, value))
-  if (Schema.IsOneOf(schema)) conditions.push(BuildOneOf(stack, context, schema, value))
-  if (Schema.IsUnevaluatedItems(schema)) conditions.push(E.Or(E.Not(E.IsArray(value)), BuildUnevaluatedItems(stack, context, schema, value)))
-  if (Schema.IsUnevaluatedProperties(schema)) conditions.push(E.Or(E.Not(E.IsObject(value)), BuildUnevaluatedProperties(stack, context, schema, value)))
-  if (Schema.IsRefine(schema)) conditions.push(BuildRefine(stack, context, schema, value))
+  if (Schema.IsRef(schema)) conditions.push(BuildRef(current, context, schema, value))
+  if (Schema.IsRecursiveRef(schema)) conditions.push(BuildRecursiveRef(current, context, schema, value))
+  if (Schema.IsDynamicRef(schema)) conditions.push(BuildDynamicRef(current, context, schema, value))
+  if (Schema.IsConst(schema)) conditions.push(BuildConst(current, context, schema, value))
+  if (Schema.IsEnum(schema)) conditions.push(BuildEnum(current, context, schema, value))
+  if (Schema.IsIf(schema)) conditions.push(BuildIf(current, context, schema, value))
+  if (Schema.IsNot(schema)) conditions.push(BuildNot(current, context, schema, value))
+  if (Schema.IsAllOf(schema)) conditions.push(BuildAllOf(current, context, schema, value))
+  if (Schema.IsAnyOf(schema)) conditions.push(BuildAnyOf(current, context, schema, value))
+  if (Schema.IsOneOf(schema)) conditions.push(BuildOneOf(current, context, schema, value))
+  if (Schema.IsUnevaluatedItems(schema)) conditions.push(E.Or(E.Not(E.IsArray(value)), BuildUnevaluatedItems(current, context, schema, value)))
+  if (Schema.IsUnevaluatedProperties(schema)) conditions.push(E.Or(E.Not(E.IsObject(value)), BuildUnevaluatedProperties(current, context, schema, value)))
+  if (Schema.IsRefine(schema)) conditions.push(BuildRefine(current, context, schema, value))
   const result = E.ReduceAnd(conditions)
-  stack.Pop(schema)
   return result
 }
 // ----------------------------------------------------------------
 // Check
 // ----------------------------------------------------------------
-export function CheckSchemaPushStack(stack: Stack, context: CheckContext, schema: Schema.XSchema, value: unknown): boolean {
+export function CheckSchemaPushStack(stack: Stack.XStack, context: CheckContext, schema: Schema.XSchema, value: unknown): boolean {
   return (context.Push() && CheckSchema(stack, context, schema, value)) && context.Pop()
 }
-export function CheckSchema(stack: Stack, context: CheckContext, schema: Schema.XSchema, value: unknown): boolean {
-  stack.Push(schema)
-  const result = Schema.IsSchemaBoolean(schema) ? CheckSchemaBoolean(stack, context, schema, value) : (
-    (!Schema.IsType(schema) || CheckType(stack, context, schema, value)) &&
+export function CheckSchema(stack: Stack.XStack, context: CheckContext, schema: Schema.XSchema, value: unknown): boolean {
+  const current = Stack.NextStack(stack, schema)
+  const result = Schema.IsSchemaBoolean(schema) ? CheckSchemaBoolean(current, context, schema, value) : (
+    (!Schema.IsType(schema) || CheckType(current, context, schema, value)) &&
     (!(G.IsObject(value) && !G.IsArray(value)) || (
-      (!Schema.IsRequired(schema) || CheckRequired(stack, context, schema, value)) &&
-      (!Schema.IsAdditionalProperties(schema) || CheckAdditionalProperties(stack, context, schema, value)) &&
-      (!Schema.IsDependencies(schema) || CheckDependencies(stack, context, schema, value)) &&
-      (!Schema.IsDependentRequired(schema) || CheckDependentRequired(stack, context, schema, value)) &&
-      (!Schema.IsDependentSchemas(schema) || CheckDependentSchemas(stack, context, schema, value)) &&
-      (!Schema.IsPatternProperties(schema) || CheckPatternProperties(stack, context, schema, value)) &&
-      (!Schema.IsProperties(schema) || CheckProperties(stack, context, schema, value)) &&
-      (!Schema.IsPropertyNames(schema) || CheckPropertyNames(stack, context, schema, value)) &&
-      (!Schema.IsMinProperties(schema) || CheckMinProperties(stack, context, schema, value)) &&
-      (!Schema.IsMaxProperties(schema) || CheckMaxProperties(stack, context, schema, value))
+      (!Schema.IsRequired(schema) || CheckRequired(current, context, schema, value)) &&
+      (!Schema.IsAdditionalProperties(schema) || CheckAdditionalProperties(current, context, schema, value)) &&
+      (!Schema.IsDependencies(schema) || CheckDependencies(current, context, schema, value)) &&
+      (!Schema.IsDependentRequired(schema) || CheckDependentRequired(current, context, schema, value)) &&
+      (!Schema.IsDependentSchemas(schema) || CheckDependentSchemas(current, context, schema, value)) &&
+      (!Schema.IsPatternProperties(schema) || CheckPatternProperties(current, context, schema, value)) &&
+      (!Schema.IsProperties(schema) || CheckProperties(current, context, schema, value)) &&
+      (!Schema.IsPropertyNames(schema) || CheckPropertyNames(current, context, schema, value)) &&
+      (!Schema.IsMinProperties(schema) || CheckMinProperties(current, context, schema, value)) &&
+      (!Schema.IsMaxProperties(schema) || CheckMaxProperties(current, context, schema, value))
     )) &&
     (!G.IsArray(value) || (
-      (!Schema.IsAdditionalItems(schema) || CheckAdditionalItems(stack, context, schema, value)) &&
-      (!Schema.IsContains(schema) || CheckContains(stack, context, schema, value)) &&
-      (!Schema.IsItems(schema) || CheckItems(stack, context, schema, value)) &&
-      (!Schema.IsMaxContains(schema) || CheckMaxContains(stack, context, schema, value)) &&
-      (!Schema.IsMaxItems(schema) || CheckMaxItems(stack, context, schema, value)) &&
-      (!Schema.IsMinContains(schema) || CheckMinContains(stack, context, schema, value)) &&
-      (!Schema.IsMinItems(schema) || CheckMinItems(stack, context, schema, value)) &&
-      (!Schema.IsPrefixItems(schema) || CheckPrefixItems(stack, context, schema, value)) &&
-      (!Schema.IsUniqueItems(schema) || CheckUniqueItems(stack, context, schema, value))
+      (!Schema.IsAdditionalItems(schema) || CheckAdditionalItems(current, context, schema, value)) &&
+      (!Schema.IsContains(schema) || CheckContains(current, context, schema, value)) &&
+      (!Schema.IsItems(schema) || CheckItems(current, context, schema, value)) &&
+      (!Schema.IsMaxContains(schema) || CheckMaxContains(current, context, schema, value)) &&
+      (!Schema.IsMaxItems(schema) || CheckMaxItems(current, context, schema, value)) &&
+      (!Schema.IsMinContains(schema) || CheckMinContains(current, context, schema, value)) &&
+      (!Schema.IsMinItems(schema) || CheckMinItems(current, context, schema, value)) &&
+      (!Schema.IsPrefixItems(schema) || CheckPrefixItems(current, context, schema, value)) &&
+      (!Schema.IsUniqueItems(schema) || CheckUniqueItems(current, context, schema, value))
     )) &&
     (!G.IsString(value) || (
-      (!Schema.IsMaxLength(schema) || CheckMaxLength(stack, context, schema, value)) &&
-      (!Schema.IsMinLength(schema) || CheckMinLength(stack, context, schema, value)) &&
-      (!Schema.IsFormat(schema) || CheckFormat(stack, context, schema, value)) &&
-      (!Schema.IsPattern(schema) || CheckPattern(stack, context, schema, value))
+      (!Schema.IsMaxLength(schema) || CheckMaxLength(current, context, schema, value)) &&
+      (!Schema.IsMinLength(schema) || CheckMinLength(current, context, schema, value)) &&
+      (!Schema.IsFormat(schema) || CheckFormat(current, context, schema, value)) &&
+      (!Schema.IsPattern(schema) || CheckPattern(current, context, schema, value))
     )) &&
     (!(G.IsNumber(value) || G.IsBigInt(value)) || (
-      (!Schema.IsExclusiveMaximum(schema) || CheckExclusiveMaximum(stack, context, schema, value)) &&
-      (!Schema.IsExclusiveMinimum(schema) || CheckExclusiveMinimum(stack, context, schema, value)) &&
-      (!Schema.IsMaximum(schema) || CheckMaximum(stack, context, schema, value)) &&
-      (!Schema.IsMinimum(schema) || CheckMinimum(stack, context, schema, value)) &&
-      (!Schema.IsMultipleOf(schema) || CheckMultipleOf(stack, context, schema, value))
+      (!Schema.IsExclusiveMaximum(schema) || CheckExclusiveMaximum(current, context, schema, value)) &&
+      (!Schema.IsExclusiveMinimum(schema) || CheckExclusiveMinimum(current, context, schema, value)) &&
+      (!Schema.IsMaximum(schema) || CheckMaximum(current, context, schema, value)) &&
+      (!Schema.IsMinimum(schema) || CheckMinimum(current, context, schema, value)) &&
+      (!Schema.IsMultipleOf(schema) || CheckMultipleOf(current, context, schema, value))
     )) &&
-    (!Schema.IsRef(schema) || CheckRef(stack, context, schema, value)) &&
-    (!Schema.IsRecursiveRef(schema) || CheckRecursiveRef(stack, context, schema, value)) &&
-    (!Schema.IsDynamicRef(schema) || CheckDynamicRef(stack, context, schema, value)) &&
-    (!Schema.IsConst(schema) || CheckConst(stack, context, schema, value)) &&
-    (!Schema.IsEnum(schema) || CheckEnum(stack, context, schema, value)) &&
-    (!Schema.IsIf(schema) || CheckIf(stack, context, schema, value)) &&
-    (!Schema.IsNot(schema) || CheckNot(stack, context, schema, value)) &&
-    (!Schema.IsAllOf(schema) || CheckAllOf(stack, context, schema, value)) &&
-    (!Schema.IsAnyOf(schema) || CheckAnyOf(stack, context, schema, value)) &&
-    (!Schema.IsOneOf(schema) || CheckOneOf(stack, context, schema, value)) &&
-    (!Schema.IsUnevaluatedItems(schema) || (!G.IsArray(value) || CheckUnevaluatedItems(stack, context, schema, value))) &&
-    (!Schema.IsUnevaluatedProperties(schema) || (!G.IsObject(value) || CheckUnevaluatedProperties(stack, context, schema, value))) &&
-    (!Schema.IsRefine(schema) || CheckRefine(stack, context, schema, value))
+    (!Schema.IsRef(schema) || CheckRef(current, context, schema, value)) &&
+    (!Schema.IsRecursiveRef(schema) || CheckRecursiveRef(current, context, schema, value)) &&
+    (!Schema.IsDynamicRef(schema) || CheckDynamicRef(current, context, schema, value)) &&
+    (!Schema.IsConst(schema) || CheckConst(current, context, schema, value)) &&
+    (!Schema.IsEnum(schema) || CheckEnum(current, context, schema, value)) &&
+    (!Schema.IsIf(schema) || CheckIf(current, context, schema, value)) &&
+    (!Schema.IsNot(schema) || CheckNot(current, context, schema, value)) &&
+    (!Schema.IsAllOf(schema) || CheckAllOf(current, context, schema, value)) &&
+    (!Schema.IsAnyOf(schema) || CheckAnyOf(current, context, schema, value)) &&
+    (!Schema.IsOneOf(schema) || CheckOneOf(current, context, schema, value)) &&
+    (!Schema.IsUnevaluatedItems(schema) || (!G.IsArray(value) || CheckUnevaluatedItems(current, context, schema, value))) &&
+    (!Schema.IsUnevaluatedProperties(schema) || (!G.IsObject(value) || CheckUnevaluatedProperties(current, context, schema, value))) &&
+    (!Schema.IsRefine(schema) || CheckRefine(current, context, schema, value))
   )
-  stack.Pop(schema)
   return result
 }
 // ----------------------------------------------------------------
 // Error
 // ----------------------------------------------------------------
-export function ErrorSchemaPushStack(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XSchema, value: unknown): boolean {
+export function ErrorSchemaPushStack(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XSchema, value: unknown): boolean {
   return (context.Push() && ErrorSchema(stack, context, schemaPath, instancePath, schema, value)) && context.Pop()
 }
-export function ErrorSchema(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XSchema, value: unknown): boolean {
+export function ErrorSchema(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XSchema, value: unknown): boolean {
   // Optimization: We can safely terminate here when the context is at capacity because we are unable to
   // append additional errors. It is worth being mindful that logical keywords such as allOf, anyOf,
   // oneOf pass a new context per operand, so the capacity check applies per context, not across the
   // full set of errors accumulated by the schema as a whole. (review)
   if(context.AtCapacity()) return false
-  stack.Push(schema)
-  const result = (Schema.IsSchemaBoolean(schema)) ? ErrorSchemaBoolean(stack, context, schemaPath, instancePath, schema, value) : (
+  const current = Stack.NextStack(stack, schema)
+  const result = (Schema.IsSchemaBoolean(schema)) ? ErrorSchemaBoolean(current, context, schemaPath, instancePath, schema, value) : (
     !!(
-      +(!Schema.IsType(schema) || ErrorType(stack, context, schemaPath, instancePath, schema, value)) &
+      +(!Schema.IsType(schema) || ErrorType(current, context, schemaPath, instancePath, schema, value)) &
       +(!(G.IsObject(value) && !G.IsArray(value)) || !!(
-        +(!Schema.IsRequired(schema) || ErrorRequired(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsAdditionalProperties(schema) || ErrorAdditionalProperties(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsDependencies(schema) || ErrorDependencies(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsDependentRequired(schema) || ErrorDependentRequired(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsDependentSchemas(schema) || ErrorDependentSchemas(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsPatternProperties(schema) || ErrorPatternProperties(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsProperties(schema) || ErrorProperties(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsPropertyNames(schema) || ErrorPropertyNames(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsMinProperties(schema) || ErrorMinProperties(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsMaxProperties(schema) || ErrorMaxProperties(stack, context, schemaPath, instancePath, schema, value))
+        +(!Schema.IsRequired(schema) || ErrorRequired(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsAdditionalProperties(schema) || ErrorAdditionalProperties(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsDependencies(schema) || ErrorDependencies(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsDependentRequired(schema) || ErrorDependentRequired(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsDependentSchemas(schema) || ErrorDependentSchemas(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsPatternProperties(schema) || ErrorPatternProperties(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsProperties(schema) || ErrorProperties(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsPropertyNames(schema) || ErrorPropertyNames(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsMinProperties(schema) || ErrorMinProperties(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsMaxProperties(schema) || ErrorMaxProperties(current, context, schemaPath, instancePath, schema, value))
       )) &
       +(!G.IsArray(value) || !!(
-        +(!Schema.IsAdditionalItems(schema) || ErrorAdditionalItems(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsContains(schema) || ErrorContains(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsItems(schema) || ErrorItems(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsMaxContains(schema) || ErrorMaxContains(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsMaxItems(schema) || ErrorMaxItems(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsMinContains(schema) || ErrorMinContains(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsMinItems(schema) || ErrorMinItems(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsPrefixItems(schema) || ErrorPrefixItems(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsUniqueItems(schema) || ErrorUniqueItems(stack, context, schemaPath, instancePath, schema, value))
+        +(!Schema.IsAdditionalItems(schema) || ErrorAdditionalItems(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsContains(schema) || ErrorContains(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsItems(schema) || ErrorItems(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsMaxContains(schema) || ErrorMaxContains(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsMaxItems(schema) || ErrorMaxItems(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsMinContains(schema) || ErrorMinContains(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsMinItems(schema) || ErrorMinItems(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsPrefixItems(schema) || ErrorPrefixItems(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsUniqueItems(schema) || ErrorUniqueItems(current, context, schemaPath, instancePath, schema, value))
       )) &
       +(!G.IsString(value) || !!(
-        +(!Schema.IsMaxLength(schema) || ErrorMaxLength(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsMinLength(schema) || ErrorMinLength(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsFormat(schema) || ErrorFormat(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsPattern(schema) || ErrorPattern(stack, context, schemaPath, instancePath, schema, value))
+        +(!Schema.IsMaxLength(schema) || ErrorMaxLength(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsMinLength(schema) || ErrorMinLength(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsFormat(schema) || ErrorFormat(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsPattern(schema) || ErrorPattern(current, context, schemaPath, instancePath, schema, value))
       )) &
       +(!(G.IsNumber(value) || G.IsBigInt(value)) || !!(
-        +(!Schema.IsExclusiveMaximum(schema) || ErrorExclusiveMaximum(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsExclusiveMinimum(schema) || ErrorExclusiveMinimum(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsMaximum(schema) || ErrorMaximum(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsMinimum(schema) || ErrorMinimum(stack, context, schemaPath, instancePath, schema, value)) &
-        +(!Schema.IsMultipleOf(schema) || ErrorMultipleOf(stack, context, schemaPath, instancePath, schema, value))
+        +(!Schema.IsExclusiveMaximum(schema) || ErrorExclusiveMaximum(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsExclusiveMinimum(schema) || ErrorExclusiveMinimum(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsMaximum(schema) || ErrorMaximum(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsMinimum(schema) || ErrorMinimum(current, context, schemaPath, instancePath, schema, value)) &
+        +(!Schema.IsMultipleOf(schema) || ErrorMultipleOf(current, context, schemaPath, instancePath, schema, value))
       )) &
-      +(!Schema.IsRef(schema) || ErrorRef(stack, context, schemaPath, instancePath, schema, value)) &
-      +(!Schema.IsRecursiveRef(schema) || ErrorRecursiveRef(stack, context, schemaPath, instancePath, schema, value)) &
-      +(!Schema.IsDynamicRef(schema) || ErrorDynamicRef(stack, context, schemaPath, instancePath, schema, value)) &
-      +(!Schema.IsConst(schema) || ErrorConst(stack, context, schemaPath, instancePath, schema, value)) &
-      +(!Schema.IsEnum(schema) || ErrorEnum(stack, context, schemaPath, instancePath, schema, value)) &
-      +(!Schema.IsIf(schema) || ErrorIf(stack, context, schemaPath, instancePath, schema, value)) &
-      +(!Schema.IsNot(schema) || ErrorNot(stack, context, schemaPath, instancePath, schema, value)) &
-      +(!Schema.IsAllOf(schema) || ErrorAllOf(stack, context, schemaPath, instancePath, schema, value)) &
-      +(!Schema.IsAnyOf(schema) || ErrorAnyOf(stack, context, schemaPath, instancePath, schema, value)) &
-      +(!Schema.IsOneOf(schema) || ErrorOneOf(stack, context, schemaPath, instancePath, schema, value)) &
-      +(!Schema.IsUnevaluatedItems(schema) || (!G.IsArray(value) || ErrorUnevaluatedItems(stack, context, schemaPath, instancePath, schema, value))) &
-      +(!Schema.IsUnevaluatedProperties(schema) || (!G.IsObject(value) || ErrorUnevaluatedProperties(stack, context, schemaPath, instancePath, schema, value)))
+      +(!Schema.IsRef(schema) || ErrorRef(current, context, schemaPath, instancePath, schema, value)) &
+      +(!Schema.IsRecursiveRef(schema) || ErrorRecursiveRef(current, context, schemaPath, instancePath, schema, value)) &
+      +(!Schema.IsDynamicRef(schema) || ErrorDynamicRef(current, context, schemaPath, instancePath, schema, value)) &
+      +(!Schema.IsConst(schema) || ErrorConst(current, context, schemaPath, instancePath, schema, value)) &
+      +(!Schema.IsEnum(schema) || ErrorEnum(current, context, schemaPath, instancePath, schema, value)) &
+      +(!Schema.IsIf(schema) || ErrorIf(current, context, schemaPath, instancePath, schema, value)) &
+      +(!Schema.IsNot(schema) || ErrorNot(current, context, schemaPath, instancePath, schema, value)) &
+      +(!Schema.IsAllOf(schema) || ErrorAllOf(current, context, schemaPath, instancePath, schema, value)) &
+      +(!Schema.IsAnyOf(schema) || ErrorAnyOf(current, context, schemaPath, instancePath, schema, value)) &
+      +(!Schema.IsOneOf(schema) || ErrorOneOf(current, context, schemaPath, instancePath, schema, value)) &
+      +(!Schema.IsUnevaluatedItems(schema) || (!G.IsArray(value) || ErrorUnevaluatedItems(current, context, schemaPath, instancePath, schema, value))) &
+      +(!Schema.IsUnevaluatedProperties(schema) || (!G.IsObject(value) || ErrorUnevaluatedProperties(current, context, schemaPath, instancePath, schema, value)))
     ) &&
-    (!Schema.IsRefine(schema) || ErrorRefine(stack, context, schemaPath, instancePath, schema, value))
+    (!Schema.IsRefine(schema) || ErrorRefine(current, context, schemaPath, instancePath, schema, value))
   )
-  stack.Pop(schema)
   return result
 }

--- a/src/schema/engine/type.ts
+++ b/src/schema/engine/type.ts
@@ -29,14 +29,14 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // TypeName
 // ------------------------------------------------------------------
-function BuildTypeName(_stack: Stack, _context: BuildContext, type: string, value: string): string {
+function BuildTypeName(_stack: Stack.XStack, _context: BuildContext, type: string, value: string): string {
   return (
     // jsonschema
     G.IsEqual(type, 'object') ? E.IsObjectNotArray(value) :
@@ -56,7 +56,7 @@ function BuildTypeName(_stack: Stack, _context: BuildContext, type: string, valu
     E.Constant(true)
   )
 }
-function CheckTypeName(_stack: Stack, _context: CheckContext, type: string, _schema: Schema.XSchemaObject, value: unknown): boolean {
+function CheckTypeName(_stack: Stack.XStack, _context: CheckContext, type: string, _schema: Schema.XSchemaObject, value: unknown): boolean {
   return (
     // jsonschema
     G.IsEqual(type, 'object') ? G.IsObjectNotArray(value) :
@@ -79,27 +79,23 @@ function CheckTypeName(_stack: Stack, _context: CheckContext, type: string, _sch
 // ------------------------------------------------------------------
 // TypeNames
 // ------------------------------------------------------------------
-function BuildTypeNames(stack: Stack, context: BuildContext, typenames: string[], value: string): string {
+function BuildTypeNames(stack: Stack.XStack, context: BuildContext, typenames: string[], value: string): string {
   return E.ReduceOr(typenames.map(type => BuildTypeName(stack, context, type, value)))
 }
-function CheckTypeNames(stack: Stack, context: CheckContext, types: string[], schema: Schema.XSchemaObject, value: unknown): boolean {
+function CheckTypeNames(stack: Stack.XStack, context: CheckContext, types: string[], schema: Schema.XSchemaObject, value: unknown): boolean {
   return G.Some(types, type => CheckTypeName(stack, context, type, schema, value))
 }
 // ------------------------------------------------------------------
 // Type
 // ------------------------------------------------------------------
-export function BuildType(stack: Stack, context: BuildContext, schema: Schema.XType, value: string): string {
+export function BuildType(stack: Stack.XStack, context: BuildContext, schema: Schema.XType, value: string): string {
   return G.IsArray(schema.type) ? BuildTypeNames(stack, context, schema.type, value) : BuildTypeName(stack, context, schema.type, value)
 }
-export function CheckType(stack: Stack, context: CheckContext, schema: Schema.XType, value: unknown): boolean {
+export function CheckType(stack: Stack.XStack, context: CheckContext, schema: Schema.XType, value: unknown): boolean {
   return G.IsArray(schema.type) ? CheckTypeNames(stack, context, schema.type, schema, value) : CheckTypeName(stack, context, schema.type, schema, value)
 }
-export function ErrorType(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XType, value: unknown): boolean {
+export function ErrorType(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XType, value: unknown): boolean {
   const isType = G.IsArray(schema.type) ? CheckTypeNames(stack, context, schema.type, schema, value) : CheckTypeName(stack, context, schema.type, schema, value)
-  return isType || context.AddError({
-    keyword: 'type',
-    schemaPath,
-    instancePath,
-    params: { type: schema.type }
-  })
+  return isType ||
+    context.AddError('type', schemaPath, instancePath, { type: schema.type })
 }

--- a/src/schema/engine/unevaluatedItems.ts
+++ b/src/schema/engine/unevaluatedItems.ts
@@ -29,16 +29,16 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { Unique } from './_unique.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
-import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
+import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildUnevaluatedItems(stack: Stack, context: BuildContext, schema: Schema.XUnevaluatedItems, value: string): string {
+export function BuildUnevaluatedItems(stack: Stack.XStack, context: BuildContext, schema: Schema.XUnevaluatedItems, value: string): string {
   const [index, item] = [Unique(), Unique()]
   const indices = E.Call(E.Member('context', 'GetIndices'), [])
   const hasIndex = E.Call(E.Member('indices', 'has'), [index])
@@ -53,7 +53,7 @@ export function BuildUnevaluatedItems(stack: Stack, context: BuildContext, schem
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckUnevaluatedItems(stack: Stack, context: CheckContext, schema: Schema.XUnevaluatedItems, value: unknown[]): boolean {
+export function CheckUnevaluatedItems(stack: Stack.XStack, context: CheckContext, schema: Schema.XUnevaluatedItems, value: unknown[]): boolean {
   const indices = context.GetIndices()
   return G.Every(value, 0, (item, index) => {
     return (indices.has(index) || CheckSchema(stack, context, schema.unevaluatedItems, item))
@@ -63,7 +63,7 @@ export function CheckUnevaluatedItems(stack: Stack, context: CheckContext, schem
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorUnevaluatedItems(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XUnevaluatedItems, value: unknown[]): boolean {
+export function ErrorUnevaluatedItems(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XUnevaluatedItems, value: unknown[]): boolean {
   const indices = context.GetIndices()
   const unevaluatedItems: number[] = []
   const isUnevaluatedItems = G.EveryAll(value, 0, (item, index) => {
@@ -73,10 +73,6 @@ export function ErrorUnevaluatedItems(stack: Stack, context: ErrorContext, schem
     if (!isEvaluatedItem) unevaluatedItems.push(index)
     return isEvaluatedItem
   })
-  return isUnevaluatedItems || context.AddError({
-    keyword: 'unevaluatedItems',
-    schemaPath,
-    instancePath,
-    params: { unevaluatedItems }
-  })
+  return isUnevaluatedItems ||
+    context.AddError('unevaluatedItems', schemaPath, instancePath, { unevaluatedItems })
 }

--- a/src/schema/engine/unevaluatedProperties.ts
+++ b/src/schema/engine/unevaluatedProperties.ts
@@ -29,17 +29,16 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
-import { Stack } from './_stack.ts'
+import * as Stack from './_stack.ts'
 import { Unique } from './_unique.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
-import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 import { BuildSchema, CheckSchema, ErrorSchema } from './schema.ts'
-
+import { Guard as G, EmitGuard as E } from '../../guard/index.ts'
 
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildUnevaluatedProperties(stack: Stack, context: BuildContext, schema: Schema.XUnevaluatedProperties, value: string): string {
+export function BuildUnevaluatedProperties(stack: Stack.XStack, context: BuildContext, schema: Schema.XUnevaluatedProperties, value: string): string {
   const [key, prop] = [Unique(), Unique()]
   const keys = E.Call(E.Member('context', 'GetKeys'), [])
   const hasKey = E.Call(E.Member('keys', 'has'), [key])
@@ -54,7 +53,7 @@ export function BuildUnevaluatedProperties(stack: Stack, context: BuildContext, 
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckUnevaluatedProperties(stack: Stack, context: CheckContext, schema: Schema.XUnevaluatedProperties, value: Record<PropertyKey, unknown>) {
+export function CheckUnevaluatedProperties(stack: Stack.XStack, context: CheckContext, schema: Schema.XUnevaluatedProperties, value: Record<PropertyKey, unknown>) {
   const keys = context.GetKeys()
   return G.Every(G.Entries(value), 0, ([key, prop]) => {
     return keys.has(key)
@@ -64,7 +63,7 @@ export function CheckUnevaluatedProperties(stack: Stack, context: CheckContext, 
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorUnevaluatedProperties(stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XUnevaluatedProperties, value: Record<PropertyKey, unknown>) {
+export function ErrorUnevaluatedProperties(stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XUnevaluatedProperties, value: Record<PropertyKey, unknown>) {
   const keys = context.GetKeys()
   const unevaluatedProperties: PropertyKey[] = []
   const isUnevaluatedProperties = G.EveryAll(G.Entries(value), 0, ([key, prop]) => {
@@ -74,10 +73,6 @@ export function ErrorUnevaluatedProperties(stack: Stack, context: ErrorContext, 
     if (!isEvaluatedProperty) unevaluatedProperties.push(key)
     return isEvaluatedProperty
   })
-  return isUnevaluatedProperties || context.AddError({
-    keyword: 'unevaluatedProperties',
-    schemaPath,
-    instancePath,
-    params: { unevaluatedProperties }
-  })
+  return isUnevaluatedProperties ||
+    context.AddError('unevaluatedProperties', schemaPath, instancePath, { unevaluatedProperties })
 }

--- a/src/schema/engine/uniqueItems.ts
+++ b/src/schema/engine/uniqueItems.ts
@@ -29,8 +29,8 @@ THE SOFTWARE.
 // deno-fmt-ignore-file
 
 import * as Schema from '../types/index.ts'
+import * as Stack from './_stack.ts'
 import { Hashing } from '../../system/hashing/index.ts'
-import { Stack } from './_stack.ts'
 import { BuildContext, CheckContext, ErrorContext } from './_context.ts'
 import { EmitGuard as E, Guard as G } from '../../guard/index.ts'
 
@@ -43,7 +43,7 @@ function IsValid(schema: Schema.XUniqueItems): schema is Schema.XUniqueItems & {
 // ------------------------------------------------------------------
 // Build
 // ------------------------------------------------------------------
-export function BuildUniqueItems(_stack: Stack, _context: BuildContext, schema: Schema.XUniqueItems, value: string): string {
+export function BuildUniqueItems(_stack: Stack.XStack, _context: BuildContext, schema: Schema.XUniqueItems, value: string): string {
   if (!IsValid(schema)) return E.Constant(true)
 
   const set = E.Member(E.New('Set', [E.Call(E.Member(value, 'map'), [E.Member('Hashing', 'Hash')])]), 'size')
@@ -53,7 +53,7 @@ export function BuildUniqueItems(_stack: Stack, _context: BuildContext, schema: 
 // ------------------------------------------------------------------
 // Check
 // ------------------------------------------------------------------
-export function CheckUniqueItems(_stack: Stack, _context: CheckContext, schema: Schema.XUniqueItems, value: unknown[]): boolean {
+export function CheckUniqueItems(_stack: Stack.XStack, _context: CheckContext, schema: Schema.XUniqueItems, value: unknown[]): boolean {
   if (!IsValid(schema)) return true
   const set = new Set(value.map(Hashing.Hash)).size
   const isLength = value.length
@@ -62,7 +62,7 @@ export function CheckUniqueItems(_stack: Stack, _context: CheckContext, schema: 
 // ------------------------------------------------------------------
 // Error
 // ------------------------------------------------------------------
-export function ErrorUniqueItems(_stack: Stack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XUniqueItems, value: unknown[]): boolean {
+export function ErrorUniqueItems(_stack: Stack.XStack, context: ErrorContext, schemaPath: string, instancePath: string, schema: Schema.XUniqueItems, value: unknown[]): boolean {
   if (!IsValid(schema)) return true
   const set = new Set<string>()
   const duplicateItems = value.reduce<number[]>((result, value, index) => {
@@ -72,10 +72,6 @@ export function ErrorUniqueItems(_stack: Stack, context: ErrorContext, schemaPat
     return result
   }, [] as number[])
   const isUniqueItems = G.IsEqual(duplicateItems.length, 0)
-  return isUniqueItems || context.AddError({
-    keyword: 'uniqueItems',
-    schemaPath,
-    instancePath,
-    params: { duplicateItems },
-  })
+  return isUniqueItems ||
+    context.AddError('uniqueItems', schemaPath, instancePath, { duplicateItems })
 }

--- a/src/schema/errors.ts
+++ b/src/schema/errors.ts
@@ -45,7 +45,7 @@ export function Errors(...args: unknown[]): [boolean, TLocalizedValidationError[
     3: (context, schema, value) => [context, schema, value],
     2: (schema, value) => [{}, schema, value]
   })
-  const stack = new Engine.Stack(context, schema)
+  const stack = Engine.Stack(context, schema)
   const errorContext = new Engine.ErrorContext()
   const result = Engine.ErrorSchema(stack, errorContext, '#', '', schema, value)
   const errors = errorContext.GetErrors()

--- a/src/schema/intern/intern.ts
+++ b/src/schema/intern/intern.ts
@@ -31,6 +31,7 @@ import { Guard } from '../../guard/index.ts'
 import { Resolve } from '../resolve/index.ts'
 import { type XStatic } from '../static/index.ts'
 import * as S from '../types/index.ts'
+import * as Engine from '../engine/index.ts'
 
 // ----------------------------------------------------------------
 // UnsupportedKeyword
@@ -164,7 +165,7 @@ function FromPropertyNames(context: RefContext, schema: S.XPropertyNames): S.XSc
 // Ref
 // ----------------------------------------------------------------
 function ResolveRef(context: Record<string, S.XSchema>, schema: S.XSchemaObject, ref: string): S.XSchema {
-  return Resolve.Ref(context, schema, Resolve.DefaultBase, ref) ?? UnresolvableRef(ref)
+  return Resolve.Ref(Engine.Stack(context, schema), { $ref: ref }).schema ?? UnresolvableRef(ref)
 }
 function FromRef(context: RefContext, schema: S.XRef): S.XSchema {
   // Resolve target

--- a/src/schema/resolve/index.ts
+++ b/src/schema/resolve/index.ts
@@ -27,4 +27,3 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 export * as Resolve from './resolve.ts'
-export * from './resolve.ts'

--- a/src/schema/resolve/index.ts
+++ b/src/schema/resolve/index.ts
@@ -27,3 +27,4 @@ THE SOFTWARE.
 ---------------------------------------------------------------------------*/
 
 export * as Resolve from './resolve.ts'
+export * from './resolve.ts'

--- a/src/schema/resolve/resolve.ts
+++ b/src/schema/resolve/resolve.ts
@@ -26,347 +26,340 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-// deno-fmt-ignore-file
-
 import { Guard } from '../../guard/index.ts'
 import { Pointer } from '../pointer/index.ts'
 import * as Schema from '../types/index.ts'
-
-export const DefaultBase = 'https://json-schema.org'
+import * as Stack from '../engine/_stack.ts'
 
 // ------------------------------------------------------------------
-// StackFrame
+// XRefResult
 //
-// A read-only snapshot of everything Stack has accumulated during
-// traversal that resolution needs in order to make a decision. This
-// is the sole channel through which Stack state reaches this module:
-// nothing below ever mutates it or reaches back into Stack.
+// Return shape for every top level resolution function: the
+// resolved schema (or undefined) plus the stack state after
+// following the reference, since crossing or deferring a resource
+// can change base URI and lexical scope for later steps.
 // ------------------------------------------------------------------
-export interface StackFrame {
-  context: Record<string, Schema.XSchema>
-  root: Schema.XSchemaObject
-  lexicalSchema: Schema.XSchemaObject
-  lexicalBase: string
-  referenceBase: string
-  resourceBase: string
-  ids: Schema.XId[]
-  recursiveAnchors: Schema.XRecursiveAnchor[]
-  dynamicAnchors: Schema.XDynamicAnchor[]
-  inRetrievedFrame: boolean
+export interface XRefResult {
+  schema: Schema.XSchema | undefined
+  stack: Stack.XStack
 }
 // ------------------------------------------------------------------
-// RefResult
+// (Internal) XDeferredResource | XResolvedResource
 //
-// The outcome of resolving a $ref. `schema` is the resolved target.
-// `retrievedResource` and `resolvedResource` are *instructions*: they
-// tell the caller (Stack) what bookkeeping, if any, it should apply
-// to its own state as a result of this resolution. This module never
-// applies them itself.
+// A deferred resource is a boundary detected but not yet entered,
+// typically a draft-4 style in-place base change. A resolved
+// resource is one the ref has definitely crossed into, identified
+// by $id, so the stack can advance into it right away.
 // ------------------------------------------------------------------
-export interface RetrievedResource {
+interface XDeferredResource {
   target: Schema.XSchemaObject
+  root: Schema.XSchemaObject
   base: string
-  root: Schema.XSchemaObject
 }
-export interface ResolvedResource {
-  target: Schema.XSchemaObject
+interface XResolvedResource {
   resource: Schema.XId
 }
-export interface RefResult {
-  schema: Schema.XSchema | undefined
-  retrievedResource?: RetrievedResource
-  resolvedResource?: ResolvedResource
+// ------------------------------------------------------------------
+// Helpers
+//
+// Shared utilities: effective base URI of a schema, normalizing a
+// base to an absolute URL, stripping a URL's fragment to get its
+// canonical href, finding a target schema's base URI, picking the
+// root a $ref resolves against, and detecting a JSON pointer
+// fragment versus a plain anchor name.
+// ------------------------------------------------------------------
+function RelativeBase(schema: unknown, base: URL): URL {
+  return Schema.IsSchemaObject(schema) && Schema.IsId(schema) ? Stack.NextUri(schema.$id, base.href) : base
+}
+function AbsoluteBase(base: string): URL {
+  return Stack.NextUri(base, Stack.DefaultUri)
+}
+function CanonicalHref(url: URL): string {
+  return url.href.split('#')[0]
+}
+function Base(schema: Schema.XSchema, base: string, target: Schema.XSchema): string | undefined {
+  return SearchBase(schema, AbsoluteBase(base), target)
+}
+function RefRoot(stack: Stack.XStack, ref: Schema.XRef): Schema.XSchema {
+  return (ref.$ref.startsWith('#') || stack.enteredResource) ? stack.lexicalSchema : stack.schema
+}
+function IsPointerFragment(fragment: string): boolean {
+  return fragment.startsWith('#/')
 }
 // ------------------------------------------------------------------
-// Find: FindDynamicAnchor
+// Search
+//
+// Recursive tree walks that locate things by identity, not URL.
+// SearchDynamicAnchor finds a node with a matching $dynamicAnchor.
+// SearchBase finds a specific target schema (by reference) and
+// returns its base URI, tracking $id rebasing as it descends.
 // ------------------------------------------------------------------
-function FindDynamicAnchor(schema: unknown, name: string): Schema.XDynamicAnchor | undefined {
+function SearchDynamicAnchor(schema: unknown, name: string): Schema.XDynamicAnchor | undefined {
   if (Guard.IsObject(schema) && Schema.IsDynamicAnchor(schema) && Guard.IsEqual(schema.$dynamicAnchor, name)) {
     return schema
   }
   if (Guard.IsObject(schema)) {
     for (const key of Guard.Keys(schema)) {
-      const result = FindDynamicAnchor(schema[key], name)
+      const result = SearchDynamicAnchor(schema[key], name)
       if (result) return result
     }
   }
-  // (no-coverage) - is it even possible to search for an anchor
-  // with embedded logical schema like allOf, anyOf, etc?
-  // if (Guard.IsArray(schema)) { // (no-coverage)
-  //   for (const item of schema) {
-  //     const result = FindDynamicAnchor(item, name)
-  //     if (result) return result
-  //   }
-  // }
   return undefined
 }
-// ------------------------------------------------------------------
-// Find: FindBase
-// ------------------------------------------------------------------
-function FindBase(schema: unknown, base: URL, target: Schema.XSchema): string | undefined {
+function SearchBase(schema: unknown, base: URL, target: Schema.XSchema): string | undefined {
   if (Guard.IsEqual(schema, target)) return base.href
-  const nextBase = Schema.IsSchemaObject(schema) && Schema.IsId(schema) ? new URL(schema.$id, base.href) : base
+  const nextBase = RelativeBase(schema, base)
   if (Guard.IsArray(schema)) {
     for (const item of schema) {
-      const result = FindBase(item, nextBase, target)
+      const result = SearchBase(item, nextBase, target)
       if (!Guard.IsUndefined(result)) return result
     }
   } else if (Guard.IsObject(schema)) {
     for (const key of Guard.Keys(schema)) {
-      const result = FindBase(schema[key], nextBase, target)
+      const result = SearchBase(schema[key], nextBase, target)
       if (!Guard.IsUndefined(result)) return result
     }
   }
   return undefined
 }
 // ------------------------------------------------------------------
-// Match: MatchId
+// Match
+//
+// Tests whether a schema node is what a reference URL points to.
+// MatchSchemaObject checks a single node in order: $id, $anchor,
+// $dynamicAnchor, then JSON pointer/hash. MatchFromArray,
+// MatchFromObject, and Match recurse through the tree to try every
+// node, skipping const and enum since their values are user data,
+// not schema.
 // ------------------------------------------------------------------
-function MatchId(schema: Schema.XId, base: URL, ref: URL): Schema.XSchema | undefined {
-  // ref is a bare fragment naming this schema's $id directly
+function MatchWithHash(schema: Schema.XSchemaObject, ref: URL): Schema.XSchema | undefined {
+  if (ref.href.endsWith('#')) return schema
+  if (!ref.hash.startsWith('#')) return undefined
+  const fragment = decodeURIComponent(ref.hash.slice(1))
+  if (!fragment.startsWith('/')) return undefined
+  return Pointer.Get(schema, fragment) as Schema.XSchema | undefined
+}
+function MatchWithId(schema: Schema.XSchemaObject, base: URL, ref: URL): Schema.XSchema | undefined {
+  if (!Schema.IsId(schema)) return undefined
   if (Guard.IsEqual(schema.$id, ref.hash)) return schema
   const absoluteRef = new URL(ref.href, base.href)
-  // ref shares this $id's document, so resolve the fragment within it
-  if (Guard.IsEqual(base.pathname, absoluteRef.pathname)) return ref.hash.startsWith('#') ? MatchHash(schema, ref) : schema
+  if (Guard.IsEqual(base.pathname, absoluteRef.pathname)) return ref.hash.startsWith('#') ? MatchWithHash(schema, ref) : schema
   return undefined
 }
-// ------------------------------------------------------------------
-// Match: MatchAnchor
-// ------------------------------------------------------------------
-function MatchAnchor(schema: Schema.XAnchor, base: URL, ref: URL): Schema.XSchema | undefined {
+function MatchWithAnchor(schema: Schema.XSchemaObject, base: URL, ref: URL): Schema.XSchema | undefined {
+  if (!Schema.IsAnchor(schema)) return undefined
   const absoluteAnchor = new URL(`#${schema.$anchor}`, base.href)
   const absoluteRef = new URL(ref.href, base.href)
   return Guard.IsEqual(absoluteAnchor.href, absoluteRef.href) ? schema : undefined
 }
-// ------------------------------------------------------------------
-// Match: MatchDynamicAnchor
-// ------------------------------------------------------------------
-function MatchDynamicAnchor(schema: Schema.XDynamicAnchor, base: URL, ref: URL): Schema.XSchema | undefined {
+function MatchWithDynamicAnchor(schema: Schema.XSchemaObject, base: URL, ref: URL): Schema.XSchema | undefined {
+  if (!Schema.IsDynamicAnchor(schema)) return undefined
   const absoluteAnchor = new URL(`#${schema.$dynamicAnchor}`, base.href)
   const absoluteRef = new URL(ref.href, base.href)
   const isMatch = Guard.IsEqual(absoluteAnchor.href, absoluteRef.href)
   return isMatch ? schema : undefined
 }
-// ------------------------------------------------------------------
-// Match: MatchHash
-// ------------------------------------------------------------------
-function MatchHash(schema: Schema.XSchemaObject, ref: URL): Schema.XSchema | undefined {
-  if (ref.href.endsWith('#')) return schema
-  if (!ref.hash.startsWith('#')) return undefined
-  const fragment = decodeURIComponent(ref.hash.slice(1))
-  if (!fragment.startsWith('/')) return undefined
-  const result = Pointer.Get(schema, fragment) as Schema.XSchema | undefined
-  return result
+function MatchSchemaObject(schema: unknown, base: URL, ref: URL): Schema.XSchema | undefined {
+  if (!Schema.IsSchemaObject(schema)) return undefined
+  return MatchWithId(schema, base, ref) ??
+    MatchWithAnchor(schema, base, ref) ??
+    MatchWithDynamicAnchor(schema, base, ref) ??
+    MatchWithHash(schema, ref)
 }
-// ------------------------------------------------------------------
-// Match: Match
-// ------------------------------------------------------------------
-function Match(schema: Schema.XSchemaObject, base: URL, ref: URL): Schema.XSchema | undefined {
-  if (Schema.IsId(schema)) {
-    const result = MatchId(schema, base, ref)
-    if (!Guard.IsUndefined(result)) return result
-  }
-  if (Schema.IsAnchor(schema)) {
-    const result = MatchAnchor(schema, base, ref)
-    if (!Guard.IsUndefined(result)) return result
-  }
-  if (Schema.IsDynamicAnchor(schema)) {
-    const result = MatchDynamicAnchor(schema, base, ref)
-    if (!Guard.IsUndefined(result)) return result
-  }
-  return MatchHash(schema, ref)
-}
-// ------------------------------------------------------------------
-// FromArray
-// ------------------------------------------------------------------
-function FromArray(schema: unknown[], base: URL, ref: URL): Schema.XSchema | undefined {
+function MatchFromArray(schema: unknown, base: URL, ref: URL): Schema.XSchema | undefined {
+  if (!Guard.IsArray(schema)) return undefined
   return schema.reduce<Schema.XSchema | undefined>((result, item) => {
-    const match = FromValue(item, base, ref)
+    const match = Match(item, base, ref)
     return !Guard.IsUndefined(match) ? match : result
   }, undefined)
 }
-// ------------------------------------------------------------------
-// FromObject
-// ------------------------------------------------------------------
-function SkipProperty(key: PropertyKey): boolean {
-  return Guard.IsEqual(key, 'const') || Guard.IsEqual(key, 'enum')
-}
-function FromObject(schema: Record<PropertyKey, unknown>, base: URL, ref: URL): Schema.XSchema | undefined {
+function MatchFromObject(schema: unknown, base: URL, ref: URL): Schema.XSchema | undefined {
+  if (!Guard.IsObject(schema)) return undefined
   return Guard.Keys(schema).reduce<Schema.XSchema | undefined>((result, key) => {
-    if (SkipProperty(key)) return result
-    const match = FromValue(schema[key], base, ref)
+    if (Guard.IsEqual(key, 'const') || Guard.IsEqual(key, 'enum')) return result
+    const match = Match(schema[key], base, ref)
     return !Guard.IsUndefined(match) ? match : result
   }, undefined)
 }
-// ------------------------------------------------------------------
-// FromValue
-// ------------------------------------------------------------------
-function FromValue(schema: unknown, base: URL, ref: URL): Schema.XSchema | undefined {
-  const nextBase = Schema.IsSchemaObject(schema) && Schema.IsId(schema) ? new URL(schema.$id, base.href) : base
-  if (Schema.IsSchemaObject(schema)) {
-    const result = Match(schema, nextBase, ref)
-    if (!Guard.IsUndefined(result)) return result
-  }
-  if (Guard.IsArray(schema)) return FromArray(schema, nextBase, ref)
-  if (Guard.IsObject(schema)) return FromObject(schema, nextBase, ref)
-  return undefined
-}
-// ------------------------------------------------------------------
-// Base
-// ------------------------------------------------------------------
-export function Base(schema: Schema.XSchemaObject, base: string, target: Schema.XSchema): string | undefined {
-  return FindBase(schema, new URL(base || '.', DefaultBase), target)
+function Match(schema: unknown, base: URL, ref: URL): Schema.XSchema | undefined {
+  const relativeBase = RelativeBase(schema, base)
+  return MatchSchemaObject(schema, relativeBase, ref) ??
+    MatchFromArray(schema, relativeBase, ref) ??
+    MatchFromObject(schema, relativeBase, ref)
 }
 // ------------------------------------------------------------------
 // Resource
+//
+// Wraps RefInternal to check whether the resolved schema is itself
+// a resource root (carries its own $id). Used by FindResolvedResource
+// to tell a boundary hit from a landing inside a resource.
 // ------------------------------------------------------------------
-export function Resource(context: Record<string, Schema.XSchema>, schema: Schema.XSchemaObject, base: string, ref: string): Schema.XId | undefined {
-  const result = Ref(context, schema, base, ref, false)
+function Resource(context: Record<string, Schema.XSchema>, schema: Schema.XSchemaObject, base: string, ref: string): Schema.XId | undefined {
+  const result = RefInternal(context, schema, base, ref)
   return Schema.IsSchemaObject(result) && Schema.IsId(result) ? result : undefined
 }
 // ------------------------------------------------------------------
-// CanonicalHref
-// ------------------------------------------------------------------
-function CanonicalHref(url: URL): string {
-  return url.href.split('#')[0]
-}
-// ------------------------------------------------------------------
-// Ref: RefRemote (Phase 1)
-// ------------------------------------------------------------------
-function RefContext(context: Record<string, Schema.XSchema>, ref: string): Schema.XSchema | undefined {
-  return Guard.HasPropertyKey(context, ref) ? context[ref] : undefined
-}
-// ------------------------------------------------------------------
-// Ref: RefRemote (Phase 2)
-// ------------------------------------------------------------------
-function RefLocal(schema: Schema.XSchemaObject, base: URL, ref: URL): Schema.XSchema | undefined {
-  return FromValue(schema, base, ref)
-}
-// ------------------------------------------------------------------
-// Ref: RefRemote (Phase 3)
-// ------------------------------------------------------------------
-function RefRemote(context: Record<string, Schema.XSchema>, base: URL, ref: URL): Schema.XSchema | undefined {
-  const canonicalHref = CanonicalHref(ref)
-  if (Guard.IsEqual(canonicalHref, CanonicalHref(base))) return undefined
-  if (!Guard.HasPropertyKey(context, canonicalHref)) return undefined
-  const remoteSchema = context[canonicalHref]
-  const remoteBase = (Schema.IsSchemaObject(remoteSchema) && Schema.IsId(remoteSchema)) ? new URL(remoteSchema.$id, canonicalHref) : new URL(canonicalHref)
-  const result = Guard.IsEqual(ref.hash, '') ? remoteSchema : FromValue(remoteSchema, remoteBase, ref)
-  return result
-}
-// ------------------------------------------------------------------
-// RetrievedResource: LegacyRetrievedResource
+// FindDeferredResource
 //
-// Draft-4 style schemas (no $schema keyword) treat a nested $id as an
-// in-place base URI change rather than a new resource boundary. A
-// local ('#...') ref that lands somewhere with a different base than
-// the current reference base needs a frame so later anchor/pointer
-// resolution is computed against the right base.
+// Legacy Draft-4 schemas (no $schema keyword) treat a nested $id as
+// an in-place base change, not a new resource. A local ('#...') ref
+// landing at a different base than the current one needs a stack
+// entry so later lookups use the right base.
 // ------------------------------------------------------------------
-function LegacyRetrievedResource(root: Schema.XSchemaObject, lexicalSchema: Schema.XSchemaObject, referenceBase: string, ref: Schema.XRef, schema: Schema.XSchemaObject): RetrievedResource | undefined {
+function FindDeferredResourceLegacy(stack: Stack.XStack, ref: Schema.XRef, schema: Schema.XSchemaObject): XDeferredResource | undefined {
   if (!ref.$ref.startsWith('#')) return undefined
-  if (Guard.HasPropertyKey(root, '$schema')) return undefined
-  const targetBase = Base(lexicalSchema, referenceBase, schema)
-  if (Guard.IsUndefined(targetBase) || Guard.IsEqual(targetBase, referenceBase)) return undefined
-  return { target: schema, base: targetBase, root: lexicalSchema }
+  if (!Schema.IsSchemaObject(stack.schema) || Guard.HasPropertyKey(stack.schema, '$schema')) return undefined
+  const targetBase = Base(stack.lexicalSchema, stack.referenceBase, schema)
+  if (Guard.IsUndefined(targetBase) || Guard.IsEqual(targetBase, stack.referenceBase)) return undefined
+  return { target: schema, base: targetBase, root: /* safe-object-root */ stack.lexicalSchema as Schema.XSchemaObject }
 }
-// ------------------------------------------------------------------
-// RetrievedResource: RemoteRetrievedResource
-//
-// The ref's canonical URL names a document already loaded into
-// context. That document becomes the frame's root going forward.
-// ------------------------------------------------------------------
-function RemoteRetrievedResource(context: Record<string, Schema.XSchema>, canonical: string, schema: Schema.XSchemaObject): RetrievedResource | undefined {
-  const remoteRoot = context[canonical]
+function FindDeferredResourceModern(stack: Stack.XStack, canonical: string, schema: Schema.XSchemaObject): XDeferredResource | undefined {
+  const remoteRoot = stack.context[canonical]
   if (!Schema.IsSchemaObject(remoteRoot)) return undefined
   return { target: schema, base: canonical, root: remoteRoot }
 }
-// ------------------------------------------------------------------
-// RetrievedResource
-//
-// A genuinely remote document frame always wins over a same-document
-// legacy one: only one frame is ever entered per ref.
-// ------------------------------------------------------------------
-function FindRetrievedResource(stackframe: StackFrame, ref: Schema.XRef, schema: Schema.XSchemaObject, canonical: string, isRemote: boolean): RetrievedResource | undefined {
-  const remote = isRemote ? RemoteRetrievedResource(stackframe.context, canonical, schema) : undefined
-  if (!Guard.IsUndefined(remote)) return remote
-  return LegacyRetrievedResource(stackframe.root, stackframe.lexicalSchema, stackframe.referenceBase, ref, schema)
+function FindDeferredResource(stack: Stack.XStack, ref: Schema.XRef, schema: Schema.XSchemaObject, canonical: string, isRemote: boolean): XDeferredResource | undefined {
+  const remote = isRemote ? FindDeferredResourceModern(stack, canonical, schema) : undefined
+  return Guard.IsUndefined(remote) ? FindDeferredResourceLegacy(stack, ref, schema) : remote
 }
 // ------------------------------------------------------------------
-// ResolvedResource: FindResolvedResource
+// FindResolvedResource
 //
-// The ref crossed into a different resource but landed on a schema
-// that doesn't itself carry that resource's $id (e.g. a pointer into
-// the middle of a remote document). The enclosing resource still
-// needs to be entered so lexical/base lookups behave as if traversal
-// had walked in from its top.
+// Handles a ref that crossed into a different resource but landed
+// on a schema without that resource's $id (e.g. a pointer into the
+// middle of a remote document). Enters the enclosing resource so
+// lexical/base lookups behave as if traversal walked in from its top.
 // ------------------------------------------------------------------
-function FindResolvedResource(context: Record<string, Schema.XSchema>, root: Schema.XSchemaObject, referenceBase: string, canonical: string, schema: Schema.XSchemaObject, ids: Schema.XId[]): ResolvedResource | undefined {
+function FindResolvedResource(stack: Stack.XStack, canonical: string, schema: Schema.XSchemaObject): XResolvedResource | undefined {
   if (Schema.IsId(schema)) return undefined
-  const resource = Resource(context, root, referenceBase, canonical)
-  if (!resource || ids.includes(resource)) return undefined
-  return { target: schema, resource }
+  const resource = Resource(stack.context, /* safe-object-root */ stack.schema as Schema.XSchemaObject, stack.referenceBase, canonical)
+  if (!resource || stack.ids.includes(resource)) return undefined
+  return { resource }
+}
+// ------------------------------------------------------------------
+// RefInternal
+//
+// Shared lookup used by Ref, RecursiveRef, and DynamicRef. Tries,
+// in order: exact match in the pre-registered context, then a local
+// search within the given schema, then a search in a remote
+// document. Returns just the schema; caller-specific bookkeeping
+// (deferred/resolved resources) happens one level up.
+// ------------------------------------------------------------------
+function RefInternalWithContext(context: Record<string, Schema.XSchema>, ref: string): Schema.XSchema | undefined {
+  return Guard.HasPropertyKey(context, ref) ? context[ref] : undefined
+}
+function RefInternalWithLocal(schema: Schema.XSchema, base: URL, ref: URL): Schema.XSchema | undefined {
+  return Match(schema, base, ref)
+}
+function RefInternalWithRemote(context: Record<string, Schema.XSchema>, base: URL, ref: URL): Schema.XSchema | undefined {
+  const canonicalHref = CanonicalHref(ref)
+  if (!Guard.HasPropertyKey(context, canonicalHref) || Guard.IsEqual(canonicalHref, CanonicalHref(base))) return undefined
+  const remoteSchema = context[canonicalHref]
+  const remoteBase = RelativeBase(remoteSchema, new URL(canonicalHref))
+  return Guard.IsEqual(ref.hash, '') ? remoteSchema : Match(remoteSchema, remoteBase, ref)
+}
+function RefInternal(context: Record<string, Schema.XSchema>, schema: Schema.XSchema, base: string, ref: string): Schema.XSchema | undefined {
+  const absoluteBase = AbsoluteBase(base)
+  const target = Stack.NextUri(ref, absoluteBase.href)
+  return RefInternalWithContext(context, ref) ??
+    RefInternalWithLocal(schema, absoluteBase, target) ??
+    RefInternalWithRemote(context, absoluteBase, target)
+}
+// ------------------------------------------------------------------
+// RefNextStack
+//
+// Computes the next stack state from any deferred or resolved
+// resource found while following a $ref, carrying existing stack
+// state forward rather than rebuilding it.
+// ------------------------------------------------------------------
+function RefNextStackDeferred(stack: Stack.XStack, deferredResource?: XDeferredResource): Stack.XStack {
+  if (!deferredResource) return stack
+  const resourceEntries = new Map(stack.resourceEntries)
+  resourceEntries.set(deferredResource.target, { base: deferredResource.base, root: deferredResource.root })
+  return { ...stack, resourceEntries }
+}
+function RefNextStackResolved(stack: Stack.XStack, resolvedResource?: XResolvedResource): Stack.XStack {
+  return resolvedResource ? Stack.NextStack(stack, resolvedResource.resource) : stack
+}
+function RefNextStack(stack: Stack.XStack, pendingResource: boolean, deferredResource?: XDeferredResource, resolvedResource?: XResolvedResource): Stack.XStack {
+  const withDeferred = RefNextStackDeferred({ ...stack, pendingResource }, deferredResource)
+  const withResolved = RefNextStackResolved(withDeferred, resolvedResource)
+  return withResolved
+}
+// ------------------------------------------------------------------
+// RefResult
+//
+// Builds the final XRefResult. RefResultFound gets the canonical
+// URL, checks if it's remote from the current resource, and looks
+// for a deferred or resolved resource crossing accordingly.
+// RefResultNotFound just advances pendingResource if a schema was
+// found without crossing into a resource.
+// ------------------------------------------------------------------
+function RefResultFound(stack: Stack.XStack, ref: Schema.XRef, schema: Schema.XSchemaObject): XRefResult {
+  const canonical = CanonicalHref(Stack.NextUri(ref.$ref, stack.referenceBase))
+  const isRemote = !Guard.IsEqual(canonical, stack.resourceBase)
+  const deferredResource = FindDeferredResource(stack, ref, schema, canonical, isRemote)
+  const resolvedResource = isRemote ? FindResolvedResource(stack, canonical, schema) : undefined
+  return { schema, stack: RefNextStack(stack, true, deferredResource, resolvedResource) }
+}
+function RefResultNotFound(stack: Stack.XStack, schema: Schema.XSchema | undefined): XRefResult {
+  return { schema, stack: RefNextStack(stack, !Guard.IsUndefined(schema)) }
 }
 // ------------------------------------------------------------------
 // Ref
-// ------------------------------------------------------------------
-export function Ref(remotes: Record<string, Schema.XSchema>, schema: Schema.XSchemaObject, base: string, ref: string, applySchemaId: boolean = true): Schema.XSchema | undefined {
-  const initialBase = new URL(base || '.', DefaultBase)
-  const resolvedBase = applySchemaId && Schema.IsId(schema) ? new URL(schema.$id, initialBase) : initialBase
-  const initialRef = new URL(ref, resolvedBase.href)
-  return RefContext(remotes, ref) ?? RefLocal(schema, resolvedBase, initialRef) ?? RefRemote(remotes, resolvedBase, initialRef)
-}
-// ------------------------------------------------------------------
-// DynamicRef
-// ------------------------------------------------------------------
-export function DynamicRef(context: Record<string, Schema.XSchema>, root: Schema.XSchemaObject, base: string, schema: Schema.XSchemaObject, dynamicRef: Schema.XDynamicRef, dynamicAnchors: Schema.XDynamicAnchor[]): Schema.XSchema | undefined {
-  const initialBase = new URL(base || '.', DefaultBase)
-  const fragmentRoot = dynamicRef.$dynamicRef.startsWith('#') ? schema : root
-  const fragmentTarget = Ref(context, fragmentRoot, base, dynamicRef.$dynamicRef, false)
-  if (Guard.IsUndefined(fragmentTarget)) {
-    const fragment = new URL(dynamicRef.$dynamicRef, initialBase).hash
-    if (!fragment.startsWith('#/') && fragment.startsWith('#')) {
-      const name = decodeURIComponent(fragment.slice(1))
-      const anchorTarget = dynamicAnchors.find((anchor) => Guard.IsEqual(anchor.$dynamicAnchor, name)) ?? FindDynamicAnchor(root, name)
-      return anchorTarget
-    }
-    return undefined
-  }
-  if (!Schema.IsSchemaObject(fragmentTarget) || !Schema.IsDynamicAnchor(fragmentTarget)) return fragmentTarget
-  const fragment = new URL(dynamicRef.$dynamicRef, initialBase).hash
-  if (fragment.startsWith('#/')) return fragmentTarget
-  const anchorTarget = dynamicAnchors.find((anchor) => Guard.IsEqual(anchor.$dynamicAnchor, fragmentTarget.$dynamicAnchor))
-  return anchorTarget ?? fragmentTarget
-}
-// ------------------------------------------------------------------
-// ResolveRef
 //
-// Resolves the schema a $ref points to, and describes whether that
-// crossing implies a "retrieved resource" frame or entering a
-// resource the target doesn't itself carry the $id for. The caller
-// decides whether and how to record these.
+// Picks the root to resolve against, and returns a XRefResult
+// containing the resolved schema and the next stack state for
+// subsequent evaluation.
 // ------------------------------------------------------------------
-export function ResolveRef(stackframe: StackFrame, ref: Schema.XRef): RefResult {
-  const source = stackframe.inRetrievedFrame ? stackframe.lexicalSchema : stackframe.root
-  const refRoot = ref.$ref.startsWith('#') ? stackframe.lexicalSchema : source
-  const schema = Ref(stackframe.context, refRoot, stackframe.referenceBase, ref.$ref, false)
-  if (!schema || !Schema.IsSchemaObject(schema)) return { schema }
-  const canonical = new URL(ref.$ref, stackframe.referenceBase).href.split('#')[0]
-  const isRemote = !Guard.IsEqual(canonical, stackframe.resourceBase)
-  const retrievedResource = FindRetrievedResource(stackframe, ref, schema, canonical, isRemote)
-  const resolvedResource = isRemote ? FindResolvedResource(stackframe.context, stackframe.root, stackframe.referenceBase, canonical, schema, stackframe.ids) : undefined
-  return { schema, retrievedResource, resolvedResource }
+export function Ref(stack: Stack.XStack, ref: Schema.XRef): XRefResult {
+  const schema = RefInternal(stack.context, RefRoot(stack, ref), stack.referenceBase, ref.$ref)
+  return Schema.IsSchemaObject(schema) ? RefResultFound(stack, ref, schema) : RefResultNotFound(stack, schema)
 }
 // ------------------------------------------------------------------
-// ResolveRecursiveRef
+// RecursiveRef: Draft 2019-09
+//
+// If a $recursiveAnchor is active in scope, it's used as the root
+// instead of the lexical schema, letting the ref bind to the
+// outermost applicable schema rather than the innermost.
 // ------------------------------------------------------------------
-export function ResolveRecursiveRef(stackframe: StackFrame, recursiveRef: Schema.XRecursiveRef): Schema.XSchema | undefined {
-  const refRoot = Schema.IsRecursiveAnchorTrue(stackframe.lexicalSchema) ? stackframe.recursiveAnchors[0] : stackframe.lexicalSchema
-  return Ref(stackframe.context, refRoot, stackframe.lexicalBase, recursiveRef.$recursiveRef, false)
+function IsRecursiveAnchorInScope(stack: Stack.XStack): boolean {
+  return Schema.IsSchemaObject(stack.lexicalSchema) && Schema.IsRecursiveAnchorTrue(stack.lexicalSchema)
+}
+export function RecursiveRef(stack: Stack.XStack, recursiveRef: Schema.XRecursiveRef): Schema.XSchema | undefined {
+  const schema = IsRecursiveAnchorInScope(stack) ? stack.recursiveAnchor : stack.lexicalSchema
+  return RefInternal(stack.context, schema as never, stack.lexicalBase, recursiveRef.$recursiveRef)
 }
 // ------------------------------------------------------------------
-// ResolveDynamicRef
+// DynamicRef: Draft 2020-12
+//
+// FindScopedDynamicAnchor checks anchors tracked on the stack first,
+// then falls back to a full tree search. If RefInternal finds a target
+// directly, DynamicRefWhenFound only continues the scoped search when
+// that target itself has a $dynamicAnchor. If RefInternal finds nothing,
+// DynamicRefWhenNotFound goes straight to a scoped anchor search
+// by name.
 // ------------------------------------------------------------------
-export function ResolveDynamicRef(stackframe: StackFrame, dynamicRef: Schema.XDynamicRef): Schema.XSchema | undefined {
-  return DynamicRef(stackframe.context, stackframe.root, stackframe.lexicalBase, stackframe.lexicalSchema, dynamicRef, stackframe.dynamicAnchors)
+function DynamicRefFragment(stack: Stack.XStack, dynamicRef: Schema.XDynamicRef): string {
+  return Stack.NextUri(dynamicRef.$dynamicRef, AbsoluteBase(stack.lexicalBase).href).hash
+}
+function FindScopedDynamicAnchor(stack: Stack.XStack, name: string): Schema.XDynamicAnchor | undefined {
+  return stack.dynamicAnchors.find((anchor) => Guard.IsEqual(anchor.$dynamicAnchor, name)) ?? SearchDynamicAnchor(stack.schema, name)
+}
+function DynamicRefWhenFound(stack: Stack.XStack, dynamicRef: Schema.XDynamicRef, fragmentTarget: Schema.XSchema): Schema.XSchema | undefined {
+  if (!Schema.IsSchemaObject(fragmentTarget) || !Schema.IsDynamicAnchor(fragmentTarget)) return fragmentTarget
+  const fragment = DynamicRefFragment(stack, dynamicRef)
+  // todo: review why we need to check if the fragment is a pointer before finding the scoped dynamic anchor
+  return IsPointerFragment(fragment) ? fragmentTarget : FindScopedDynamicAnchor(stack, fragmentTarget.$dynamicAnchor)
+}
+function DynamicRefWhenNotFound(stack: Stack.XStack, dynamicRef: Schema.XDynamicRef): Schema.XSchema | undefined {
+  const fragment = DynamicRefFragment(stack, dynamicRef)
+  // todo: we never observe this condition, we should review.
+  // if (IsPointerFragment(fragment) || !fragment.startsWith('#')) return undefined
+  return FindScopedDynamicAnchor(stack, decodeURIComponent(fragment.slice(1)))
+}
+export function DynamicRef(stack: Stack.XStack, dynamicRef: Schema.XDynamicRef): Schema.XSchema | undefined {
+  const fragmentRoot = dynamicRef.$dynamicRef.startsWith('#') ? stack.lexicalSchema : stack.schema
+  const fragmentTarget = RefInternal(stack.context, fragmentRoot, stack.lexicalBase, dynamicRef.$dynamicRef)
+  return Guard.IsUndefined(fragmentTarget) ? DynamicRefWhenNotFound(stack, dynamicRef) : DynamicRefWhenFound(stack, dynamicRef, fragmentTarget)
 }

--- a/task/spec/refresh.ts
+++ b/task/spec/refresh.ts
@@ -84,7 +84,7 @@ function process(context: Record<string, Schema.XSchema>): JSONSchemaTestSuite {
 // ------------------------------------------------------------------
 function report(suite: JSONSchemaTestSuite): void {
   const requiredTable = Report.reportRequired(suite, {
-    ignore: ['divisibleBy', 'disallow', 'extends', 'vocabulary']
+    ignore: ['format', 'divisibleBy', 'disallow', 'extends', 'vocabulary']
   })
   console.log('')
   console.log('## Required Keywords')

--- a/tasks.ts
+++ b/tasks.ts
@@ -9,7 +9,7 @@ import { Metrics } from './task/metrics/index.ts'
 import { Spec } from './task/spec/index.ts'
 import { Task } from 'tasksmith'
 
-const Version = '1.3.28'
+const Version = '1.3.29'
 
 // ------------------------------------------------------------------
 // Build

--- a/test/typebox/runtime/schema/additional.ts
+++ b/test/typebox/runtime/schema/additional.ts
@@ -185,3 +185,20 @@ Test('Should Coverage 16', () => {
   Assert.IsFalse(validator.Check({ x: null }))
   Assert.IsFalse(validator.Check(0))
 })
+// ------------------------------------------------------------------
+// Coverage: Non-resolvable RecursiveRef and DynamicRef is false.
+// ------------------------------------------------------------------
+Test('Should Coverage 17', () => {
+  const schema = { $dynamicRef: '#non-resolvable' }
+  const validator = Schema.Compile(schema)
+  Assert.IsFalse(validator.Check(1))
+  Assert.IsFalse(Schema.Check(schema, 1))
+  Assert.IsFalse(Schema.Errors(schema, 1)[0])
+})
+Test('Should Coverage 18', () => {
+  const schema = { $recursiveRef: '#non-resolvable' }
+  const validator = Schema.Compile(schema)
+  Assert.IsFalse(validator.Check(1))
+  Assert.IsFalse(Schema.Check(schema, 1))
+  Assert.IsFalse(Schema.Errors(schema, 1)[0])
+})

--- a/test/typebox/runtime/schema/resolve/resolve.ts
+++ b/test/typebox/runtime/schema/resolve/resolve.ts
@@ -4,85 +4,141 @@ import Schema from 'typebox/schema'
 const Test = Assert.Context('Schema.Resolve')
 
 // ------------------------------------------------------------------
+// These Tests Assert Schema Resolution Mechanisms. These are quite
+// difficult to test in isolation due to the complexity as resolution
+// typically occurs in the context of schema evaluation and traversal.
+// This test asserts on known resolution behaviors to catch regressions.
+// ------------------------------------------------------------------
+
+// ------------------------------------------------------------------
 // Resolve.Ref
 // ------------------------------------------------------------------
 Test('Should Resolve.Ref 1', () => {
-  const A = Schema.Resolve.Ref({}, { $defs: { A: { type: 'string' } } }, '', '#/$defs/A')
-  Assert.IsEqual(A, { type: 'string' })
+  const A = { $defs: { A: { type: 'string' } } }
+  const B = Schema.Stack({}, A)
+  const C = Schema.Resolve.Ref(B, { $ref: '#/$defs/A' }).schema
+  Assert.IsEqual(C, { type: 'string' })
 })
 Test('Should Resolve.Ref 2', () => {
-  const A = Schema.Resolve.Ref(
-    {},
-    {
-      $id: 'https://example.com/root/',
-      $defs: { A: { $id: 'A', type: 'string' } }
-    },
-    '',
-    'A'
-  )
-  Assert.IsEqual(A, { $id: 'A', type: 'string' })
+  const A = {
+    $id: 'https://example.com/root/',
+    $defs: { A: { $id: 'A', type: 'string' } }
+  }
+  const B = Schema.Stack({}, A)
+  const C = Schema.Resolve.Ref(B, { $ref: 'A' }).schema
+  Assert.IsEqual(C, { $id: 'A', type: 'string' })
 })
 Test('Should Resolve.Ref 3', () => {
-  const A = Schema.Resolve.Ref(
-    {
-      'https://example.com/remote.json': { type: 'number' }
-    },
-    {},
-    '',
-    'https://example.com/remote.json'
-  )
-  Assert.IsEqual(A, { type: 'number' })
+  const A = {}
+  const B = Schema.Stack({ 'https://example.com/remote.json': { type: 'number' } }, A)
+  const C = Schema.Resolve.Ref(B, { $ref: 'https://example.com/remote.json' }).schema
+  Assert.IsEqual(C, { type: 'number' })
 })
 Test('Should Resolve.Ref 4', () => {
-  const A = Schema.Resolve.Ref(
-    {
-      'https://example.com/remote.json': { $defs: { A: { type: 'boolean' } } }
-    },
-    {},
-    '',
-    'https://example.com/remote.json#/$defs/A'
-  )
-  Assert.IsEqual(A, { type: 'boolean' })
+  const A = {}
+  const B = Schema.Stack({ 'https://example.com/remote.json': { $defs: { A: { type: 'boolean' } } } }, A)
+  const C = Schema.Resolve.Ref(B, { $ref: 'https://example.com/remote.json#/$defs/A' }).schema
+  Assert.IsEqual(C, { type: 'boolean' })
+})
+// ------------------------------------------------------------------
+// Resolve.RecursiveRef
+// ------------------------------------------------------------------
+Test('Should Resolve.RecursiveRef 1', () => {
+  const A = { $recursiveAnchor: true, type: 'string' }
+  const B = Schema.NextStack(Schema.Stack({}, A), A)
+  const C = Schema.Resolve.RecursiveRef(B, { $recursiveRef: '#' })
+  Assert.IsEqual(C, A)
+})
+Test('Should Resolve.RecursiveRef 2', () => {
+  const A = { type: 'string' }
+  const B = Schema.NextStack(Schema.Stack({}, A), A)
+  const C = Schema.Resolve.RecursiveRef(B, { $recursiveRef: '#' })
+  Assert.IsEqual(C, A)
+})
+Test('Should Resolve.RecursiveRef 3', () => {
+  const A = { $id: 'https://example.com/root/', $recursiveAnchor: true, $defs: { X: { type: 'string' } } }
+  const B = { $id: 'child', $recursiveAnchor: true, $defs: { X: { type: 'number' } } }
+  const C = Schema.NextStack(Schema.NextStack(Schema.Stack({}, A), A), B)
+  const D = Schema.Resolve.RecursiveRef(C, { $recursiveRef: '#/$defs/X' })
+  Assert.IsEqual(D, { type: 'string' })
+})
+Test('Should Resolve.RecursiveRef 4', () => {
+  const A = { type: 'boolean' }
+  const B = Schema.Stack({}, { $defs: { A } })
+  const C = Schema.Resolve.RecursiveRef(B, { $recursiveRef: '#/definitions/A' })
+  Assert.IsEqual(C, undefined)
 })
 // ------------------------------------------------------------------
 // Resolve.DynamicRef
 // ------------------------------------------------------------------
 Test('Should Resolve.DynamicRef 1', () => {
   const A = { $dynamicAnchor: 'A', type: 'string' }
-  const R = Schema.Resolve.DynamicRef({}, A, '', A, { $dynamicRef: '#A' }, [])
-  Assert.IsEqual(R, A)
+  const B = Schema.Stack({}, A)
+  const C = Schema.Resolve.DynamicRef(B, { $dynamicRef: '#A' })
+  Assert.IsEqual(C, A)
 })
 Test('Should Resolve.DynamicRef 2', () => {
   const A = { $dynamicAnchor: 'A', type: 'string' }
   const B = { $dynamicAnchor: 'A', type: 'number' }
-  const R = Schema.Resolve.DynamicRef({}, A, '', A, { $dynamicRef: '#A' }, [B])
-  Assert.IsEqual(R, B)
+  const C = Schema.NextStack(Schema.Stack({}, A), B)
+  const D = Schema.Resolve.DynamicRef(C, { $dynamicRef: '#A' })
+  Assert.IsEqual(D, B)
 })
 Test('Should Resolve.DynamicRef 3', () => {
   const A = { $dynamicAnchor: 'A', type: 'boolean' }
-  const R = Schema.Resolve.DynamicRef({}, {}, '', {}, { $dynamicRef: '#A' }, [A])
-  Assert.IsEqual(R, A)
+  const B = Schema.NextStack(Schema.Stack({}, {}), A)
+  const C = Schema.Resolve.DynamicRef(B, { $dynamicRef: '#A' })
+  Assert.IsEqual(C, A)
 })
 Test('Should Resolve.DynamicRef 4', () => {
   const A = { $dynamicAnchor: 'A', type: 'boolean' }
-  const R = Schema.Resolve.DynamicRef({}, { $defs: [A] }, '', {}, { $dynamicRef: '#A' }, [])
-  Assert.IsEqual(R, A)
+  const B = Schema.Stack({}, { $defs: [A] })
+  const C = Schema.Resolve.DynamicRef(B, { $dynamicRef: '#A' })
+  Assert.IsEqual(C, A)
 })
 Test('Should Resolve.DynamicRef 5', () => {
   const A = { $dynamicAnchor: 'A', type: 'boolean' }
-  const R = Schema.Resolve.DynamicRef({}, { $defs: { A } }, '', {}, { $dynamicRef: '#A' }, [])
-  Assert.IsEqual(R, A)
+  const B = Schema.Stack({}, { $defs: { A } })
+  const C = Schema.Resolve.DynamicRef(B, { $dynamicRef: '#A' })
+  Assert.IsEqual(C, A)
+})
+Test('Should Resolve.DynamicRef 6', () => {
+  const A = { $dynamicAnchor: 'A', type: 'boolean' }
+  const B = Schema.Stack({}, { $defs: { A } })
+  const C = Schema.Resolve.DynamicRef(B, { $dynamicRef: '#B' })
+  Assert.IsEqual(C, undefined)
 })
 // ------------------------------------------------------------------
-// Resolve.Resource
+// Resolve.Ref Next Evaluation
 // ------------------------------------------------------------------
-Test('Should Resolve.Resource 1', () => {
-  const A = { $id: 'child.json', type: 'string' }
-  const R = Schema.Resolve.Resource({}, { $defs: { A } }, 'https://example.com/', 'child.json')
-  Assert.IsEqual(R, A)
+Test('Should Resolve.Ref Next Evaluation 1', () => {
+  const A = Schema.Stack({}, true)
+  Assert.IsEqual(A.schema, true)
+  Assert.IsEqual(A.lexicalSchema, true)
 })
-Test('Should Resolve.Resource 2', () => {
-  const A = { $id: 'https://example.com/child.json', type: 'number' }
-  const R = Schema.Resolve.Resource({}, { $defs: { A } }, 'https://example.com/', 'https://example.com/child.json')
-  Assert.IsEqual(R, A)
+Test('Should Resolve.Ref Next Evaluation 2', () => {
+  const A = { $id: 'widget', type: 'string' }
+  const B = { $id: 'https://example.com/root/', $defs: { widget: A } }
+  const C = Schema.NextStack(Schema.NextStack(Schema.Stack({}, B), B), A)
+  const D = Schema.Resolve.Ref(C, { $ref: '#' }).schema
+  Assert.IsEqual(D, A)
+})
+// ------------------------------------------------------------------
+// URN Base Resolution
+// ------------------------------------------------------------------
+Test('Should Resolve.Ref Urn 1', () => {
+  const A = { $id: 'widget', type: 'string' }
+  const B = { $defs: { widget: A } }
+  const C = Schema.NextStack(Schema.Stack({}, B), A)
+  Assert.IsEqual(C.lexicalBase, 'urn:typebox:root:widget')
+  const D = Schema.Resolve.Ref(C, { $ref: 'widget' }).schema
+  Assert.IsEqual(D, A)
+  const E = Schema.Resolve.Ref(C, { $ref: 'widget' }).stack
+  Assert.IsEqual(E.referenceBase, 'urn:typebox:root:widget')
+})
+Test('Should Resolve.Ref Urn 2', () => {
+  const A = { $defs: { A: { type: 'string' } } }
+  const B = Schema.Stack({}, A)
+  const C = Schema.Resolve.Ref(B, { $ref: '#/$defs/A' }).schema
+  Assert.IsEqual(C, { type: 'string' })
 })


### PR DESCRIPTION
This PR is a re-implementation of TypeBox's internal `Ref`, `DynamicRef`, and `RecursiveRef` handling, improving performance and testing against the keyword implementations added in 1.3.26.

> The update is a continuation of [#1682](https://github.com/sinclairzx81/typebox/pull/1682), where TypeBox reached full compliance for 2020-12 and V1, but where the implementation was fairly archaic and not very well optimized for build and bundle performance. This PR optimizes and simplifies the resolution algorithm overall. The update also adds additional resolution tests and pushes local test coverage to 100%.

### Updates

- `DefaultUri` changed from `http://json-schema.org` to `urn:typebox:root`
- Replaced `Push` and `Pop` with immutable `NextStack`
- Internal `Stack` changed from a class to an immutable object instance